### PR TITLE
Write to nix file object / tweak tests

### DIFF
--- a/+nix/File.m
+++ b/+nix/File.m
@@ -46,6 +46,11 @@ classdef File < nix.Entity
                 'File::blocks', obj.nix_handle, obj.blocksCache, @nix.Block);
         end
         
+        function newBlock = createBlock(obj, name, type)
+            newBlockHandle = nix_mx('File::createBlock', obj.nix_handle, name, type);
+            newBlock = nix.Block(newBlockHandle);
+        end;
+
         % ----------------
         % Section methods
         % ----------------
@@ -64,6 +69,11 @@ classdef File < nix.Entity
                 'File::sections', obj.nix_handle, obj.sectionsCache, @nix.Section);
         end;
 
+        function newSec = createSection(obj, name, type)
+            newSecHandle = nix_mx('File::createSection', obj.nix_handle, name, type);
+            newSec = nix.Section(newSecHandle);
+        end;
+        
     end
 end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -48,11 +48,13 @@ classdef File < nix.Entity
         
         function newBlock = createBlock(obj, name, type)
             newBlock = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
+            obj.blocksCache.lastUpdate = 0;
         end;
 
         function delCheck = deleteBlock(obj, deleteBlockObj)
             retStruct = nix_mx('File::deleteBlock', obj.nix_handle, deleteBlockObj.nix_handle);
             delCheck = logical(retStruct.deleted);
+            obj.blocksCache.lastUpdate = 0;
         end;
 
         % ----------------
@@ -75,11 +77,13 @@ classdef File < nix.Entity
 
         function newSec = createSection(obj, name, type)
             newSec = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
+            obj.sectionsCache.lastUpdate = 0;
         end;
 
         function delCheck = deleteSection(obj, deleteSectionObj)
             retStruct = nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle);
             delCheck = logical(retStruct.deleted);
+            obj.sectionsCache.lastUpdate = 0;
         end;
 
     end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -47,8 +47,11 @@ classdef File < nix.Entity
         end
         
         function newBlock = createBlock(obj, name, type)
-            newBlockHandle = nix_mx('File::createBlock', obj.nix_handle, name, type);
-            newBlock = nix.Block(newBlockHandle);
+            newBlock = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
+        end;
+
+        function delCheck = deleteBlock(obj, deleteBlockObj)
+            delCheck = logical(nix_mx('File::deleteBlock', obj.nix_handle, deleteBlockObj.nix_handle));
         end;
 
         % ----------------
@@ -70,10 +73,13 @@ classdef File < nix.Entity
         end;
 
         function newSec = createSection(obj, name, type)
-            newSecHandle = nix_mx('File::createSection', obj.nix_handle, name, type);
-            newSec = nix.Section(newSecHandle);
+            newSec = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
         end;
-        
+
+        function delCheck = deleteSection(obj, deleteSectionObj)
+            delCheck = logical(nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle));
+        end;
+
     end
 end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -51,7 +51,8 @@ classdef File < nix.Entity
         end;
 
         function delCheck = deleteBlock(obj, deleteBlockObj)
-            delCheck = logical(nix_mx('File::deleteBlock', obj.nix_handle, deleteBlockObj.nix_handle));
+            retStruct = nix_mx('File::deleteBlock', obj.nix_handle, deleteBlockObj.nix_handle);
+            delCheck = logical(retStruct.deleted);
         end;
 
         % ----------------
@@ -77,7 +78,8 @@ classdef File < nix.Entity
         end;
 
         function delCheck = deleteSection(obj, deleteSectionObj)
-            delCheck = logical(nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle));
+            retStruct = nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle);
+            delCheck = logical(retStruct.deleted);
         end;
 
     end

--- a/examples/Primer.m
+++ b/examples/Primer.m
@@ -3,6 +3,9 @@
 % using nix-mx.
 % --------------------------------------
 
+clear all;
+
+%% File operations
 path = 'C:\projects\nix-mx\tests\test.h5';
 
 % Open NIX file
@@ -17,7 +20,7 @@ cellfun(@(x) disp(x.name), f.blocks);
 % get a certain Block
 b = f.blocks{2};
 
