### PR TITLE
Access metadata section from nix objects

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -184,12 +184,18 @@ classdef Block < nix.Entity
         % Metadata methods
         % -----------------
         
-        function metadata = open_metadata(obj)
-            metadataHandle = nix_mx('Block::openMetadataSection', obj.nix_handle);
-            metadata = 'TODO: implement MetadataSection';
-            %metadata = nix.Section(metadataHandle);
+        function hasMetadata = has_metadata(obj)
+            getHasMetadata = nix_mx('Block::hasMetadataSection', obj.nix_handle);
+            hasMetadata = logical(getHasMetadata.hasMetadataSection);
         end;
         
-    end;
+        function metadata = open_metadata(obj)
+            metadata = {};
+            metadataHandle = nix_mx('Block::openMetadataSection', obj.nix_handle);
+            if obj.has_metadata()
+                metadata = nix.Section(metadataHandle);
+            end;
+        end;
 
+    end;
 end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -69,12 +69,21 @@ classdef DataArray < nix.Entity
            data = permute(tmp, length(size(tmp)):-1:1);
         end;
         
-        function metadata = open_metadata(obj)
-            metadataHandle = nix_mx('DataArray::openMetadataSection', obj.nix_handle);
-            metadata = 'TODO: implement MetadataSection';
-            %metadata = nix.Section(metadataHandle);
+        % -----------------
+        % Metadata methods
+        % -----------------
+        
+        function hasMetadata = has_metadata(obj)
+            getHasMetadata = nix_mx('DataArray::hasMetadataSection', obj.nix_handle);
+            hasMetadata = logical(getHasMetadata.hasMetadataSection);
         end;
-
-    end
-    
+        
+        function metadata = open_metadata(obj)
+            metadata = {};
+            metadataHandle = nix_mx('DataArray::openMetadataSection', obj.nix_handle);
+            if obj.has_metadata()
+                metadata = nix.Section(metadataHandle);
+            end;
+        end;
+    end;
 end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -177,11 +177,18 @@ classdef MultiTag < nix.Entity
         % Metadata methods
         % ------------------
         
-        function metadata = open_metadata(obj)
-            metadataHandle = nix_mx('MultiTag::openMetadataSection', obj.nix_handle);
-            metadata = 'TODO: implement MetadataSection';
-            %metadata = nix.Section(metadataHandle);
+        function hasMetadata = has_metadata(obj)
+            getHasMetadata = nix_mx('MultiTag::hasMetadataSection', obj.nix_handle);
+            hasMetadata = logical(getHasMetadata.hasMetadataSection);
         end;
-    end;
+        
+        function metadata = open_metadata(obj)
+            metadata = {};
+            metadataHandle = nix_mx('MultiTag::openMetadataSection', obj.nix_handle);
+            if obj.has_metadata()
+                metadata = nix.Section(metadataHandle);
+            end;
+        end;
 
+    end;
 end

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -74,11 +74,18 @@ classdef Source < nix.Entity
         % Metadata methods
         % ------------------
         
-        function metadata = open_metadata(obj)
-            metadataHandle = nix_mx('Source::openMetadataSection', obj.nix_handle);
-            metadata = 'TODO: implement MetadataSection';
-            %metadata = nix.Section(metadataHandle);
+        function hasMetadata = has_metadata(obj)
+            getHasMetadata = nix_mx('Source::hasMetadataSection', obj.nix_handle);
+            hasMetadata = logical(getHasMetadata.hasMetadataSection);
         end;
-    end;
+        
+        function metadata = open_metadata(obj)
+            metadata = {};
+            metadataHandle = nix_mx('Source::openMetadataSection', obj.nix_handle);
+            if obj.has_metadata()
+                metadata = nix.Section(metadataHandle);
+            end;
+        end;
 
+    end;
 end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -159,12 +159,19 @@ classdef Tag < nix.Entity
         % ------------------
         % Metadata methods
         % ------------------
+
+        function hasMetadata = has_metadata(obj)
+            getHasMetadata = nix_mx('Tag::hasMetadataSection', obj.nix_handle);
+            hasMetadata = logical(getHasMetadata.hasMetadataSection);
+        end;
         
         function metadata = open_metadata(obj)
+            metadata = {};
             metadataHandle = nix_mx('Tag::openMetadataSection', obj.nix_handle);
