### PR TITLE
win32: initial multitag entity bindings

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -70,6 +70,19 @@ classdef Block < nix.Entity
            tagHandle = nix_mx('Block::openTag', obj.nix_handle, id_or_name); 
            tag = nix.Tag(tagHandle);
         end;
+        
+        function tagList = list_multi_tags(obj)
+            tagList = nix_mx('Block::listMultiTags', obj.nix_handle);
+        end;
+        
+        function hasTag = has_multi_tag(obj, id_or_name)
+            hasTag = nix_mx('Block::hasMultiTag', obj.nix_handle, id_or_name);
+        end;
+        
+        function tag = open_multi_tag(obj, id_or_name)
+           tagHandle = nix_mx('Block::openMultiTag', obj.nix_handle, id_or_name); 
+           tag = nix.MultiTag(tagHandle);
+        end;
     end;
 
 end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -1,0 +1,93 @@
+classdef MultiTag < nix.Entity
+    %MultiTag nix MultiTag object
+
+    properties(Hidden)
+        info
+    end;
+    
+    properties(Dependent)
+        id
+        type
+        name
+        definition
+        units
+        featuresCount
+        sourcesCount
+        dataArrayReferenceCount
+    end;
+
+    methods
+        function obj = MultiTag(h)
+           obj@nix.Entity(h);
+           obj.info = nix_mx('MultiTag::describe', obj.nix_handle);
+        end;
+        
+        function id = get.id(tag)
+           id = tag.info.id; 
+        end;
+        
+        function name = get.name(tag)
+           name = tag.info.name;
+        end;
+        
+        function type = get.type(tag)
+            type = tag.info.type;
+        end;
+
+        function definition = get.definition(tag)
+            definition = tag.info.definition;
+        end;
+
+        function units = get.units(tag)
+            units = tag.info.units;
+        end;
+
+        function featuresCount = get.featuresCount(tag)
+            featuresCount = tag.info.featuresCount;
+        end;
+
+        function sourcesCount = get.sourcesCount(tag)
+             sourcesCount = tag.info.sourcesCount;
+        end;
+
+        function dataArrayReferenceCount = get.dataArrayReferenceCount(tag)
+            dataArrayReferenceCount = tag.info.dataArrayReferenceCount;
+        end;
+        
+        function refList = list_references(obj)
+            refList = nix_mx('MultiTag::listReferences', obj.nix_handle);
+        end;
+
+        function featureList = list_features(obj)
+            featureList = nix_mx('MultiTag::listFeatures', obj.nix_handle);
+        end;
+
+        function sourceList = list_sources(obj)
+            sourceList = nix_mx('MultiTag::listSources', obj.nix_handle);
+        end;
+
+        function source = open_source(obj, id_or_name)
+            sourceHandle = nix_mx('MultiTag::openSource', obj.nix_handle, id_or_name);
+            source = 'TODO: implement source';
+            %source = nix.Source(sourceHandle);
+        end;
+
+        function feature = open_feature(obj, id_or_name)
+            featureHandle = nix_mx('MultiTag::openFeature', obj.nix_handle, id_or_name);
+            feature = 'TODO: implement feature';
+            %feature = nix.Feature(featureHandle);
+        end;
+
+        function dataArray = open_referenced_data_array(obj, id_or_name)
+            daHandle = nix_mx('MultiTag::openReferenceDataArray', obj.nix_handle, id_or_name);
+            dataArray = nix.DataArray(daHandle);
+        end;
+
+        function metadata = open_metadata(obj)
+            metadataHandle = nix_mx('MultiTag::openMetadataSection', obj.nix_handle);
+            metadata = 'TODO: implement MetadataSection';
+            %metadata = nix.Section(metadataHandle);
+        end;
+    end;
+
+end

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -115,7 +115,7 @@ static void list_blocks(const extractor &input, infusor &output)
 
 static void open_block(const extractor &input, infusor &output)
 {
-    mexPrintf("[+] list_data_arrays\n");
+    mexPrintf("[+] open_block\n");
     nix::File nf = input.entity<nix::File>(1);
     nix::Block block = nf.getBlock(input.str(2));
     handle bb = handle(block);
@@ -140,32 +140,37 @@ static void block_describe(const extractor &input, infusor &output)
     output.set(0, sb.array());
 }
 