-% --------------------------------------
+%% Data operations
 
 % get Data Arrays of a certain type
 idx = cellfun(@(x) strcmp(x.type, 'nix.spiketimes'), b.dataArrays);
@@ -31,7 +34,16 @@ cond4 = @(x) x.open_metadata.properties_map('ExperimentalCondition') == 3;
 idx = cellfun(@(x) cond1(x) & cond2(x) & cond3(x) & cond4(x), b.dataArrays);
 selection2 = b.dataArrays(idx);
 
-% --------------------------------------
+% get actual data
+d1 = b.dataArrays{1};
+dataset = d1.read_all();
+
+% understand dimensions
+dim1 = d1.dimensions{1};
+dim1.type
+dim1.unit
+
+%% Metadata operations
 
 % explore root metadata Sections (type, name)
 cellfun(@(x) disp(strcat(x.type, ': ', x.name)), f.sections);
@@ -47,3 +59,6 @@ value = sec.properties_cell{1}.values{1};
 
 % or by name
 value = sec.properties_map('Name');
+
+%% clear space
+clear all;

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -63,6 +63,8 @@ const std::vector<fendpoint> funcs = {
         { "File::openBlock", nixfile::open_block },
         { "File::listSections", nixfile::list_sections },
         { "File::openSection", nixfile::open_section },
+        { "File::createBlock", nixfile::create_block },
+        { "File::createSection", nixfile::create_section },
 
         // Block
         { "Block::describe", nixblock::describe },

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -65,6 +65,8 @@ const std::vector<fendpoint> funcs = {
         { "File::openSection", nixfile::open_section },
         { "File::createBlock", nixfile::create_block },
         { "File::createSection", nixfile::create_section },
+        { "File::deleteBlock", nixfile::delete_block },
+        { "File::deleteSection", nixfile::delete_section },
 
         // Block
         { "Block::describe", nixblock::describe },

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -103,9 +103,6 @@ void create_block(const extractor &input, infusor &output)
     nix::File currObj = input.entity<nix::File>(1);
     nix::Block newBlock = currObj.createBlock(input.str(2), input.str(3));
 
-    // set updatedAt, otherwise cache on matlab side is not refreshed
-    currObj.forceUpdatedAt();
-
     handle nbh = handle(newBlock);
     output.set(0, nbh);
 }
@@ -114,9 +111,6 @@ void create_section(const extractor &input, infusor &output)
 {
     nix::File currObj = input.entity<nix::File>(1);
     nix::Section newSection = currObj.createSection(input.str(2), input.str(3));
-
-    // set updatedAt, otherwise cache on matlab side is not refreshed
-    currObj.forceUpdatedAt();
 
     handle nsh = handle(newSection);
     output.set(0, nsh);
@@ -128,9 +122,6 @@ void delete_block(const extractor &input, infusor &output)
     nix::Block delObj = input.entity<nix::Block>(2);
     bool checkDeleted = currObj.deleteBlock(delObj);
 
-    // set updatedAt, otherwise cache on matlab side is not refreshed
-    currObj.forceUpdatedAt();
-
     // TODO rename has_entity or implement other means of returning boolean value to Matlab
     output.set(0, nixgen::has_entity(checkDeleted, { "deleted" }));
 }
@@ -140,9 +131,6 @@ void delete_section(const extractor &input, infusor &output)
     nix::File currObj = input.entity<nix::File>(1);
     nix::Section delObj = input.entity<nix::Section>(2);
     bool checkDeleted = currObj.deleteSection(delObj);
-
-    // set updatedAt, otherwise cache on matlab side is not refreshed
-    currObj.forceUpdatedAt();
 
     // TODO rename has_entity or implement other means of returning boolean value to Matlab
     output.set(0, nixgen::has_entity(checkDeleted, { "deleted" }));

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -97,4 +97,20 @@ void open_section(const extractor &input, infusor &output)
     output.set(0, bb);
 }
 
