### PR TITLE
migrate to glue: File, Block, Source, Tag entities

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -29,9 +29,12 @@ classdef Block < nix.NamedEntity
             das = nix_mx('Block::listDataArrays', obj.nix_handle);
         end;
         
-        function da = data_array(obj, id_or_name)
-           dh = nix_mx('Block::openDataArray', obj.nix_handle, id_or_name); 
-           da = nix.DataArray(dh);
+        function retObj = data_array(obj, id_or_name)
+            handle = nix_mx('Block::openDataArray', obj.nix_handle, id_or_name); 
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.DataArray(handle);
+            end;
         end;
         
         % -----------------
@@ -42,9 +45,12 @@ classdef Block < nix.NamedEntity
             sourcesList = nix_mx('Block::listSources', obj.nix_handle);
         end;
 
-        function source = open_source(obj, id_or_name)
-           sh = nix_mx('Block::openSource', obj.nix_handle, id_or_name); 
-           source = nix.Source(sh);
+        function retObj = open_source(obj, id_or_name)
+            handle = nix_mx('Block::openSource', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Source(handle);
+            end;
         end;
 
         % -----------------
@@ -60,9 +66,12 @@ classdef Block < nix.NamedEntity
             tagList = nix_mx('Block::listTags', obj.nix_handle);
         end;
         
-        function tag = open_tag(obj, id_or_name)
-           tagHandle = nix_mx('Block::openTag', obj.nix_handle, id_or_name); 
-           tag = nix.Tag(tagHandle);
+        function retObj = open_tag(obj, id_or_name)
+            handle = nix_mx('Block::openTag', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Tag(handle);
+            end;
         end;
         
         function tag = create_tag(obj, name, type, position)
@@ -85,9 +94,12 @@ classdef Block < nix.NamedEntity
             tagList = nix_mx('Block::listMultiTags', obj.nix_handle);
         end;
         
-        function tag = open_multi_tag(obj, id_or_name)
-           tagHandle = nix_mx('Block::openMultiTag', obj.nix_handle, id_or_name); 
-           tag = nix.MultiTag(tagHandle);
+        function retObj = open_multi_tag(obj, id_or_name)
+            handle = nix_mx('Block::openMultiTag', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.MultiTag(handle);
+            end;
         end;
         
         % -----------------

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -80,8 +80,7 @@ classdef File < nix.Entity
         end;
 
         function delCheck = deleteSection(obj, deleteSectionObj)
-            retStruct = nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle);
-            delCheck = logical(retStruct.deleted);
+            delCheck = nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle);
             obj.sectionsCache.lastUpdate = 0;
         end;
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -38,7 +38,10 @@ classdef File < nix.Entity
         
         function b = openBlock(obj, id_or_name)
             bh = nix_mx('File::openBlock', obj.nix_handle, id_or_name);
-            b = nix.Block(bh);
+            b = {};
+            if bh~=0
+                b = nix.Block(bh);
+            end;
         end
         
         function blocks = get.blocks(obj)
@@ -51,8 +54,13 @@ classdef File < nix.Entity
             obj.blocksCache.lastUpdate = 0;
         end;
 
-        function delCheck = deleteBlock(obj, deleteBlockObj)
-            delCheck = nix_mx('File::deleteBlock', obj.nix_handle, deleteBlockObj.nix_handle);
+        function delCheck = deleteBlock(obj, del)
+            if(strcmp(class(del),'nix.Block'))
+                delID = del.id;
+            else
+                delID = del;
+            end;
+            delCheck = nix_mx('File::deleteBlock', obj.nix_handle, delID);
             obj.blocksCache.lastUpdate = 0;
         end;
 
@@ -65,8 +73,11 @@ classdef File < nix.Entity
         end
         
         function section = openSection(obj, id_or_name)
-           h = nix_mx('File::openSection', obj.nix_handle, id_or_name); 
-           section = nix.Section(h);
+            h = nix_mx('File::openSection', obj.nix_handle, id_or_name); 
+            section = {};
+            if h~=0
+                section = nix.Section(h);
+            end;
         end
         
         function sections = get.sections(obj)
@@ -79,8 +90,13 @@ classdef File < nix.Entity
             obj.sectionsCache.lastUpdate = 0;
         end;
 
-        function delCheck = deleteSection(obj, deleteSectionObj)
-            delCheck = nix_mx('File::deleteSection', obj.nix_handle, deleteSectionObj.nix_handle);
+        function delCheck = deleteSection(obj, del)
+            if(strcmp(class(del),'nix.Section'))
+                delID = del.id;
+            else
+                delID = del;
+            end;
+            delCheck = nix_mx('File::deleteSection', obj.nix_handle, delID);
             obj.sectionsCache.lastUpdate = 0;
         end;
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -36,11 +36,11 @@ classdef File < nix.Entity
             block_list = nix_mx('File::listBlocks', obj.nix_handle);
         end
         
-        function b = openBlock(obj, id_or_name)
-            bh = nix_mx('File::openBlock', obj.nix_handle, id_or_name);
-            b = {};
-            if bh~=0
-                b = nix.Block(bh);
+        function retObj = openBlock(obj, id_or_name)
+            handle = nix_mx('File::openBlock', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Block(handle);
             end;
         end
         
@@ -72,11 +72,11 @@ classdef File < nix.Entity
             section_list = nix_mx('File::listSections', obj.nix_handle);
         end
         
-        function section = openSection(obj, id_or_name)
-            h = nix_mx('File::openSection', obj.nix_handle, id_or_name); 
-            section = {};
-            if h~=0
-                section = nix.Section(h);
+        function retObj = openSection(obj, id_or_name)
+            handle = nix_mx('File::openSection', obj.nix_handle, id_or_name); 
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Section(handle);
             end;
         end
         

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -56,9 +56,12 @@ classdef Source < nix.Entity
             sourcesList = nix_mx('Source::listSources', obj.nix_handle);
         end;
 
-        function source = open_source(obj, id_or_name)
-           sourceHandle = nix_mx('Source::openSource', obj.nix_handle, id_or_name); 
-           source = nix.Source(sourceHandle);
+        function retObj = open_source(obj, id_or_name)
+            handle = nix_mx('Source::openSource', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Source(handle);
+            end;
         end;
 
         function sources = get.sources(obj)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -89,9 +89,12 @@ classdef Tag < nix.Entity
             refList = nix_mx('Tag::listReferences', obj.nix_handle);
         end;
 
-        function dataArray = open_reference(obj, id_or_name)
-            daHandle = nix_mx('Tag::openReferenceDataArray', obj.nix_handle, id_or_name);
-            dataArray = nix.DataArray(daHandle);
+        function retObj = open_reference(obj, id_or_name)
+            handle = nix_mx('Tag::openReferenceDataArray', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.DataArray(handle);
+            end;
         end;
 
         function da = get.references(obj)
@@ -117,9 +120,12 @@ classdef Tag < nix.Entity
             featureList = nix_mx('Tag::listFeatures', obj.nix_handle);
         end;
 
-        function feature = open_feature(obj, id_or_name)
-            featureHandle = nix_mx('Tag::openFeature', obj.nix_handle, id_or_name);
-            feature = nix.Feature(featureHandle);
+        function retObj = open_feature(obj, id_or_name)
+            handle = nix_mx('Tag::openFeature', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Feature(handle);
+            end;
         end;
 
         function feat = get.features(obj)
@@ -145,9 +151,12 @@ classdef Tag < nix.Entity
             sourceList = nix_mx('Tag::listSources', obj.nix_handle);
         end;
 
-        function source = open_source(obj, id_or_name)
-            sourceHandle = nix_mx('Tag::openSource', obj.nix_handle, id_or_name);
-            source = nix.Source(sourceHandle);
+        function retObj = open_source(obj, id_or_name)
+            handle = nix_mx('Tag::openSource', obj.nix_handle, id_or_name);
+            retObj = {};
+            if handle ~= 0
+                retObj = nix.Source(handle);
+            end;
         end;
 
         function sources = get.sources(obj)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -42,111 +42,104 @@ static void entity_updated_at(const extractor &input, infusor &output)
 
 // *** ***
 
-typedef void (*fn_t)(const extractor &input, infusor &output);
+typedef void(*fn_t)(const extractor &input, infusor &output);
 
 struct fendpoint {
 
-fendpoint(std::string name, fn_t fn) : name(name), fn(fn) {}
+    fendpoint(std::string name, fn_t fn) : name(name), fn(fn) {}
 
     std::string name;
     fn_t fn;
 };
 
 const std::vector<fendpoint> funcs = {
-        { "Entity::destroy", entity_destroy },
-        { "Entity::updatedAt", entity_updated_at },
+    { "Entity::destroy", entity_destroy },
+    { "Entity::updatedAt", entity_updated_at },
 
-        // File
-        { "File::open", nixfile::open },
-        { "File::describe", nixfile::describe },
-        { "File::listBlocks", nixfile::list_blocks },
-        { "File::listSections", nixfile::list_sections },
-        { "File::createBlock", nixfile::create_block },
-        { "File::createSection", nixfile::create_section },
+    // File
+    { "File::open", nixfile::open },
+    { "File::describe", nixfile::describe },
+    { "File::listBlocks", nixfile::list_blocks },
+    { "File::listSections", nixfile::list_sections },
+    { "File::createBlock", nixfile::create_block },
+    { "File::createSection", nixfile::create_section },
 
-        // Block
-        { "Block::describe", nixblock::describe },
-        { "Block::listDataArrays", nixblock::list_data_arrays },
-        { "Block::openDataArray", nixblock::open_data_array },
-        { "Block::listSources", nixblock::list_sources },
-        { "Block::openSource", nixblock::open_source },
-        { "Block::sources", nixblock::sources },
-        { "Block::hasTag", nixblock::has_tag },
-        { "Block::listTags", nixblock::list_tags },
-        { "Block::openTag", nixblock::open_tag },
-        { "Block::tags", nixblock::tags },
-        { "Block::hasMultiTag", nixblock::has_multi_tag },
-        { "Block::listMultiTags", nixblock::list_multi_tags },
-        { "Block::openMultiTag", nixblock::open_multi_tag },
-        { "Block::multiTags", nixblock::multitags },
-        { "Block::hasMetadataSection", nixblock::has_metadata_section },
-        { "Block::openMetadataSection", nixblock::open_metadata_section },
+    // Block
+    { "Block::describe", nixblock::describe },
+    { "Block::listDataArrays", nixblock::list_data_arrays },
+    { "Block::listSources", nixblock::list_sources },
+    { "Block::hasTag", nixblock::has_tag },
+    { "Block::listTags", nixblock::list_tags },
+    { "Block::hasMultiTag", nixblock::has_multi_tag },
+    { "Block::listMultiTags", nixblock::list_multi_tags },
+    { "Block::hasMetadataSection", nixblock::has_metadata_section },
+    { "Block::openMetadataSection", nixblock::open_metadata_section },
 
-        // Data Array
-        { "DataArray::describe", nixdataarray::describe },
-        { "DataArray::readAll", nixdataarray::read_all },
-        { "DataArray::hasMetadataSection", nixdataarray::has_metadata_section },
-        { "DataArray::openMetadataSection", nixdataarray::open_metadata_section },
-        { "DataArray::sources", nixdataarray::sources },
+    // Data Array
+    { "DataArray::describe", nixdataarray::describe },
+    { "DataArray::readAll", nixdataarray::read_all },
+    { "DataArray::hasMetadataSection", nixdataarray::has_metadata_section },
+    { "DataArray::openMetadataSection", nixdataarray::open_metadata_section },
+    { "DataArray::sources", nixdataarray::sources },
 
-        // Tag
-        { "Tag::describe", nixtag::describe },
-        { "Tag::listReferences", nixtag::list_references_array },
-        { "Tag::listFeatures", nixtag::list_features },
-        { "Tag::listSources", nixtag::list_sources },
-        { "Tag::references", nixtag::references },
-        { "Tag::features", nixtag::features },
-        { "Tag::sources", nixtag::sources },
-        { "Tag::openReferenceDataArray", nixtag::open_data_array },
-        { "Tag::openFeature", nixtag::open_feature },
-        { "Tag::openSource", nixtag::open_source },
-        { "Tag::hasMetadataSection", nixtag::has_metadata_section },
-        { "Tag::openMetadataSection", nixtag::open_metadata_section },
-        { "Tag::retrieveData", nixtag::retrieve_data },
-        { "Tag::featureRetrieveData", nixtag::retrieve_feature_data },
+    // Tag
+    { "Tag::describe", nixtag::describe },
+    { "Tag::listReferences", nixtag::list_references_array },
+    { "Tag::listFeatures", nixtag::list_features },
+    { "Tag::listSources", nixtag::list_sources },
+    { "Tag::references", nixtag::references },
+    { "Tag::features", nixtag::features },
+    { "Tag::sources", nixtag::sources },
+    { "Tag::openReferenceDataArray", nixtag::open_data_array },
+    { "Tag::openFeature", nixtag::open_feature },
+    { "Tag::openSource", nixtag::open_source },
+    { "Tag::hasMetadataSection", nixtag::has_metadata_section },
+    { "Tag::openMetadataSection", nixtag::open_metadata_section },
+    { "Tag::retrieveData", nixtag::retrieve_data },
+    { "Tag::featureRetrieveData", nixtag::retrieve_feature_data },
 
-        // Multi Tag
-        { "MultiTag::describe", nixmultitag::describe },
-        { "MultiTag::listReferences", nixmultitag::list_references_array },
-        { "MultiTag::listFeatures", nixmultitag::list_features },
-        { "MultiTag::listSources", nixmultitag::list_sources },
-        { "MultiTag::references", nixmultitag::references },
-        { "MultiTag::features", nixmultitag::features },
-        { "MultiTag::sources", nixmultitag::sources },
-        { "MultiTag::hasPositions", nixmultitag::has_positions },
-        { "MultiTag::openPositions", nixmultitag::open_positions },
-        { "MultiTag::openExtents", nixmultitag::open_extents },
-        { "MultiTag::openReferences", nixmultitag::open_references },
-        { "MultiTag::openFeature", nixmultitag::open_features },
-        { "MultiTag::openSource", nixmultitag::open_source },
-        { "MultiTag::hasMetadataSection", nixmultitag::has_metadata_section },
-        { "MultiTag::openMetadataSection", nixmultitag::open_metadata_section },
-        { "MultiTag::retrieveData", nixmultitag::retrieve_data },
-        { "MultiTag::featureRetrieveData", nixmultitag::retrieve_feature_data },
+    // Multi Tag
+    { "MultiTag::describe", nixmultitag::describe },
+    { "MultiTag::listReferences", nixmultitag::list_references_array },
+    { "MultiTag::listFeatures", nixmultitag::list_features },
+    { "MultiTag::listSources", nixmultitag::list_sources },
+    { "MultiTag::references", nixmultitag::references },
+    { "MultiTag::features", nixmultitag::features },
+    { "MultiTag::sources", nixmultitag::sources },
+    { "MultiTag::hasPositions", nixmultitag::has_positions },
+    { "MultiTag::openPositions", nixmultitag::open_positions },
+    { "MultiTag::openExtents", nixmultitag::open_extents },
+    { "MultiTag::openReferences", nixmultitag::open_references },
+    { "MultiTag::openFeature", nixmultitag::open_features },
+    { "MultiTag::openSource", nixmultitag::open_source },
+    { "MultiTag::hasMetadataSection", nixmultitag::has_metadata_section },
+    { "MultiTag::openMetadataSection", nixmultitag::open_metadata_section },
+    { "MultiTag::retrieveData", nixmultitag::retrieve_data },
+    { "MultiTag::featureRetrieveData", nixmultitag::retrieve_feature_data },
 
-        // Source
-        { "Source::describe", nixsource::describe },
-        { "Source::listSources", nixsource::list_sources },
-        { "Source::openSource", nixsource::open_source },
-        { "Source::sources", nixsource::sources },
-        { "Source::hasMetadataSection", nixsource::has_metadata_section },
-        { "Source::openMetadataSection", nixsource::open_metadata_section },
+    // Source
+    { "Source::describe", nixsource::describe },
+    { "Source::listSources", nixsource::list_sources },
+    { "Source::openSource", nixsource::open_source },
+    { "Source::sources", nixsource::sources },
+    { "Source::hasMetadataSection", nixsource::has_metadata_section },
+    { "Source::openMetadataSection", nixsource::open_metadata_section },
 
-        // Feature
-        { "Feature::describe", nixfeature::describe },
-        { "Feature::linkType", nixfeature::link_type },
-        { "Feature::openData", nixfeature::open_data },
+    // Feature
+    { "Feature::describe", nixfeature::describe },
+    { "Feature::linkType", nixfeature::link_type },
+    { "Feature::openData", nixfeature::open_data },
 
-        // Section
-        { "Section::describe", nixsection::describe },
-        { "Section::link", nixsection::link },
-        { "Section::parent", nixsection::parent },
-        { "Section::hasSection", nixsection::has_section },
-        { "Section::openSection", nixsection::open_section },
-        { "Section::listSections", nixsection::list_sections },
-        { "Section::sections", nixsection::sections },
-        { "Section::hasProperty", nixsection::has_property },
-        { "Section::listProperties", nixsection::list_properties }
+    // Section
+    { "Section::describe", nixsection::describe },
+    { "Section::link", nixsection::link },
+    { "Section::parent", nixsection::parent },
+    { "Section::hasSection", nixsection::has_section },
+    { "Section::openSection", nixsection::open_section },
+    { "Section::listSections", nixsection::list_sections },
+    { "Section::sections", nixsection::sections },
+    { "Section::hasProperty", nixsection::has_property },
+    { "Section::listProperties", nixsection::list_properties }
 };
 
 //glue "globals"
@@ -155,7 +148,7 @@ static glue::registry *methods = nullptr;
 
 static void on_exit() {
 #ifdef DEBUG_GLUE
-    mexPrintf("[GLUE] deleting hanlders!\n");
+    mexPrintf("[GLUE] deleting handlers!\n");
 #endif
 
     delete methods;
@@ -167,9 +160,9 @@ static void on_exit() {
 
 // main entry point
 void mexFunction(int            nlhs,
-                 mxArray       *lhs[],
-                 int            nrhs,
-                 const mxArray *rhs[])
+    mxArray       *lhs[],
+    int            nrhs,
+    const mxArray *rhs[])
 {
     extractor input(rhs, nrhs);
     infusor   output(lhs, nlhs);
@@ -181,9 +174,9 @@ void mexFunction(int            nlhs,
     std::call_once(init_flag, []() {
         using namespace glue;
 
-        #ifdef DEBUG_GLUE
+#ifdef DEBUG_GLUE
         mexPrintf("[GLUE] Registering classdefs...\n");
-        #endif
+#endif
 
         methods = new registry{};
 
@@ -197,7 +190,14 @@ void mexFunction(int            nlhs,
 
         classdef<nix::Block>("Block", methods)
             .reg("dataArrays", &nix::Block::dataArrays)
-            .reg("createTag", &nix::Block::createTag);
+            .reg("createTag", &nix::Block::createTag)
+            .reg("sources", &nix::Block::sources)
+            .reg("tags", &nix::Block::tags)
+            .reg("multiTags", &nix::Block::multiTags)
+            .reg("openDataArray", GETBYSTR(nix::DataArray, nix::Block, getDataArray))
+            .reg("openSource", GETBYSTR(nix::Source, nix::Block, getSource))
+            .reg("openTag", GETBYSTR(nix::Tag, nix::Block, getTag))
+            .reg("openMultiTag", GETBYSTR(nix::MultiTag, nix::Block, getMultiTag));
 
         mexAtExit(on_exit);
     });
@@ -207,11 +207,11 @@ void mexFunction(int            nlhs,
     try {
         processed = methods->dispatch(cmd, input, output);
 
-        #ifdef DEBUG_GLUE
+#ifdef DEBUG_GLUE
         if (processed) {
             mexPrintf("[GLUE] %s: processed by glue.\n", cmd.c_str());
         }
-        #endif
+#endif
 
         for (const auto &fn : funcs) {
 
@@ -225,11 +225,14 @@ void mexFunction(int            nlhs,
             }
         }
 
-    } catch (const std::invalid_argument &e) {
+    }
+    catch (const std::invalid_argument &e) {
         mexErrMsgIdAndTxt("nix:arg:inval", e.what());
-    } catch (const std::exception &e) {
+    }
+    catch (const std::exception &e) {
         mexErrMsgIdAndTxt("nix:arg:dispatch", e.what());
-    } catch (...) {
+    }
+    catch (...) {
         mexErrMsgIdAndTxt("nix:arg:dispatch", "unkown exception");
     }
 

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -87,12 +87,6 @@ const std::vector<fendpoint> funcs = {
     { "Tag::listReferences", nixtag::list_references_array },
     { "Tag::listFeatures", nixtag::list_features },
     { "Tag::listSources", nixtag::list_sources },
-    { "Tag::references", nixtag::references },
-    { "Tag::features", nixtag::features },
-    { "Tag::sources", nixtag::sources },
-    { "Tag::openReferenceDataArray", nixtag::open_data_array },
-    { "Tag::openFeature", nixtag::open_feature },
-    { "Tag::openSource", nixtag::open_source },
     { "Tag::hasMetadataSection", nixtag::has_metadata_section },
     { "Tag::openMetadataSection", nixtag::open_metadata_section },
     { "Tag::retrieveData", nixtag::retrieve_data },
@@ -154,6 +148,7 @@ static void on_exit() {
 
 #define GETTER(type, class, name) static_cast<type(class::*)()const>(&class::name)
 #define GETBYSTR(type, class, name) static_cast<type(class::*)(const std::string &)const>(&class::name)
+#define GETCONTENT(type, class, name) static_cast<type(class::*)()const>(&class::name)
 #define REMOVER(type, class, name) static_cast<bool(class::*)(const std::string&)>(&class::name)
 
 // main entry point
@@ -200,6 +195,14 @@ void mexFunction(int            nlhs,
         classdef<nix::Source>("Source", methods)
             .reg("sources", &nix::Source::sources)
             .reg("openSource", GETBYSTR(nix::Source, nix::Source, getSource));
+
+        classdef<nix::Tag>("Tag", methods)
+            .reg("references", GETTER(std::vector<nix::DataArray>, nix::Tag, references))
+            .reg("features", &nix::Tag::features)
+            .reg("sources", static_cast<std::vector<nix::Source>(nix::base::EntityWithSources<nix::base::ITag>::*)(std::function<bool(const nix::Source &)>)const>(&nix::base::EntityWithSources<nix::base::ITag>::sources))
+            .reg("openReferenceDataArray", GETBYSTR(nix::DataArray, nix::Tag, getReference))
+            .reg("openFeature", GETBYSTR(nix::Feature, nix::Tag, getFeature))
+            .reg("openSource", GETBYSTR(nix::Source, nix::Tag, getSource));
 
         mexAtExit(on_exit);
     });

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -60,12 +60,9 @@ const std::vector<fendpoint> funcs = {
         { "File::open", nixfile::open },
         { "File::describe", nixfile::describe },
         { "File::listBlocks", nixfile::list_blocks },
-        { "File::openBlock", nixfile::open_block },
         { "File::listSections", nixfile::list_sections },
-        { "File::openSection", nixfile::open_section },
         { "File::createBlock", nixfile::create_block },
         { "File::createSection", nixfile::create_section },
-        { "File::deleteSection", nixfile::delete_section },
 
         // Block
         { "Block::describe", nixblock::describe },
@@ -193,8 +190,10 @@ void mexFunction(int            nlhs,
         classdef<nix::File>("File", methods)
             .reg("blocks", GETTER(std::vector<nix::Block>, nix::File, blocks))
             .reg("sections", GETTER(std::vector<nix::Section>, nix::File, sections))
-			.reg("deleteBlock", REMOVER(nix::Block, nix::File, deleteBlock))
-            .reg("openBlock", GETBYSTR(nix::Block, nix::File, getBlock));
+            .reg("deleteBlock", REMOVER(nix::Block, nix::File, deleteBlock))
+            .reg("deleteSection", REMOVER(nix::Section, nix::File, deleteSection))
+            .reg("openBlock", GETBYSTR(nix::Block, nix::File, getBlock))
+            .reg("openSection", GETBYSTR(nix::Section, nix::File, getSection));
 
         classdef<nix::Block>("Block", methods)
             .reg("dataArrays", &nix::Block::dataArrays)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -120,8 +120,6 @@ const std::vector<fendpoint> funcs = {
     // Source
     { "Source::describe", nixsource::describe },
     { "Source::listSources", nixsource::list_sources },
-    { "Source::openSource", nixsource::open_source },
-    { "Source::sources", nixsource::sources },
     { "Source::hasMetadataSection", nixsource::has_metadata_section },
     { "Source::openMetadataSection", nixsource::open_metadata_section },
 
@@ -198,6 +196,10 @@ void mexFunction(int            nlhs,
             .reg("openSource", GETBYSTR(nix::Source, nix::Block, getSource))
             .reg("openTag", GETBYSTR(nix::Tag, nix::Block, getTag))
             .reg("openMultiTag", GETBYSTR(nix::MultiTag, nix::Block, getMultiTag));
+
+        classdef<nix::Source>("Source", methods)
+            .reg("sources", &nix::Source::sources)
+            .reg("openSource", GETBYSTR(nix::Source, nix::Source, getSource));
 
         mexAtExit(on_exit);
     });

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -163,7 +163,7 @@ static void on_exit() {
 
 #define GETTER(type, class, name) static_cast<type(class::*)()const>(&class::name)
 #define GETBYSTR(type, class, name) static_cast<type(class::*)(const std::string &)const>(&class::name)
-#define REMOVER(type, class, name) static_cast<bool(class::*)(const type&)>(&class::name)
+#define REMOVER(type, class, name) static_cast<bool(class::*)(const std::string&)>(&class::name)
 
 // main entry point
 void mexFunction(int            nlhs,

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -25,12 +25,6 @@ namespace nixblock {
         output.set(0, sb.array());
     }
 
-    void open_data_array(const extractor &input, infusor &output)
-    {
-        nix::Block block = input.entity<nix::Block>(1);
-        output.set(0, nixgen::open_data_array(block.getDataArray(input.str(2))));
-    }
-
     void list_data_arrays(const extractor &input, infusor &output)
     {
         nix::Block block = input.entity<nix::Block>(1);
@@ -43,31 +37,10 @@ namespace nixblock {
         output.set(0, nixgen::list_sources(currSource.sources()));
     }
 
-    void open_source(const extractor &input, infusor &output)
-    {
-        nix::Block currSource = input.entity<nix::Block>(1);
-        output.set(0, nixgen::open_source(currSource.getSource(input.str(2))));
-    }
-
-    void sources(const extractor &input, infusor &output)
-    {
-        nix::Block block = input.entity<nix::Block>(1);
-        std::vector<nix::Source> sources = block.sources();
-        output.set(0, sources);
-    }
-
     void has_tag(const extractor &input, infusor &output)
     {
         nix::Block block = input.entity<nix::Block>(1);
         output.set(0, nixgen::has_entity(block.hasTag(input.str(2)), { "hasTag" }));
-    }
-
-    void open_tag(const extractor &input, infusor &output)
-    {
-        nix::Block block = input.entity<nix::Block>(1);
-        nix::Tag currTag = block.getTag(input.str(2));
-        handle currBlockTagHandle = handle(currTag);
-        output.set(0, currBlockTagHandle);
     }
 
     void list_tags(const extractor &input, infusor &output)
@@ -91,25 +64,10 @@ namespace nixblock {
         output.set(0, sb.array());
     }
 
-    void tags(const extractor &input, infusor &output)
-    {
-        nix::Block block = input.entity<nix::Block>(1);
-        std::vector<nix::Tag> tags = block.tags();
-        output.set(0, tags);
-    }
-
     void has_multi_tag(const extractor &input, infusor &output)
     {
         nix::Block block = input.entity<nix::Block>(1);
         output.set(0, nixgen::has_entity(block.hasMultiTag(input.str(2)), { "hasMultiTag" }));
-    }
-
-    void open_multi_tag(const extractor &input, infusor &output)
-    {
-        nix::Block block = input.entity<nix::Block>(1);
-        nix::MultiTag currMultiTag = block.getMultiTag(input.str(2));
-        handle currBlockMultiTagHandle = handle(currMultiTag);
-        output.set(0, currBlockMultiTagHandle);
     }
 
     void list_multi_tags(const extractor &input, infusor &output)
@@ -129,13 +87,6 @@ namespace nixblock {
             sb.next();
         }
         output.set(0, sb.array());
-    }
-
-    void multitags(const extractor &input, infusor &output)
-    {
-        nix::Block block = input.entity<nix::Block>(1);
-        std::vector<nix::MultiTag> arr = block.multiTags();
-        output.set(0, arr);
     }
 
     void has_metadata_section(const extractor &input, infusor &output)

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -7,31 +7,17 @@ namespace nixblock {
 
     void describe(const extractor &input, infusor &output);
 
-    void open_data_array(const extractor &input, infusor &output);
-
     void list_data_arrays(const extractor &input, infusor &output);
 
     void list_sources(const extractor &input, infusor &output);
 
-    void open_source(const extractor &input, infusor &output);
-
-    void sources(const extractor &input, infusor &output);
-
     void has_tag(const extractor &input, infusor &output);
-    
-    void open_tag(const extractor &input, infusor &output);
 
     void list_tags(const extractor &input, infusor &output);
 
-    void tags(const extractor &input, infusor &output);
-
     void has_multi_tag(const extractor &input, infusor &output);
 
-    void open_multi_tag(const extractor &input, infusor &output);
-
     void list_multi_tags(const extractor &input, infusor &output);
-
-    void multitags(const extractor &input, infusor &output);
 
     void has_metadata_section(const extractor &input, infusor &output);
 

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -63,14 +63,6 @@ void list_blocks(const extractor &input, infusor &output)
     output.set(0, sb.array());
 }
 
-void open_block(const extractor &input, infusor &output)
-{
-    nix::File nf = input.entity<nix::File>(1);
-    nix::Block block = nf.getBlock(input.str(2));
-    handle bb = handle(block);
-    output.set(0, bb);
-}
-
 void list_sections(const extractor &input, infusor &output)
 {
     nix::File fd = input.entity<nix::File>(1);
@@ -90,14 +82,6 @@ void list_sections(const extractor &input, infusor &output)
     output.set(0, sb.array());
 }
 
-void open_section(const extractor &input, infusor &output)
-{
-    nix::File nf = input.entity<nix::File>(1);
-    nix::Section sec = nf.getSection(input.str(2));
-    handle bb = handle(sec);
-    output.set(0, bb);
-}
-
 void create_block(const extractor &input, infusor &output)
 {
     nix::File currObj = input.entity<nix::File>(1);
@@ -114,17 +98,6 @@ void create_section(const extractor &input, infusor &output)
 
     handle nsh = handle(newSection);
     output.set(0, nsh);
-}
-
-
-void delete_section(const extractor &input, infusor &output)
-{
-    nix::File currObj = input.entity<nix::File>(1);
-    nix::Section delObj = input.entity<nix::Section>(2);
-    bool checkDeleted = currObj.deleteSection(delObj);
-
-    // TODO rename has_entity or implement other means of returning boolean value to Matlab
-    output.set(0, nixgen::has_entity(checkDeleted, { "deleted" }));
 }
 
 } // namespace nixfile

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -11,17 +11,11 @@ void describe(const extractor &input, infusor &output);
 
 void list_blocks(const extractor &input, infusor &output);
 
-void open_block(const extractor &input, infusor &output);
-
 void list_sections(const extractor &input, infusor &output);
-
-void open_section(const extractor &input, infusor &output);
 
 void create_block(const extractor &input, infusor &output);
 
 void create_section(const extractor &input, infusor &output);
-
-void delete_section(const extractor &input, infusor &output);
 
 } // namespace nixfile
 

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -28,12 +28,6 @@ namespace nixsource {
         output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
-    void open_source(const extractor &input, infusor &output)
-    {
-        nix::Source currObj = input.entity<nix::Source>(1);
-        output.set(0, nixgen::open_source(currObj.getSource(input.str(2))));
-    }
-
     void has_metadata_section(const extractor &input, infusor &output)
     {
         nix::Source currObj = input.entity<nix::Source>(1);
@@ -44,14 +38,6 @@ namespace nixsource {
     {
         nix::Source currObj = input.entity<nix::Source>(1);
         output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
-    void sources(const extractor &input, infusor &output)
-    {
-        nix::Source currObj = input.entity<nix::Source>(1);
-        std::vector<nix::Source> arr = currObj.sources();
-
-        output.set(0, arr);
     }
 
 } // namespace nixsource

--- a/src/nixsource.h
+++ b/src/nixsource.h
@@ -9,13 +9,9 @@ namespace nixsource {
 
     void list_sources(const extractor &input, infusor &output);
 
-    void open_source(const extractor &input, infusor &output);
-
     void has_metadata_section(const extractor &input, infusor &output);
 
     void open_metadata_section(const extractor &input, infusor &output);
-
-    void sources(const extractor &input, infusor &output);
 
 } // namespace nixsource
 

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -28,12 +28,6 @@ namespace nixtag {
         output.set(0, sb.array());
     }
 
-    void open_data_array(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_data_array(currObj.getReference(input.str(2))));
-    }
-
     void list_references_array(const extractor &input, infusor &output)
     {
         nix::Tag currObj = input.entity<nix::Tag>(1);
@@ -52,18 +46,6 @@ namespace nixtag {
         output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
-    void open_feature(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_feature(currObj.getFeature(input.str(2))));
-    }
-
-    void open_source(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::open_source(currObj.getSource(input.str(2))));
-    }
-
     void has_metadata_section(const extractor &input, infusor &output)
     {
         nix::Tag currObj = input.entity<nix::Tag>(1);
@@ -74,30 +56,6 @@ namespace nixtag {
     {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
-    void references(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        std::vector<nix::DataArray> arr = currObj.references();
-
-        output.set(0, arr);
-    }
-
-    void features(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        std::vector<nix::Feature> arr = currObj.features();
-
-        output.set(0, arr);
-    }
-
-    void sources(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        std::vector<nix::Source> arr = currObj.sources();
-
-        output.set(0, arr);
     }
 
     void retrieve_data(const extractor &input, infusor &output) {

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -7,27 +7,15 @@ namespace nixtag {
 
     void describe(const extractor &input, infusor &output);
 
-    void open_data_array(const extractor &input, infusor &output);
-
     void list_references_array(const extractor &input, infusor &output);
 
     void list_features(const extractor &input, infusor &output);
 
     void list_sources(const extractor &input, infusor &output);
 
-    void open_feature(const extractor &input, infusor &output);
-
-    void open_source(const extractor &input, infusor &output);
-
     void has_metadata_section(const extractor &input, infusor &output);
 
     void open_metadata_section(const extractor &input, infusor &output);
-
-    void references(const extractor &input, infusor &output);
-
-    void features(const extractor &input, infusor &output);
-
-    void sources(const extractor &input, infusor &output);
 
     void retrieve_data(const extractor &input, infusor &output);
 

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -65,6 +65,10 @@ function [] = test_open_array( varargin )
 
     getDataArrayByName = getBlock.data_array(getBlock.dataArrays{1,1}.name);
     assert(strcmp(getDataArrayByName.id, 'e0ca39b7-632f-47c9-968c-c65e6db58719'));
+    
+    %-- test open non existing dataarray
+    getDataArray = getBlock.data_array('I dont exist');
+    assert(isempty(getDataArray));
 end
 
 function [] = test_open_tag( varargin )
@@ -77,6 +81,10 @@ function [] = test_open_tag( varargin )
 
     getTagByName = getBlock.open_tag(getBlock.tags{1,1}.name);
     assert(strcmp(getTagByName.id, 'f49f4a56-0c93-4323-8e37-4b02b8cabb55'));
+    
+    %-- test open non existing tag
+    getTag = getBlock.open_tag('I dont exist');
+    assert(isempty(getTag));
 end
 
 function [] = test_open_multitag( varargin )
@@ -89,6 +97,10 @@ function [] = test_open_multitag( varargin )
 
     getMultiTagByName = getBlock.open_multi_tag(getBlock.multiTags{1,1}.name);
     assert(strcmp(getMultiTagByName.id, '9e3fdaa5-a71c-4be0-91b3-9c35ed2d4723'));
+    
+    %-- test open non existing multitag
+    getMultiTag = getBlock.open_multi_tag('I dont exist');
+    assert(isempty(getMultiTag));
 end
 
 function [] = test_open_source( varargin )
@@ -101,6 +113,10 @@ function [] = test_open_source( varargin )
 
     getSourceByName = getBlock.open_source(getBlock.sources{1,1}.name);
     assert(strcmp(getSourceByName.id, 'edf4c8b6-8569-4952-bcee-4203dd26571e'));
+    
+    %-- test open non existing source
+    getSource = getBlock.open_source('I dont exist');
+    assert(isempty(getSource));
 end
 
 function [] = test_has_multitag( varargin )

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -51,17 +51,41 @@ end
 %% Test: Delete Block
 function [] = test_delete_block( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+
+    %-- test delete block by object
     checkDelete = test_file.deleteBlock(test_file.blocks{1});
     assert(checkDelete);
     assert(size(test_file.blocks, 1) == 0);
+    
+    %-- test delete block by id
+    newBlock = test_file.createBlock('name', 'type');
+    checkDelete = test_file.deleteBlock(newBlock.id);
+    assert(checkDelete);
+    assert(size(test_file.blocks, 1) == 0);
+
+    %-- test delete non existing block
+    checkDelete = test_file.deleteBlock('I do not exist');
+    assert(~checkDelete);
 end
 
 %% Test: Delete Section
 function [] = test_delete_section( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+    
+    %-- test delete section by object
     checkDelete = test_file.deleteSection(test_file.sections{1});
     assert(checkDelete);
     assert(size(test_file.sections, 1) == 0);
+    
+    %-- test delete section by id
+    newSection = test_file.createSection('name', 'type');
+    checkDelete = test_file.deleteSection(newSection.id);
+    assert(checkDelete);
+    assert(size(test_file.sections, 1) == 0);
+
+    %-- test delete non existing section
+    checkDelete = test_file.deleteSection('I do not exist');
+    assert(~checkDelete);
 end
 
 function [] = test_list_sections( varargin )
@@ -77,8 +101,11 @@ function [] = test_open_section( varargin )
 %% Test open section
     test_file = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
     getSection = test_file.openSection(test_file.sections{1,1}.id);
-
     assert(strcmp(getSection.name, 'General'));
+    
+    %-- test open non existing section
+    getSection = test_file.openSection('I dont exist');
+    assert(isempty(getSection));
 end
 
 function [] = test_list_blocks( varargin )
@@ -99,4 +126,8 @@ function [] = test_open_block( varargin )
 
     getBlockByName = test_file.openBlock(test_file.blocks{1,1}.name);
     assert(strcmp(getBlockByName.name, 'joe097'));
+
+    %-- test open non existing block
+    getBlock = test_file.openBlock('I dont exist');
+    assert(isempty(getBlock));
 end

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -37,6 +37,10 @@ function [] = test_open_source( varargin )
     %getSourceByName = getSFromB.open_source(getSFromB.sources{1,1}.name);
     %assert(strcmp(getSourceByName.id, ''));
     disp('Test Source: open source by name ... TODO (proper testfile)');
+    
+    %-- test open non existing source
+    getSource = getSFromB.open_source('I dont exist');
+    assert(isempty(getSource));
 end
 
 %% Test: Has metadata

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -68,6 +68,10 @@ function [] = test_open_source( varargin )
     %getSourceByName = getTag.open_source(getTag.sources{1,1}.name);
     %assert(strcmp(getSourceByName.id, ''));
     disp('Test Tag: open source by name ... TODO (proper testfile)');
+    
+    %-- test open non existing source
+    getSource = getTag.open_source('I dont exist');
+    assert(isempty(getSource));
 end
 
 
@@ -85,6 +89,10 @@ function [] = test_open_feature( varargin )
     %getFeatByName = getTag.open_feature(getTag.features{1,1}.name);
     %assert(strcmp(getFeatByName.id, ''));
     disp('Test Tag: open feature by name ... TODO (proper testfile)');
+    
+    %-- test open non existing feature
+    getFeat = getTag.open_feature('I dont exist');
+    assert(isempty(getFeat));
 end
 
 
@@ -99,6 +107,10 @@ function [] = test_open_reference( varargin )
 
     getRefByName = getTag.open_reference(getTag.references{1,1}.name);
     assert(strcmp(getRefByName.id, '75138768-edc3-482e-894d-301f1dd66f8d'));
+    
+    %-- test open non existing source
+    getRef = getTag.open_reference('I dont exist');
+    assert(isempty(getRef));
 end
 
 


### PR DESCRIPTION
- refactoring File, Block Source, Tag entities in c++ and matlab
- refactoring Tests accordingly
- adding glue "GETCONTENT" getter for methods which fetch exactly one child entity without parameters