+static handle gen_open_data_array(nix::DataArray inDa){
+    nix::DataArray da = inDa;
+    handle h = handle(da);
+    return h;
+}
+
 static void open_data_array(const extractor &input, infusor &output)
 {
     mexPrintf("[+] block_open_data_array\n");
     nix::Block block = input.entity<nix::Block>(1);
-    nix::DataArray da = block.getDataArray(input.str(2));
-    handle bd = handle(da);
-    output.set(0, bd);
+    output.set(0, gen_open_data_array(block.getDataArray(input.str(2))));
 }
 
 static void tag_open_data_array(const extractor &input, infusor &output)
 {
     mexPrintf("[+] tag_open_data_array\n");
     nix::Tag currTag = input.entity<nix::Tag>(1);
-    nix::DataArray da = currTag.getReference(input.str(2));
-    handle currDAHandle = handle(da);
-    output.set(0, currDAHandle);
+    output.set(0, gen_open_data_array(currTag.getReference(input.str(2))));
 }
 
-static void block_list_data_arrays(const extractor &input, infusor &output)
+static void multi_tag_open_data_array(const extractor &input, infusor &output)
 {
-    mexPrintf("[+] list_data_arrays\n");
+    mexPrintf("[+] multi_tag_open_data_array\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_open_data_array(currMTag.getReference(input.str(2))));
+}
 
-    nix::Block block = input.entity<nix::Block>(1);
-    std::vector<nix::DataArray> arr = block.dataArrays();
+static mxArray* gen_list_data_arrays(std::vector<nix::DataArray> daIn){
+    std::vector<nix::DataArray> arr = daIn;
 
-    struct_builder sb({arr.size()}, {"name", "id", "type"});
+    struct_builder sb({ arr.size() }, { "name", "id", "type" });
 
     for (const auto &da : arr) {
         sb.set(da.name());
@@ -174,19 +179,52 @@ static void block_list_data_arrays(const extractor &input, infusor &output)
 
         sb.next();
     }
+    return sb.array();
+}
 
-    output.set(0, sb.array());
+static void block_list_data_arrays(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] list_data_arrays\n");
+    nix::Block block = input.entity<nix::Block>(1);
+    output.set(0, gen_list_data_arrays(block.dataArrays()));
+}
+
+static void tag_list_references_array(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] tag_list_data_array_references\n");
+    nix::Tag currTag = input.entity<nix::Tag>(1);
+    output.set(0, gen_list_data_arrays(currTag.references()));
+}
+
+static void multi_tag_list_references_array(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] multi_tag_list_references\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_list_data_arrays(currMTag.references()));
+}
+
+
+static mxArray* has_entity(bool boolIn, std::vector<const char *> currLabel){
+    uint8_t currHas = boolIn ? 1 : 0;
+    struct_builder sb({ 1 }, currLabel);
+    sb.set(currHas);
+    return sb.array();
 }
 
 static void has_tag(const extractor &input, infusor &output)
 {
     mexPrintf("[+] block_has_tag\n");
     nix::Block block = input.entity<nix::Block>(1);
-    uint8_t currHasTag = block.hasTag(input.str(2)) ? 1 : 0;
-    struct_builder sb({ 1 }, { "hasTag" });
-    sb.set(currHasTag);
-    output.set(0, sb.array());
+    output.set(0, has_entity(block.hasTag(input.str(2)), { "hasTag" }));
 }
+
+static void has_multi_tag(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] block_has_multi_tag\n");
+    nix::Block block = input.entity<nix::Block>(1);
+    output.set(0, has_entity(block.hasMultiTag(input.str(2)), { "hasMultiTags" }));
+}
+
 
 static void open_tag(const extractor &input, infusor &output)
 {
@@ -213,6 +251,36 @@ static void block_list_tags(const extractor &input, infusor &output)
         sb.set(da.definition());
         sb.set(da.position());
         sb.set(da.extent());
+        sb.set(da.units());
+
+        sb.next();
+    }
+    output.set(0, sb.array());
+}
+
+static void open_multi_tag(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] block_open_multi_tag\n");
+    nix::Block block = input.entity<nix::Block>(1);
+    nix::MultiTag currMultiTag = block.getMultiTag(input.str(2));
+    handle currBlockMultiTagHandle = handle(currMultiTag);
+    output.set(0, currBlockMultiTagHandle);
+}
+
+static void block_list_multi_tags(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] block_list_multi_tags\n");
+
+    nix::Block block = input.entity<nix::Block>(1);
+    std::vector<nix::MultiTag> arr = block.multiTags();
+
+    struct_builder sb({ arr.size() }, { "name", "id", "type", "definition", "units" });
+
+    for (const auto &da : arr) {
+        sb.set(da.name());
+        sb.set(da.id());
+        sb.set(da.type());
+        sb.set(da.definition());
         sb.set(da.units());
 
         sb.next();
@@ -346,6 +414,7 @@ static void data_array_read_all(const extractor &input, infusor &output)
     output.set(0, data);
 }
 