+void create_block(const extractor &input, infusor &output)
+{
+    nix::File nf = input.entity<nix::File>(1);
+    nix::Block newBlock = nf.createBlock(input.str(2), input.str(3));
+    handle nbh = handle(newBlock);
+    output.set(0, nbh);
+}
+
+void create_section(const extractor &input, infusor &output)
+{
+    nix::File nf = input.entity<nix::File>(1);
+    nix::Section newSection = nf.createSection(input.str(2), input.str(3));
+    handle nsh = handle(newSection);
+    output.set(0, nsh);
+}
+
 } // namespace nixfile

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -1,4 +1,5 @@
 #include "nixfile.h"
+#include "nixgen.h"
 
 #include "mex.h"
 
@@ -99,18 +100,52 @@ void open_section(const extractor &input, infusor &output)
 
 void create_block(const extractor &input, infusor &output)
 {
-    nix::File nf = input.entity<nix::File>(1);
-    nix::Block newBlock = nf.createBlock(input.str(2), input.str(3));
+    nix::File currObj = input.entity<nix::File>(1);
+    nix::Block newBlock = currObj.createBlock(input.str(2), input.str(3));
+
+    // set updatedAt, otherwise cache on matlab side is not refreshed
+    currObj.forceUpdatedAt();
+
     handle nbh = handle(newBlock);
     output.set(0, nbh);
 }
 
 void create_section(const extractor &input, infusor &output)
 {
-    nix::File nf = input.entity<nix::File>(1);
-    nix::Section newSection = nf.createSection(input.str(2), input.str(3));
+    nix::File currObj = input.entity<nix::File>(1);
+    nix::Section newSection = currObj.createSection(input.str(2), input.str(3));
+
+    // set updatedAt, otherwise cache on matlab side is not refreshed
+    currObj.forceUpdatedAt();
+
     handle nsh = handle(newSection);
     output.set(0, nsh);
+}
+
+void delete_block(const extractor &input, infusor &output)
+{
+    nix::File currObj = input.entity<nix::File>(1);
+    nix::Block delObj = input.entity<nix::Block>(2);
+    bool checkDeleted = currObj.deleteBlock(delObj);
+
+    // set updatedAt, otherwise cache on matlab side is not refreshed
+    currObj.forceUpdatedAt();
+
+    // TODO rename has_entity or implement other means of returning boolean value to Matlab
+    output.set(0, nixgen::has_entity(checkDeleted, { "deleted" }));
+}
+
+void delete_section(const extractor &input, infusor &output)
+{
+    nix::File currObj = input.entity<nix::File>(1);
+    nix::Section delObj = input.entity<nix::Section>(2);
+    bool checkDeleted = currObj.deleteSection(delObj);
+
+    // set updatedAt, otherwise cache on matlab side is not refreshed
+    currObj.forceUpdatedAt();
+
+    // TODO rename has_entity or implement other means of returning boolean value to Matlab
+    output.set(0, nixgen::has_entity(checkDeleted, { "deleted" }));
 }
 
 } // namespace nixfile

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -17,6 +17,10 @@ void list_sections(const extractor &input, infusor &output);
 
 void open_section(const extractor &input, infusor &output);
 
+void create_block(const extractor &input, infusor &output);
+
+void create_section(const extractor &input, infusor &output);
+
 } // namespace nixfile
 
 #endif

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -21,6 +21,10 @@ void create_block(const extractor &input, infusor &output);
 
 void create_section(const extractor &input, infusor &output);
 
+void delete_block(const extractor &input, infusor &output);
+
+void delete_section(const extractor &input, infusor &output);
+
 } // namespace nixfile
 
 #endif

--- a/startup.m
+++ b/startup.m
@@ -1,7 +1,1 @@
-buildpath = fullfile(pwd, 'build');
-addpath(buildpath);
-dbgpath = fullfile(buildpath, 'Debug');
-if exist(dbgpath, 'file')
-    addpath(dbgpath);
-end
-addpath(pwd);
+addpath(genpath(pwd));

--- a/tests/Run.m
+++ b/tests/Run.m
@@ -16,21 +16,32 @@ disp([10 'starting tests']);
 %--     name: joe097
 
 % individual tests
