### PR TITLE
Tweak tests

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -1,7 +1,1 @@
-buildpath = fullfile(pwd, 'build');
-addpath(buildpath);
-dbgpath = fullfile(buildpath, 'Debug');
-if exist(dbgpath, 'file')
-    addpath(dbgpath);
-end
-addpath(pwd);
+addpath(genpath(pwd));

--- a/tests/RunTests.m
+++ b/tests/RunTests.m
@@ -4,9 +4,6 @@ clear all;
 stats.okCount = 0;
 stats.errorCount = 0;
 
-%-- add required paths for matlab
-addpath(fullfile(pwd, 'build'));
-
 disp([10 'starting tests']);
 
 %-- ToDo: create proper testfile, loose the 24mb one

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -2,18 +2,19 @@ function funcs = testBlock
 %TESTFILE Tests for the nix.Block object
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_arrays;
-    funcs{2} = @test_list_sources;
-    funcs{3} = @test_list_tags;
-    funcs{4} = @test_list_multitags;
-    funcs{5} = @test_open_array;
-    funcs{6} = @test_open_tag;
-    funcs{7} = @test_open_multitag;
-    funcs{8} = @test_open_source;
-    funcs{9} = @test_has_multitag;
-    funcs{10} = @test_has_tag;
-    funcs{11} = @test_has_metadata;
-    funcs{12} = @test_open_metadata;
+    funcs = {};
+    funcs{end+1} = @test_list_arrays;
+    funcs{end+1} = @test_list_sources;
+    funcs{end+1} = @test_list_tags;
+    funcs{end+1} = @test_list_multitags;
+    funcs{end+1} = @test_open_array;
+    funcs{end+1} = @test_open_tag;
+    funcs{end+1} = @test_open_multitag;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_has_multitag;
+    funcs{end+1} = @test_has_tag;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
 end
 
 function [] = test_list_arrays( varargin )

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -2,10 +2,11 @@ function funcs = TestDataArray
 %TESTDATAARRAY tests for DataArray
 %   Detailed explanation goes here
 
-    funcs{1} = @test_open_data;
-    funcs{2} = @test_has_metadata;
-    funcs{3} = @test_open_metadata;
-    funcs{4} = @test_list_sources;
+    funcs = {}
+    funcs{end+1} = @test_open_data;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_list_sources;
 end
 
 %% Test: Read all data from DataArray

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -2,13 +2,14 @@ function funcs = testFile
 %TESTFILE tests for File
 %   Detailed explanation goes here
 
-    funcs{1} = @test_read_only;
-    funcs{2} = @test_read_write;
-    funcs{3} = @test_overwrite;
-    funcs{4} = @test_list_sections;
-    funcs{5} = @test_open_section;
-    funcs{6} = @test_list_blocks;
-    funcs{7} = @test_open_block;
+    funcs = {};
+    funcs{end+1} = @test_read_only;
+    funcs{end+1} = @test_read_write;
+    funcs{end+1} = @test_overwrite;
+    funcs{end+1} = @test_list_sections;
+    funcs{end+1} = @test_open_section;
+    funcs{end+1} = @test_list_blocks;
+    funcs{end+1} = @test_open_block;
 end
 
 function [] = test_read_only( varargin )

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -2,16 +2,17 @@ function funcs = TestMultiTag
 %TESTMultiTag tests for MultiTag
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_fetch_references;
-    funcs{2} = @test_list_fetch_sources;
-    funcs{3} = @test_list_fetch_features;
-    funcs{4} = @test_open_source;
-    funcs{5} = @test_open_feature;
-    funcs{6} = @test_open_reference;
-    funcs{7} = @test_has_metadata;
-    funcs{8} = @test_open_metadata;
-    funcs{9} = @test_retrieve_data;
-    funcs{10} = @test_retrieve_feature_data;
+    funcs = {};
+    funcs{end+1} = @test_list_fetch_references;
+    funcs{end+1} = @test_list_fetch_sources;
+    funcs{end+1} = @test_list_fetch_features;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_open_feature;
+    funcs{end+1} = @test_open_reference;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_retrieve_data;
+    funcs{end+1} = @test_retrieve_feature_data;
 end
 
 %% Test: List/fetch references

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -2,12 +2,13 @@ function funcs = testSection
 %TESTFILE % Tests for the nix.Section object
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_subsections;
-    funcs{2} = @test_open_section;
-    funcs{3} = @test_parent;
-    funcs{4} = @test_has_section;
-    funcs{5} = @test_attrs;
-    funcs{6} = @test_properties;
+    funcs = {};
+    funcs{end+1} = @test_list_subsections;
+    funcs{end+1} = @test_open_section;
+    funcs{end+1} = @test_parent;
+    funcs{end+1} = @test_has_section;
+    funcs{end+1} = @test_attrs;
+    funcs{end+1} = @test_properties;
 end
 
 function [] = test_list_subsections( varargin )

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -2,10 +2,11 @@ function funcs = testSource
 %TESTSOURCE tests for Source
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_fetch_sources;
-    funcs{2} = @test_open_source;
-    funcs{3} = @test_has_metadata;
-    funcs{4} = @test_open_metadata;
+    funcs = {};
+    funcs{end+1} = @test_list_fetch_sources;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
 end
 
 %% Test: List/fetch sources

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -2,16 +2,17 @@ function funcs = TestTag
 %TESTTag tests for Tag
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_fetch_references;
-    funcs{2} = @test_list_fetch_sources;
-    funcs{3} = @test_list_fetch_features;
-    funcs{4} = @test_open_source;
-    funcs{5} = @test_open_feature;
-    funcs{6} = @test_open_reference;
-    funcs{7} = @test_has_metadata;
-    funcs{8} = @test_open_metadata;
-    funcs{9} = @test_retrieve_data;
-    funcs{10} = @test_retrieve_feature_data;
+    funcs = {};
+    funcs{end+1} = @test_list_fetch_references;
+    funcs{end+1} = @test_list_fetch_sources;
+    funcs{end+1} = @test_list_fetch_features;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_open_feature;
+    funcs{end+1} = @test_open_reference;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_retrieve_data;
+    funcs{end+1} = @test_retrieve_feature_data;
 end
 
 %% Test: List/fetch references


### PR DESCRIPTION
- change  matlab startup to add all folders within the root directory to the matlab path
- rename 'Run' to 'RunTests'
- use generic index when adding unit tests to test list