-            metadata = 'TODO: implement MetadataSection';
-            %metadata = nix.Section(metadataHandle);
+            if obj.has_metadata()
+                metadata = nix.Section(metadataHandle);
+            end;
         end;
-    end;
 
+    end;
 end

--- a/include/nixblock.h
+++ b/include/nixblock.h
@@ -35,6 +35,8 @@ namespace nixblock {
 
     void multitags(const extractor &input, infusor &output);
 
+    void has_metadata_section(const extractor &input, infusor &output);
+
     void open_metadata_section(const extractor &input, infusor &output);
 
 } // namespace nixblock

--- a/include/nixdataarray.h
+++ b/include/nixdataarray.h
@@ -9,6 +9,8 @@ namespace nixdataarray {
     
     void read_all(const extractor &input, infusor &output);
 
+    void has_metadata_section(const extractor &input, infusor &output);
+
     void open_metadata_section(const extractor &input, infusor &output);
 
 } // namespace nixdataarray

--- a/include/nixgen.h
+++ b/include/nixgen.h
@@ -19,6 +19,8 @@ namespace nixgen {
 
     handle open_feature(nix::Feature featIn);
 
+    mxArray* has_metadata_section(nix::Section currSection);
+
     handle open_metadata_section(nix::Section secIn);
 
 } // namespace nixgen