-t1 = TestFile();
-t2 = TestBlock();
-t3 = TestSource();
-t4 = TestDataArray();
-t5 = TestTag();
-t6 = TestMultiTag();
-t7 = TestSection();
+t1.name = 'FILE';
+t1.tests = TestFile();
+t2.name = 'BLOCK';
+t2.tests = TestBlock();
+t3.name = 'SOURCE';
+t3.tests = TestSource();
+t4.name = 'DATA ARRAY';
+t4.tests = TestDataArray();
+t5.name = 'TAG';
+t5.tests = TestTag();
+t6.name = 'MULTITAG';
+t6.tests = TestMultiTag();
+t7.name = 'SECTION';
+t7.tests = TestSection();
 
 %-- TODO: TestFeature
 
 % concatenate all test handles
-all_tests = {t1{:}, t2{:}, t3{:}, t4{:}, t5{:}, t6{:}, t7{:}};
+all_tests = {t1, t2, t3, t4, t5, t6, t7};
 
 for i = 1:length(all_tests)
-    stats = wrapper(all_tests{i}, stats);
+    fprintf([10 'Execute ' all_tests{i}.name ' tests:\n\n']);
+    
+    for j = 1:length(all_tests{i}.tests)
+        stats = wrapper(all_tests{i}.tests{j}, stats);
+    end
 end;
 
 disp([10 'Tests: ' num2str(stats.okCount) ' succeeded, ' num2str(stats.errorCount) ' failed']);

--- a/tests/RunTests.m
+++ b/tests/RunTests.m
@@ -4,9 +4,6 @@ clear all;
 stats.okCount = 0;
 stats.errorCount = 0;
 
-%-- add required paths for matlab
-addpath(fullfile(pwd, 'build'));
-
 disp([10 'starting tests']);
 
 %-- ToDo: create proper testfile, loose the 24mb one

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -2,18 +2,19 @@ function funcs = testBlock
 %TESTFILE Tests for the nix.Block object
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_arrays;
-    funcs{2} = @test_list_sources;
-    funcs{3} = @test_list_tags;
-    funcs{4} = @test_list_multitags;
-    funcs{5} = @test_open_array;
-    funcs{6} = @test_open_tag;
-    funcs{7} = @test_open_multitag;
-    funcs{8} = @test_open_source;
-    funcs{9} = @test_has_multitag;
-    funcs{10} = @test_has_tag;
-    funcs{11} = @test_has_metadata;
-    funcs{12} = @test_open_metadata;
+    funcs = {};
+    funcs{end+1} = @test_list_arrays;
+    funcs{end+1} = @test_list_sources;
+    funcs{end+1} = @test_list_tags;
+    funcs{end+1} = @test_list_multitags;
+    funcs{end+1} = @test_open_array;
+    funcs{end+1} = @test_open_tag;
+    funcs{end+1} = @test_open_multitag;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_has_multitag;
+    funcs{end+1} = @test_has_tag;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
 end
 
 function [] = test_list_arrays( varargin )

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -2,10 +2,11 @@ function funcs = TestDataArray
 %TESTDATAARRAY tests for DataArray
 %   Detailed explanation goes here
 
-    funcs{1} = @test_open_data;
-    funcs{2} = @test_has_metadata;
-    funcs{3} = @test_open_metadata;
-    funcs{4} = @test_list_sources;
+    funcs = {}
+    funcs{end+1} = @test_open_data;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_list_sources;
 end
 
 %% Test: Read all data from DataArray

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -2,7 +2,7 @@ function funcs = TestDataArray
 %TESTDATAARRAY tests for DataArray
 %   Detailed explanation goes here
 
-    funcs = {}
+    funcs = {};
     funcs{end+1} = @test_open_data;
     funcs{end+1} = @test_has_metadata;
     funcs{end+1} = @test_open_metadata;

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -2,13 +2,14 @@ function funcs = testFile
 %TESTFILE tests for File
 %   Detailed explanation goes here
 