+// handle tag entity
 static void tag_describe(const extractor &input, infusor &output)
 {
     mexPrintf("[+] tag_describe\n");
@@ -368,92 +437,142 @@ static void tag_describe(const extractor &input, infusor &output)
     output.set(0, sb.array());
 }
 
-// return list of all data arrays referenced by the current tag
-static void tag_list_references_array(const extractor &input, infusor &output)
-{
-    mexPrintf("[+] tag_list_references\n");
-    nix::Tag currTag = input.entity<nix::Tag>(1);
 
-    std::vector<nix::DataArray> arr = currTag.references();
-
-    struct_builder sb({ arr.size() }, { "name", "id", "type" });
-
+static mxArray* gen_list_features(std::vector<nix::Feature> featIn){
+    std::vector<nix::Feature> arr = featIn;
+    struct_builder sb({ arr.size() }, { "id" });
     for (const auto &da : arr) {
-        sb.set(da.name());
         sb.set(da.id());
-        sb.set(da.type());
-
         sb.next();
     }
-
-    output.set(0, sb.array());
-
+    return sb.array();
 }
 
 static void tag_list_features(const extractor &input, infusor &output)
 {
     mexPrintf("[+] tag_list_features\n");
     nix::Tag currTag = input.entity<nix::Tag>(1);
-
-    std::vector<nix::Feature> arr = currTag.features();
-
-    struct_builder sb({ arr.size() }, { "id" });
-
-    for (const auto &da : arr) {
-        sb.set(da.id());
-
-        sb.next();
-    }
-
-    output.set(0, sb.array());
+    output.set(0, gen_list_features(currTag.features()));
 }
 
-static void tag_list_sources(const extractor &input, infusor &output)
+static void multi_tag_list_features(const extractor &input, infusor &output)
 {
-    mexPrintf("[+] tag_list_sources\n");
-    nix::Tag currTag = input.entity<nix::Tag>(1);
+    mexPrintf("[+] multi_tag_list_features\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_list_features(currMTag.features()));
+}
 
-    std::vector<nix::Source> arr = currTag.sources();
 
+static mxArray* gen_list_sources(std::vector<nix::Source> sourceIn){
+    std::vector<nix::Source> arr = sourceIn;
     struct_builder sb({ arr.size() }, { "id", "type", "name", "definition", "sourceCount" });
-
     for (const auto &da : arr) {
         sb.set(da.id());
         sb.set(da.type());
         sb.set(da.name());
         sb.set(da.definition());
         sb.set(da.sourceCount());
-
         sb.next();
     }
-    output.set(0, sb.array());
+    return sb.array();
+}
+
+static void tag_list_sources(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] tag_list_sources\n");
+    nix::Tag currTag = input.entity<nix::Tag>(1);
+    output.set(0, gen_list_sources(currTag.sources()));
+}
+
+// return list of all sources referenced by the current multitag
+static void multi_tag_list_sources(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] multi_tag_list_sources\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_list_sources(currMTag.sources()));
+}
+
+static handle gen_open_source(nix::Source sourceIn){
+    nix::Source currSource = sourceIn;
+    handle currSourceHandle = handle(currSource);
+    return currSourceHandle;
 }
 
 static void tag_open_source(const extractor &input, infusor &output)
 {
     mexPrintf("[+] tag_open_source\n");
     nix::Tag currTag = input.entity<nix::Tag>(1);
-    nix::Source currSource = currTag.getSource(input.str(2));
-    handle currTagSourceHandle = handle(currSource);
-    output.set(0, currTagSourceHandle);
+    output.set(0, gen_open_source(currTag.getSource(input.str(2))));
+}
+
+static void multi_tag_open_source(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] multi_tag_open_source\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_open_source(currMTag.getSource(input.str(2))));
+}
+
+
+static handle gen_open_feature(nix::Feature featIn){
+    nix::Feature currFeat = featIn;
+    handle currTagFeatHandle = handle(currFeat);
+    return currTagFeatHandle;
 }
 
 static void tag_open_feature(const extractor &input, infusor &output)
 {
     mexPrintf("[+] tag_open_feature\n");
     nix::Tag currTag = input.entity<nix::Tag>(1);
-    nix::Feature currFeat = currTag.getFeature(input.str(2));
-    handle currTagFeatHandle = handle(currFeat);
-    output.set(0, currTagFeatHandle);
+    output.set(0, gen_open_feature(currTag.getFeature(input.str(2))));
+}
+
+static void multi_tag_open_feature(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] multi_tag_open_feature\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_open_feature(currMTag.getFeature(input.str(2))));
+}
+
+
+static handle gen_open_metadata_section(nix::Section secIn){
+    nix::Section currMDSec = secIn;
+    handle currTagMDSecHandle = handle(currMDSec);
+    return currTagMDSecHandle;
 }
 
 static void tag_open_metadata_section(const extractor &input, infusor &output)
 {
     mexPrintf("[+] tag_open_metadata_section\n");
     nix::Tag currTag = input.entity<nix::Tag>(1);
-    nix::Section currMDSec = currTag.metadata();
-    handle currTagMDSecHandle = handle(currMDSec);
-    output.set(0, currTagMDSecHandle);
+    output.set(0, gen_open_metadata_section(currTag.metadata()));
+}
+
+static void multi_tag_open_metadata_section(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] multi_tag_open_metadata_section\n");
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+    output.set(0, gen_open_metadata_section(currMTag.metadata()));
+}
+
+// handle multi tag entity
+static void multi_tag_describe(const extractor &input, infusor &output)
+{
+    mexPrintf("[+] multi_tag_describe\n");
+
+    nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+
+    struct_builder sb({ 1 }, { "id", "type", "name", "definition", "units", "featuresCount", "sourcesCount", "dataArrayReferenceCount" });
+
+    sb.set(currMTag.id());
+    sb.set(currMTag.type());
+    sb.set(currMTag.name());
+    sb.set(currMTag.definition());
+    sb.set(currMTag.units());
+    sb.set(currMTag.featureCount());
+    sb.set(currMTag.sourceCount());
+    sb.set(currMTag.referenceCount());
+
+    output.set(0, sb.array());
 }
 
 // *** ***
