### PR TITLE
win32: initial tag entity bindings

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -3,40 +3,73 @@ classdef Block < nix.Entity
     
     properties(Hidden)
         info
-    end
+    end;
     
     properties(Dependent)
         name
         type
         id
-    end
+        sourceCount
+        dataArrayCount
+        tagCount
+        multiTagCount
+    end;
     
     methods
         function obj = Block(h)
            obj@nix.Entity(h);
            obj.info = nix_mx('Block::describe', obj.nix_handle);
-        end
+        end;
         
         function name = get.name(block)
            name = block.info.name;
-        end
+        end;
         
         function type = get.type(block)
             type = block.info.type;
-        end
+        end;
         
         function id = get.id(block)
            id = block.info.id; 
-        end
+        end;
+        
+        function sourceCount = get.sourceCount(block)
+            sourceCount = block.info.sourceCount;
+        end;
+        
+        function dataArrayCount = get.dataArrayCount(block)
+            dataArrayCount = block.info.dataArrayCount;
+        end;
+        
+        function tagCount = get.tagCount(block)
+            tagCount = block.info.tagCount;
+        end;
+        
+        function multiTagCount = get.multiTagCount(block)
+            multiTagCount = block.info.multiTagCount;
+        end;
         
         function das = data_arrays(obj)
             das = nix_mx('Block::listDataArrays', obj.nix_handle);
-        end
+        end;
         
         function da = data_array(obj, id_or_name)
            dh = nix_mx('Block::openDataArray', obj.nix_handle, id_or_name); 
            da = nix.DataArray(dh);
-        end
-    end
-    
+        end;
+        
+        function tagList = list_tags(obj)
+            tagList = nix_mx('Block::listTags', obj.nix_handle);
+        end;
+        
+        function hasTag = has_tag(obj, id_or_name)
+            hasTag = nix_mx('Block::hasTag', obj.nix_handle, id_or_name);
+        end;
+        
+        function tag = open_tag(obj, id_or_name)
+           tagHandle = nix_mx('Block::openTag', obj.nix_handle, id_or_name); 
+           tag = nix.Tag(tagHandle);
+        end;
+    end;
+
 end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -5,10 +5,10 @@ classdef File < nix.Entity
             if ~exist('mode', 'var')
                 mode = FileMode.ReadWrite; %default to ReadWrite
             end
-           h = nix_mx('File::open', path, mode); 
-           obj@nix.Entity(h);
+            h = nix_mx('File::open', path, mode); 
+            obj@nix.Entity(h);
         end
-        
+
         function blocks = listBlocks(obj)
             blocks = nix_mx('File::listBlocks', obj.nix_handle);
         end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -1,0 +1,103 @@
+classdef Tag < nix.Entity
+    %Tag nix Tag object
+
+    properties(Hidden)
+        info
+    end;
+    
+    properties(Dependent)
+        id
+        type
+        name
+        definition
+        position
+        units
+        extent
+        featuresCount
+        sourcesCount
+        dataArrayReferenceCount
+    end;
+
+    methods
+        function obj = Tag(h)
+           obj@nix.Entity(h);
+           obj.info = nix_mx('Tag::describe', obj.nix_handle);
+        end;
+        
+        function id = get.id(tag)
+           id = tag.info.id; 
+        end;
+        
+        function name = get.name(tag)
+           name = tag.info.name;
+        end;
+        
+        function type = get.type(tag)
+            type = tag.info.type;
+        end;
+
+        function definition = get.definition(tag)
+            definition = tag.info.definition;
+        end;
+
+        function position = get.position(tag)
+            position = tag.info.position;
+        end;
+
+        function units = get.units(tag)
+            units = tag.info.units;
+        end;
+
+        function extent = get.extent(tag)
+            extent = tag.info.extent;
+        end;
+
+        function featuresCount = get.featuresCount(tag)
+            featuresCount = tag.info.featuresCount;
+        end;
+
+        function sourcesCount = get.sourcesCount(tag)
+             sourcesCount = tag.info.sourcesCount;
+        end;
+
+        function dataArrayReferenceCount = get.dataArrayReferenceCount(tag)
+            dataArrayReferenceCount = tag.info.dataArrayReferenceCount;
+        end;
+        
+        function refList = list_references(obj)
+            refList = nix_mx('Tag::listReferences', obj.nix_handle);
+        end;
+
+        function featureList = list_features(obj)
+            featureList = nix_mx('Tag::listFeatures', obj.nix_handle);
+        end;
+
+        function sourceList = list_sources(obj)
+            sourceList = nix_mx('Tag::listSources', obj.nix_handle);
+        end;
+
+        function source = open_source(obj, id_or_name)
+            sourceHandle = nix_mx('Tag::openSource', obj.nix_handle, id_or_name);
+            source = 'TODO: implement source';
+            %source = nix.Source(sourceHandle);
+        end;
+
+        function feature = open_feature(obj, id_or_name)
+            featureHandle = nix_mx('Tag::openFeature', obj.nix_handle, id_or_name);
+            feature = 'TODO: implement feature';
+            %feature = nix.Feature(featureHandle);
+        end;
+
+        function dataArray = open_referenced_data_array(obj, id_or_name)
+            daHandle = nix_mx('Tag::openReferenceDataArray', obj.nix_handle, id_or_name);
+            dataArray = nix.DataArray(daHandle);
+        end;
+
+        function metadata = open_metadata(obj)
+            metadataHandle = nix_mx('Tag::openMetadataSection', obj.nix_handle);
+            metadata = 'TODO: implement MetadataSection';
+            %metadata = nix.Section(metadataHandle);
+        end;
+    end;
+
+end

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .DS_Store
 ._*
+*.asv

--- a/handle.h
+++ b/handle.h
@@ -24,6 +24,31 @@ struct entity_to_id<nix::DataArray> {
     static int value() { return 3; }
 };
 
+template<>
+struct entity_to_id<nix::Tag> {
+    static int value() { return 4; }
+};
+
+template<>
+struct entity_to_id<nix::Source> {
+    static int value() { return 5; }
+};
+
+template<>
+struct entity_to_id<nix::Feature> {
+    static int value() { return 6; }
+};
+
+template<>
+struct entity_to_id<nix::MultiTag> {
+    static int value() { return 7; }
+};
+
+template<>
+struct entity_to_id<nix::Section> {
+    static int value() { return 8; }
+};
+
 
 
 class handle {


### PR DESCRIPTION
- matlab tag object with info, openReferencedDataArray, openFeature, openSources, openMetadata
- matlab block object changed to handle associated tags