-    funcs{1} = @test_read_only;
-    funcs{2} = @test_read_write;
-    funcs{3} = @test_overwrite;
-    funcs{4} = @test_list_sections;
-    funcs{5} = @test_open_section;
-    funcs{6} = @test_list_blocks;
-    funcs{7} = @test_open_block;
+    funcs = {};
+    funcs{end+1} = @test_read_only;
+    funcs{end+1} = @test_read_write;
+    funcs{end+1} = @test_overwrite;
+    funcs{end+1} = @test_list_sections;
+    funcs{end+1} = @test_open_section;
+    funcs{end+1} = @test_list_blocks;
+    funcs{end+1} = @test_open_block;
 end
 
 function [] = test_read_only( varargin )

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -53,13 +53,7 @@ function [] = test_delete_block( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
     checkDelete = test_file.deleteBlock(test_file.blocks{1});
     assert(checkDelete);
-%-- TODO Bug: the updatedAt timestamp has a limited time resolution
-%-- if create and delete of the the same entity are too close together
-%-- in time, the updatedAt timestamp will not be changed between create and
-%-- delete and the cache on the matlab side will not be refreshed.
-%-- thats why the next statement will lead to an error if it is included 
-%-- in this test.
-%    assert(size(test_file.blocks, 1) == 0);
+    assert(size(test_file.blocks, 1) == 0);
 end
 
 %% Test: Delete Section
@@ -67,6 +61,7 @@ function [] = test_delete_section( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
     checkDelete = test_file.deleteSection(test_file.sections{1});
     assert(checkDelete);
+    assert(size(test_file.sections, 1) == 0);
 end
 
 function [] = test_list_sections( varargin )

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -6,31 +6,43 @@ function funcs = testFile
     funcs{end+1} = @test_read_only;
     funcs{end+1} = @test_read_write;
     funcs{end+1} = @test_overwrite;
+    funcs{end+1} = @test_create_block;
+    funcs{end+1} = @test_create_section;
     funcs{end+1} = @test_list_sections;
     funcs{end+1} = @test_open_section;
     funcs{end+1} = @test_list_blocks;
     funcs{end+1} = @test_open_block;
 end
 
-function [] = test_read_only( varargin )
 %% Test: Open HDF5 file in ReadOnly mode
+function [] = test_read_only( varargin )
     f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
 end
 
-function [] = test_read_write( varargin )
 %% Test: Open HDF5 file in ReadWrite mode
-
-    %-- TODO: throws error 'does not work' at the moment
-    %f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadWrite);
+function [] = test_read_write( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
 end
 
-function [] = test_overwrite( varargin )
 %% Test: Open HDF5 file in Overwrite mode
-%-- ToDo: maybe there's a cleverer way for the overwrite test than having
-%-- two test files.
-% AS: I'd excluded it for the moment as as it's always causing changes to
-% GIT.
-    %f = nix.File(fullfile(pwd,'tests','testOverwrite.h5'), nix.FileMode.Overwrite);
+function [] = test_overwrite( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+end
+
+%% Test: Create Block
+function [] = test_create_block( varargin )
+    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+    useName = 'testBlock 1';
+    newBlock = test_file.createBlock(useName, 'testType 1');
+    assert(strcmp(newBlock.name(), useName));
+end
+
+%% Test: Create Section
+function [] = test_create_section( varargin )
+    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+    useName = 'testSection 1';
+    newSection = test_file.createSection(useName, 'testType 1');
+    assert(strcmp(newSection.name(), useName));
 end
 
 function [] = test_list_sections( varargin )

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -12,6 +12,9 @@ function funcs = testFile
     funcs{end+1} = @test_open_section;
     funcs{end+1} = @test_list_blocks;
     funcs{end+1} = @test_open_block;
+    funcs{end+1} = @test_delete_block;
+    funcs{end+1} = @test_delete_section;
+
 end
 
 %% Test: Open HDF5 file in ReadOnly mode
@@ -43,6 +46,27 @@ function [] = test_create_section( varargin )
     useName = 'testSection 1';
     newSection = test_file.createSection(useName, 'testType 1');
     assert(strcmp(newSection.name(), useName));
+end
+
+%% Test: Delete Block
+function [] = test_delete_block( varargin )
+    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+    checkDelete = test_file.deleteBlock(test_file.blocks{1});
+    assert(checkDelete);
+%-- TODO Bug: the updatedAt timestamp has a limited time resolution
+%-- if create and delete of the the same entity are too close together
+%-- in time, the updatedAt timestamp will not be changed between create and
+%-- delete and the cache on the matlab side will not be refreshed.
+%-- thats why the next statement will lead to an error if it is included 
+%-- in this test.
+%    assert(size(test_file.blocks, 1) == 0);
+end
+
+%% Test: Delete Section
+function [] = test_delete_section( varargin )
+    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+    checkDelete = test_file.deleteSection(test_file.sections{1});
+    assert(checkDelete);
 end
 
 function [] = test_list_sections( varargin )

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -2,16 +2,17 @@ function funcs = TestMultiTag
 %TESTMultiTag tests for MultiTag
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_fetch_references;
-    funcs{2} = @test_list_fetch_sources;
-    funcs{3} = @test_list_fetch_features;
-    funcs{4} = @test_open_source;
-    funcs{5} = @test_open_feature;
-    funcs{6} = @test_open_reference;
-    funcs{7} = @test_has_metadata;
-    funcs{8} = @test_open_metadata;
-    funcs{9} = @test_retrieve_data;
-    funcs{10} = @test_retrieve_feature_data;
+    funcs = {};
+    funcs{end+1} = @test_list_fetch_references;
+    funcs{end+1} = @test_list_fetch_sources;
+    funcs{end+1} = @test_list_fetch_features;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_open_feature;
+    funcs{end+1} = @test_open_reference;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_retrieve_data;
+    funcs{end+1} = @test_retrieve_feature_data;
 end
 
 %% Test: List/fetch references

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -2,12 +2,13 @@ function funcs = testSection
 %TESTFILE % Tests for the nix.Section object
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_subsections;
-    funcs{2} = @test_open_section;
-    funcs{3} = @test_parent;
-    funcs{4} = @test_has_section;
-    funcs{5} = @test_attrs;
-    funcs{6} = @test_properties;
+    funcs = {};
+    funcs{end+1} = @test_list_subsections;
+    funcs{end+1} = @test_open_section;
+    funcs{end+1} = @test_parent;
+    funcs{end+1} = @test_has_section;
+    funcs{end+1} = @test_attrs;
+    funcs{end+1} = @test_properties;
 end
 
 function [] = test_list_subsections( varargin )

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -2,10 +2,11 @@ function funcs = testSource
 %TESTSOURCE tests for Source
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_fetch_sources;
-    funcs{2} = @test_open_source;
-    funcs{3} = @test_has_metadata;
-    funcs{4} = @test_open_metadata;
+    funcs = {};
+    funcs{end+1} = @test_list_fetch_sources;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
 end
 
 %% Test: List/fetch sources

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -2,16 +2,17 @@ function funcs = TestTag
 %TESTTag tests for Tag
 %   Detailed explanation goes here
 
-    funcs{1} = @test_list_fetch_references;
-    funcs{2} = @test_list_fetch_sources;
-    funcs{3} = @test_list_fetch_features;
-    funcs{4} = @test_open_source;
-    funcs{5} = @test_open_feature;
-    funcs{6} = @test_open_reference;
-    funcs{7} = @test_has_metadata;
-    funcs{8} = @test_open_metadata;
-    funcs{9} = @test_retrieve_data;
-    funcs{10} = @test_retrieve_feature_data;
+    funcs = {};
+    funcs{end+1} = @test_list_fetch_references;
+    funcs{end+1} = @test_list_fetch_sources;
+    funcs{end+1} = @test_list_fetch_features;
+    funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_open_feature;
+    funcs{end+1} = @test_open_reference;
+    funcs{end+1} = @test_has_metadata;
+    funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_retrieve_data;
+    funcs{end+1} = @test_retrieve_feature_data;
 end
 
 %% Test: List/fetch references


### PR DESCRIPTION
- create block and section entities from File object
- delete block and section entities from File object
- tests for create and delete block/section entities from File object
- add block info to tests
- matlab startup now adds all directories within project root to the matlab path
- rename main testfile 'Run' to 'RunTests'
- add generic index for unit tests