--- a/include/nixmultitag.h
+++ b/include/nixmultitag.h
@@ -25,6 +25,8 @@ namespace nixmultitag {
 
     void open_features(const extractor &input, infusor &output);
 
+    void has_metadata_section(const extractor &input, infusor &output);
+
     void open_metadata_section(const extractor &input, infusor &output);
 
     void references(const extractor &input, infusor &output);

--- a/include/nixsource.h
+++ b/include/nixsource.h
@@ -11,6 +11,8 @@ namespace nixsource {
 
     void open_source(const extractor &input, infusor &output);
 
+    void has_metadata_section(const extractor &input, infusor &output);
+
     void open_metadata_section(const extractor &input, infusor &output);
 
     void sources(const extractor &input, infusor &output);

--- a/include/nixtag.h
+++ b/include/nixtag.h
@@ -19,6 +19,8 @@ namespace nixtag {
 
     void open_source(const extractor &input, infusor &output);
 
+    void has_metadata_section(const extractor &input, infusor &output);
+
     void open_metadata_section(const extractor &input, infusor &output);
 
     void references(const extractor &input, infusor &output);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -69,11 +69,13 @@ const std::vector<fendpoint> funcs = {
         { "Block::listMultiTags", nixblock::list_multi_tags },
         { "Block::openMultiTag", nixblock::open_multi_tag },
         { "Block::multiTags", nixblock::multitags },
+        { "Block::hasMetadataSection", nixblock::has_metadata_section },
         { "Block::openMetadataSection", nixblock::open_metadata_section },
 
         // Data Array
         { "DataArray::describe", nixdataarray::describe },
         { "DataArray::readAll", nixdataarray::read_all },
+        { "DataArray::hasMetadataSection", nixdataarray::has_metadata_section },
         { "DataArray::openMetadataSection", nixdataarray::open_metadata_section },
 
         // Tag
@@ -87,6 +89,7 @@ const std::vector<fendpoint> funcs = {
         { "Tag::openReferenceDataArray", nixtag::open_data_array },
         { "Tag::openFeature", nixtag::open_feature },
         { "Tag::openSource", nixtag::open_source },
+        { "Tag::hasMetadataSection", nixtag::has_metadata_section },
         { "Tag::openMetadataSection", nixtag::open_metadata_section },
 
         // Multi Tag
@@ -103,6 +106,7 @@ const std::vector<fendpoint> funcs = {
         { "MultiTag::openReferences", nixmultitag::open_references },
         { "MultiTag::openFeature", nixmultitag::open_features },
         { "MultiTag::openSource", nixmultitag::open_source },
+        { "MultiTag::hasMetadataSection", nixmultitag::has_metadata_section },
         { "MultiTag::openMetadataSection", nixmultitag::open_metadata_section },
 
         // Source
@@ -110,6 +114,7 @@ const std::vector<fendpoint> funcs = {
         { "Source::listSources", nixsource::list_sources },
         { "Source::openSource", nixsource::open_source },
         { "Source::sources", nixsource::sources },
+        { "Source::hasMetadataSection", nixsource::has_metadata_section },
         { "Source::openMetadataSection", nixsource::open_metadata_section },
 
         // Feature

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -180,10 +180,16 @@ namespace nixblock {
         output.set(0, lst);
     }
 
+    void has_metadata_section(const extractor &input, infusor &output)
+    {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        output.set(0, nixgen::has_metadata_section(currObj.metadata()));
+    }
+
     void open_metadata_section(const extractor &input, infusor &output)
     {
-        nix::Block currTag = input.entity<nix::Block>(1);
-        output.set(0, nixgen::open_metadata_section(currTag.metadata()));
+        nix::Block currObj = input.entity<nix::Block>(1);
+        output.set(0, nixgen::open_metadata_section(currObj.metadata()));
     }
 
 } // namespace nixblock

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -42,7 +42,7 @@ namespace nixblock {
         const mwSize size = static_cast<mwSize>(dataArrays.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < dataArrays.size(); i++) {
+        for (size_t i = 0; i < dataArrays.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(dataArrays[i])));
         }
 
@@ -75,7 +75,7 @@ namespace nixblock {
         const mwSize size = static_cast<mwSize>(sources.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < sources.size(); i++) {
+        for (size_t i = 0; i < sources.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(sources[i])));
         }
 
@@ -125,7 +125,7 @@ namespace nixblock {
         const mwSize size = static_cast<mwSize>(tags.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < tags.size(); i++) {
+        for (size_t i = 0; i < tags.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(tags[i])));
         }
 
@@ -173,7 +173,7 @@ namespace nixblock {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -88,10 +88,16 @@ namespace nixdataarray {
         output.set(0, data);
     }
 
+    void has_metadata_section(const extractor &input, infusor &output)
+    {
+        nix::DataArray currObj = input.entity<nix::DataArray>(1);
+        output.set(0, nixgen::has_metadata_section(currObj.metadata()));
+    }
+
     void open_metadata_section(const extractor &input, infusor &output)
     {
-        nix::DataArray currTag = input.entity<nix::DataArray>(1);
-        output.set(0, nixgen::open_metadata_section(currTag.metadata()));
+        nix::DataArray currObj = input.entity<nix::DataArray>(1);
+        output.set(0, nixgen::open_metadata_section(currObj.metadata()));
     }
 
 } // namespace nixdataarray

--- a/src/nixgen.cc
+++ b/src/nixgen.cc
@@ -41,6 +41,18 @@ namespace nixgen {
         return sb.array();
     }
 
+    mxArray* has_metadata_section(nix::Section currSection)
+    {
+        bool hasMetadataSection = false;
+        // check if an actual, initialized section has been returned
+        if (currSection != nix::none)
+        {
+            hasMetadataSection = true;
+        }
+
+        return nixgen::has_entity(hasMetadataSection, { "hasMetadataSection" });
+    }
+
     mxArray* list_features(std::vector<nix::Feature> featIn)
     {
         std::vector<nix::Feature> arr = featIn;

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -13,85 +13,91 @@ namespace nixmultitag {
 
     void describe(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
 
         struct_builder sb({ 1 }, { "id", "type", "name", "definition", "units", "featureCount", "sourceCount", "referenceCount" });
-        sb.set(currMTag.id());
-        sb.set(currMTag.type());
-        sb.set(currMTag.name());
-        sb.set(currMTag.definition());
-        sb.set(currMTag.units());
-        sb.set(currMTag.featureCount());
-        sb.set(currMTag.sourceCount());
-        sb.set(currMTag.referenceCount());
+        sb.set(currObj.id());
+        sb.set(currObj.type());
+        sb.set(currObj.name());
+        sb.set(currObj.definition());
+        sb.set(currObj.units());
+        sb.set(currObj.featureCount());
+        sb.set(currObj.sourceCount());
+        sb.set(currObj.referenceCount());
 
         output.set(0, sb.array());
     }
 
     void open_references(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::open_data_array(currMTag.getReference(input.str(2))));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::open_data_array(currObj.getReference(input.str(2))));
     }
 
     void open_positions(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::open_data_array(currMTag.positions()));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::open_data_array(currObj.positions()));
     }
 
     void open_extents(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::open_data_array(currMTag.extents()));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::open_data_array(currObj.extents()));
     }
 
     void list_references_array(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::list_data_arrays(currMTag.references()));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::list_data_arrays(currObj.references()));
     }
 
     void has_positions(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::has_entity(currMTag.hasPositions(), { "hasPositions" }));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::has_entity(currObj.hasPositions(), { "hasPositions" }));
     }
 
     void list_features(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::list_features(currMTag.features()));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::list_features(currObj.features()));
     }
 
     void list_sources(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::list_sources(currMTag.sources()));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
     void open_source(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::open_source(currMTag.getSource(input.str(2))));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::open_source(currObj.getSource(input.str(2))));
     }
 
     void open_features(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::open_feature(currMTag.getFeature(input.str(2))));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::open_feature(currObj.getFeature(input.str(2))));