@@ -479,17 +598,28 @@ const std::vector<fendpoint> funcs = {
         {"Block::hasTag", has_tag},
         {"Block::openTag", open_tag},
         {"Block::listTags", block_list_tags},
+        {"Block::hasMultiTag", has_multi_tag},
+        {"Block::openMultiTag", open_multi_tag},
+        {"Block::listMultiTags", block_list_multi_tags},
         {"DataArray::describe", data_array_describe},
         {"DataArray::readAll", data_array_read_all},
         {"Tag::describe", tag_describe},
         {"Tag::listReferences", tag_list_references_array},
         {"Tag::listFeatures", tag_list_features},
         {"Tag::listSources", tag_list_sources},
-        {"Tag::openSource", tag_open_source },
-        {"Tag::openFeature", tag_open_feature },
         {"Tag::openReferenceDataArray", tag_open_data_array},
-        {"Tag::openMetadataSection", tag_open_metadata_section}
-
+        {"Tag::openFeature", tag_open_feature},
+        {"Tag::openSource", tag_open_source},
+        {"Tag::openMetadataSection", tag_open_metadata_section},
+        {"MultiTag::describe", multi_tag_describe},
+        {"MultiTag::listReferences", multi_tag_list_references_array},
+        {"MultiTag::listFeatures", multi_tag_list_features},
+        {"MultiTag::listSources", multi_tag_list_sources},
+        {"MultiTag::openReferenceDataArray", multi_tag_open_data_array},
+        {"MultiTag::openFeature", multi_tag_open_feature},
+        {"MultiTag::openSource", multi_tag_open_source},
+        {"MultiTag::openMetadataSection", multi_tag_open_metadata_section}
+        //TODO: implement handling of multitag positions and extents
 };
 
 // main entry point


### PR DESCRIPTION
- matlab multitag object with info,  openReferencedDataArray, openFeature, openSources, openMetadata
- matlab block object updated to handle associated multitags
- cleanup mexprintf messages
- introducing generic functions to reduce redundant code on the nix_mx side, functions indicated by "gen_[name_of_function]" prefix