+    }
+
+    void has_metadata_section(const extractor &input, infusor &output)
+    {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::has_metadata_section(currObj.metadata()));
     }
 
     void open_metadata_section(const extractor &input, infusor &output)
     {
-        nix::MultiTag currMTag = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::open_metadata_section(currMTag.metadata()));
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        output.set(0, nixgen::open_metadata_section(currObj.metadata()));
     }
 
     void references(const extractor &input, infusor &output)
     {
-        nix::MultiTag tag = input.entity<nix::MultiTag>(1);
-        std::vector<nix::DataArray> arr = tag.references();
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        std::vector<nix::DataArray> arr = currObj.references();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
@@ -105,8 +111,8 @@ namespace nixmultitag {
 
     void features(const extractor &input, infusor &output)
     {
-        nix::MultiTag tag = input.entity<nix::MultiTag>(1);
-        std::vector<nix::Feature> arr = tag.features();
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        std::vector<nix::Feature> arr = currObj.features();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
@@ -120,8 +126,8 @@ namespace nixmultitag {
 
     void sources(const extractor &input, infusor &output)
     {
-        nix::MultiTag tag = input.entity<nix::MultiTag>(1);
-        std::vector<nix::Source> arr = tag.sources();
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        std::vector<nix::Source> arr = currObj.sources();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -102,7 +102,7 @@ namespace nixmultitag {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 
@@ -117,7 +117,7 @@ namespace nixmultitag {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 
@@ -132,7 +132,7 @@ namespace nixmultitag {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -13,38 +13,44 @@ namespace nixsource {
 
     void describe(const extractor &input, infusor &output)
     {
-        nix::Source currSource = input.entity<nix::Source>(1);
+        nix::Source currObj = input.entity<nix::Source>(1);
         struct_builder sb({ 1 }, { "id", "type", "name", "definition", "sourceCount" });
-        sb.set(currSource.id());
-        sb.set(currSource.type());
-        sb.set(currSource.name());
-        sb.set(currSource.definition());
-        sb.set(currSource.sourceCount());
+        sb.set(currObj.id());
+        sb.set(currObj.type());
+        sb.set(currObj.name());
+        sb.set(currObj.definition());
+        sb.set(currObj.sourceCount());
         output.set(0, sb.array());
     }
 
     void list_sources(const extractor &input, infusor &output)
     {
-        nix::Source currSource = input.entity<nix::Source>(1);
-        output.set(0, nixgen::list_sources(currSource.sources()));
+        nix::Source currObj = input.entity<nix::Source>(1);
+        output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
     void open_source(const extractor &input, infusor &output)
     {
-        nix::Source currSource = input.entity<nix::Source>(1);
-        output.set(0, nixgen::open_source(currSource.getSource(input.str(2))));
+        nix::Source currObj = input.entity<nix::Source>(1);
+        output.set(0, nixgen::open_source(currObj.getSource(input.str(2))));
+    }
+
+    void has_metadata_section(const extractor &input, infusor &output)
+    {
+        nix::Source currObj = input.entity<nix::Source>(1);
+        output.set(0, nixgen::has_metadata_section(currObj.metadata()));
     }
 
     void open_metadata_section(const extractor &input, infusor &output)
     {
-        nix::Source currTag = input.entity<nix::Source>(1);
-        output.set(0, nixgen::open_metadata_section(currTag.metadata()));
+        nix::Source currObj = input.entity<nix::Source>(1);
+        output.set(0, nixgen::open_metadata_section(currObj.metadata()));
     }
 
     void sources(const extractor &input, infusor &output)
     {
-        nix::Source tag = input.entity<nix::Source>(1);
-        std::vector<nix::Source> arr = tag.sources();
+        nix::Source currObj = input.entity<nix::Source>(1);
+        std::vector<nix::Source> arr = currObj.sources();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -55,7 +55,7 @@ namespace nixsource {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -88,7 +88,7 @@ namespace nixtag {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 
@@ -103,7 +103,7 @@ namespace nixtag {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 
@@ -118,7 +118,7 @@ namespace nixtag {
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
 
-        for (int i = 0; i < arr.size(); i++) {
+        for (size_t i = 0; i < arr.size(); i++) {
             mxSetCell(lst, i, make_mx_array(handle(arr[i])));
         }
 

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -13,71 +13,77 @@ namespace nixtag {
 
     void describe(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
+        nix::Tag currObj = input.entity<nix::Tag>(1);
 
         struct_builder sb({ 1 }, { "id", "type", "name", "definition", "position", "extent",
             "units", "featureCount", "sourceCount", "referenceCount" });
 
-        sb.set(currTag.id());
-        sb.set(currTag.type());
-        sb.set(currTag.name());
-        sb.set(currTag.definition());
-        sb.set(currTag.position());
-        sb.set(currTag.extent());
-        sb.set(currTag.units());
-        sb.set(currTag.featureCount());
-        sb.set(currTag.sourceCount());
-        sb.set(currTag.referenceCount());
+        sb.set(currObj.id());
+        sb.set(currObj.type());
+        sb.set(currObj.name());
+        sb.set(currObj.definition());
+        sb.set(currObj.position());
+        sb.set(currObj.extent());
+        sb.set(currObj.units());
+        sb.set(currObj.featureCount());
+        sb.set(currObj.sourceCount());
+        sb.set(currObj.referenceCount());
 
         output.set(0, sb.array());
     }
 
     void open_data_array(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_data_array(currTag.getReference(input.str(2))));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::open_data_array(currObj.getReference(input.str(2))));
     }
 
     void list_references_array(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::list_data_arrays(currTag.references()));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::list_data_arrays(currObj.references()));
     }
 
     void list_features(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::list_features(currTag.features()));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::list_features(currObj.features()));
     }
 
     void list_sources(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::list_sources(currTag.sources()));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
     void open_feature(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_feature(currTag.getFeature(input.str(2))));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::open_feature(currObj.getFeature(input.str(2))));
     }
 
     void open_source(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_source(currTag.getSource(input.str(2))));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::open_source(currObj.getSource(input.str(2))));
+    }
+
+    void has_metadata_section(const extractor &input, infusor &output)
+    {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::has_metadata_section(currObj.metadata()));
     }
 
     void open_metadata_section(const extractor &input, infusor &output)
     {
-        nix::Tag currTag = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_metadata_section(currTag.metadata()));
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        output.set(0, nixgen::open_metadata_section(currObj.metadata()));
     }
 
     void references(const extractor &input, infusor &output)
     {
-        nix::Tag tag = input.entity<nix::Tag>(1);
-        std::vector<nix::DataArray> arr = tag.references();
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::vector<nix::DataArray> arr = currObj.references();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
@@ -91,8 +97,8 @@ namespace nixtag {
 
     void features(const extractor &input, infusor &output)
     {
-        nix::Tag tag = input.entity<nix::Tag>(1);
-        std::vector<nix::Feature> arr = tag.features();
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::vector<nix::Feature> arr = currObj.features();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);
@@ -106,8 +112,8 @@ namespace nixtag {
 
     void sources(const extractor &input, infusor &output)
     {
-        nix::Tag tag = input.entity<nix::Tag>(1);
-        std::vector<nix::Source> arr = tag.sources();
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::vector<nix::Source> arr = currObj.sources();
 
         const mwSize size = static_cast<mwSize>(arr.size());
         mxArray *lst = mxCreateCellArray(1, &size);

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -197,20 +197,45 @@ catch me
     rethrow(me);
 end;
 
+%% Test: Has metadata
+try
+    clear; %-- ensure clean workspace
+    test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
+    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+
+    assert(~getBlock.has_metadata());
+    disp('Test Block: has empty metadata ... OK');
+    
+    %-- ToDo implement test for exising metadata
+    %getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+    %assert(getBlock.has_metadata())
+    disp('Test Block: has existing metadata ... TODO (proper testfile)');
+    
+    clear; %-- close handles
+
+catch me
+    disp('Test Block: has empty/existing metadata ... ERROR');
+    rethrow(me);
+end;
+
 %% Test: Open metadata
 try
     clear; %-- ensure clean workspace
     test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
 
-    %-- ToDo implement proper test for metadata once metadata is implemented
-    assert(strcmp(getBlock.open_metadata(),'TODO: implement MetadataSection'));
+    assert(isempty(getBlock.open_metadata()))
+    disp('Test Block: open empty metadata ... OK');
+    
+    %-- ToDo implement test for exising metadata
+    %getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+    %assert(~isempty(getBlock.open_metadata()))
+    disp('Test Block: open existing metadata ... TODO (proper testfile)');
     
     clear; %-- close handles
-    disp('Test Block: open metadata ... TODO');
 
 catch me
-    disp('Test Block: open metadata ... ERROR');
+    disp('Test Block: open empty/existing metadata ... ERROR');
     rethrow(me);
 end;
 

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -7,7 +7,7 @@ try
     getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
     getDataArray = getBlock.data_array(getBlock.dataArrays{1,1}.id);
 
-    assert(size(getDataArray.read_all(),1) == 36);
+    assert(size(getDataArray.read_all(),2) == 36);
     disp('Test DataArray: read all data ... OK');
 
     clear; %-- close handles

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -17,21 +17,47 @@ catch me
     rethrow(me);
 end;
 
+%% Test: Has metadata
+try
+    clear; %-- ensure clean workspace
+    test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
+    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+
+    %-- ToDo implement test for empty metadata
+    getDataArray = getBlock.data_array(getBlock.dataArrays{1,1}.id);
+    %assert(~getDataArray.has_metadata());
+    disp('Test DataArray: has empty metadata ... TODO (proper testfile)');
+    
+    getDataArray = getBlock.data_array(getBlock.dataArrays{1,1}.id);
+    assert(getDataArray.has_metadata())
+    disp('Test DataArray: has existing metadata ... OK');
+    
+    clear; %-- close handles
+
+catch me
+    disp('Test DataArray: has empty/existing metadata ... ERROR');
+    rethrow(me);
+end;
+
 %% Test: Open metadata
 try
     clear; %-- ensure clean workspace
     test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+    
+    %-- ToDo implement test for empty metadata
     getDataArray = getBlock.data_array(getBlock.dataArrays{1,1}.id);
-
-    %-- ToDo implement proper test for metadata once metadata is implemented
-    assert(strcmp(getDataArray.open_metadata(),'TODO: implement MetadataSection'));
+    %assert(isempty(getDataArray.open_metadata()))
+    disp('Test DataArray: open empty metadata ... TODO (proper testfile)');
+    
+    getDataArray = getBlock.data_array(getBlock.dataArrays{1,1}.id);
+    assert(~isempty(getDataArray.open_metadata()))
+    disp('Test DataArray: open existing metadata ... OK');
     
     clear; %-- close handles
-    disp('Test DataArray: open metadata ... TODO');
 
 catch me
-    disp('Test DataArray: open metadata ... ERROR');
+    disp('Test DataArray: open empty/existing metadata ... ERROR');
     rethrow(me);
 end;
 

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -128,21 +128,47 @@ catch me
     rethrow(me);
 end;
 
+%% Test: Has metadata
+try
+    clear; %-- ensure clean workspace
+    test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
+    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+
+    getMultiTag = getBlock.open_multi_tag(getBlock.multiTags{1,1}.id);
+    assert(~getMultiTag.has_metadata());
+    disp('Test MultiTag: has empty metadata ... OK');
+    
+    %-- ToDo implement test for existing metadata
+    %getMultiTag = getBlock.open_multi_tag(getBlock.multiTags{2,1}.id);
+    %assert(getMultiTag.has_metadata());
+    disp('Test MultiTag: has existing metadata ... TODO (proper testfile)');
+    
+    clear; %-- close handles
+
+catch me
+    disp('Test MultiTag: has empty/existing metadata ... ERROR');
+    rethrow(me);
+end;
+
 %% Test: Open metadata
 try
     clear; %-- ensure clean workspace
     test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+    
     getMultiTag = getBlock.open_multi_tag(getBlock.multiTags{1,1}.id);
-
-    %-- TODO: implement proper test for metadata once metadata is implemented
-    assert(strcmp(getMultiTag.open_metadata(),'TODO: implement MetadataSection'));
+    assert(isempty(getMultiTag.open_metadata()))
+    disp('Test MultiTag: open empty metadata ... OK');
+    
+    %-- ToDo implement test for existing metadata
+    %getMultiTag = getBlock.open_multi_tag(getBlock.multiTags{2,1}.id);
+    %assert(~isempty(getMultiTag.open_metadata()));
+    disp('Test MultiTag: open existing metadata ... TODO (proper testfile)');
     
     clear; %-- close handles
-    disp('Test MultiTag: open metadata ... TODO');
 
 catch me
-    disp('Test MultiTag: open metadata ... ERROR');
+    disp('Test MultiTag: open empty/existing metadata ... ERROR');
     rethrow(me);
 end;
 

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -44,22 +44,49 @@ catch me
     rethrow(me);
 end;
 
+%% Test: Has metadata
+try
+    clear; %-- ensure clean workspace
+    test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
+    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+
+    
+    getSource = getBlock.open_source(getBlock.sources{1,1}.id);
+    assert(~getSource.has_metadata());
+    disp('Test Source: has empty metadata ... OK');
+    
+    %-- ToDo implement test for empty metadata
+    %getSource = getBlock.open_source(getBlock.sources{1,1}.id);
+    %assert(getSource.has_metadata())
+    disp('Test Source: has existing metadata ... TODO (proper testfile)');
+    
+    clear; %-- close handles
+
+catch me
+    disp('Test Source: has empty/existing metadata ... ERROR');
+    rethrow(me);
+end;
+
 %% Test: Open metadata
 try
     clear; %-- ensure clean workspace
     test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
-    getBlock = test_file.openBlock(test_file.blocks{1,1}.id);
-    getSFromB = getBlock.open_source(getBlock.sources{1,1}.id);
-
-    %-- TODO implement proper test for metadata once metadata is implemented
-    %-- TODO implement testfile where a source links to metadata
-    assert(strcmp(getSFromB.open_metadata(),'TODO: implement MetadataSection'));
+    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+    
+    getSource = getBlock.open_source(getBlock.sources{1,1}.id);
+    assert(isempty(getSource.open_metadata()))
+    disp('Test Source: open empty metadata ... OK');
+    
+    %-- ToDo implement test for empty metadata
+    %getSource = getBlock.open_source(getBlock.sources{1,1}.id);
+    %assert(~isempty(getSource.open_metadata()))
+    disp('Test Source: open existing metadata ... TODO (proper testfile)');
     
     clear; %-- close handles
-    disp('Test Source: open metadata ... TODO');
 
 catch me
-    disp('Test Source: open metadata ... ERROR');
+    disp('Test Source: open empty/existing metadata ... ERROR');
     rethrow(me);
 end;
+
 

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -130,21 +130,45 @@ catch me
     rethrow(me);
 end;
 
+%% Test: Has metadata
+try
+    clear; %-- ensure clean workspace
+    test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
+    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+
+    getTag = getBlock.open_tag(getBlock.tags{1,1}.id);
+    assert(~getTag.has_metadata());
+    disp('Test Tag: has empty metadata ... OK');
+    
+    getTag = getBlock.open_tag(getBlock.tags{2,1}.id);
+    assert(getTag.has_metadata());
+    disp('Test Tag: has existing metadata ... OK');
+    
+    clear; %-- close handles
+
+catch me
+    disp('Test Tag: has empty/existing metadata ... ERROR');
+    rethrow(me);
+end;
+
 %% Test: Open metadata
 try
     clear; %-- ensure clean workspace
     test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
+    
     getTag = getBlock.open_tag(getBlock.tags{1,1}.id);
-
-    %-- TODO: implement proper test for metadata once metadata is implemented
-    assert(strcmp(getTag.open_metadata(),'TODO: implement MetadataSection'));
+    assert(isempty(getTag.open_metadata()))
+    disp('Test Tag: open empty metadata ... OK');
+    
+    getTag = getBlock.open_tag(getBlock.tags{2,1}.id);
+    assert(~isempty(getTag.open_metadata()));
+    disp('Test Tag: open existing metadata ... OK');
     
     clear; %-- close handles
-    disp('Test Tag: open metadata ... TODO');
 
 catch me
-    disp('Test Tag: open metadata ... ERROR');
+    disp('Test Tag: open empty/existing metadata ... ERROR');
     rethrow(me);
 end;
 


### PR DESCRIPTION
- access metadata section from block, source, tag and multitag
- add tests for the above mentioned
- remove sign comparison warning from block, source, tag and multitag
- fix test bug in dataarray after merge pull request 16