### PR TITLE
migrate to glue: Feature entity, openMetadata

### DIFF
--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -98,7 +98,6 @@ const std::vector<fendpoint> funcs = {
     // Feature
     { "Feature::describe", nixfeature::describe },
     { "Feature::linkType", nixfeature::link_type },
-    { "Feature::openData", nixfeature::open_data },
 
     // Section
     { "Section::describe", nixsection::describe },
@@ -207,6 +206,9 @@ void mexFunction(int            nlhs,
             .reg("hasSection", GETBYSTR(bool, nix::Section, hasSection))
             .reg("link", GETCONTENT(nix::Section, nix::Section, link))
             .reg("parent", GETCONTENT(nix::Section, nix::Section, parent));
+
+        classdef<nix::Feature>("Feature", methods)
+            .reg("openData", GETCONTENT(nix::DataArray, nix::Feature, data));
 
         mexAtExit(on_exit);
     });

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -70,7 +70,6 @@ const std::vector<fendpoint> funcs = {
     { "Block::listSources", nixblock::list_sources },
     { "Block::listTags", nixblock::list_tags },
     { "Block::listMultiTags", nixblock::list_multi_tags },
-    { "Block::openMetadataSection", nixblock::open_metadata_section },
 
     // Data Array
     { "DataArray::describe", nixdataarray::describe },
@@ -82,7 +81,6 @@ const std::vector<fendpoint> funcs = {
     { "Tag::listReferences", nixtag::list_references_array },
     { "Tag::listFeatures", nixtag::list_features },
     { "Tag::listSources", nixtag::list_sources },
-    { "Tag::openMetadataSection", nixtag::open_metadata_section },
     { "Tag::retrieveData", nixtag::retrieve_data },
     { "Tag::featureRetrieveData", nixtag::retrieve_feature_data },
 
@@ -91,14 +89,12 @@ const std::vector<fendpoint> funcs = {
     { "MultiTag::listReferences", nixmultitag::list_references_array },
     { "MultiTag::listFeatures", nixmultitag::list_features },
     { "MultiTag::listSources", nixmultitag::list_sources },
-    { "MultiTag::openMetadataSection", nixmultitag::open_metadata_section },
     { "MultiTag::retrieveData", nixmultitag::retrieve_data },
     { "MultiTag::featureRetrieveData", nixmultitag::retrieve_feature_data },
 
     // Source
     { "Source::describe", nixsource::describe },
     { "Source::listSources", nixsource::list_sources },
-    { "Source::openMetadataSection", nixsource::open_metadata_section },
 
     // Feature
     { "Feature::describe", nixfeature::describe },
@@ -170,14 +166,17 @@ void mexFunction(int            nlhs,
             .reg("openDataArray", GETBYSTR(nix::DataArray, nix::Block, getDataArray))
             .reg("openSource", GETBYSTR(nix::Source, nix::Block, getSource))
             .reg("openTag", GETBYSTR(nix::Tag, nix::Block, getTag))
-            .reg("openMultiTag", GETBYSTR(nix::MultiTag, nix::Block, getMultiTag));
+            .reg("openMultiTag", GETBYSTR(nix::MultiTag, nix::Block, getMultiTag))
+            .reg("openMetadataSection", GETCONTENT(nix::Section, nix::Block, metadata));
 
         classdef<nix::DataArray>("DataArray", methods)
             .reg("sources", GETSOURCES(IDataArray));
+//            .reg("openMetadataSection", GETCONTENT(nix::Section, nix::DataArray, metadata));
 
         classdef<nix::Source>("Source", methods)
             .reg("sources", &nix::Source::sources)
-            .reg("openSource", GETBYSTR(nix::Source, nix::Source, getSource));
+            .reg("openSource", GETBYSTR(nix::Source, nix::Source, getSource))
+            .reg("openMetadataSection", GETCONTENT(nix::Section, nix::Source, metadata));
 
         classdef<nix::Tag>("Tag", methods)
             .reg("references", GETTER(std::vector<nix::DataArray>, nix::Tag, references))
@@ -185,7 +184,8 @@ void mexFunction(int            nlhs,
             .reg("sources", GETSOURCES(ITag))
             .reg("openReferenceDataArray", GETBYSTR(nix::DataArray, nix::Tag, getReference))
             .reg("openFeature", GETBYSTR(nix::Feature, nix::Tag, getFeature))
-            .reg("openSource", GETBYSTR(nix::Source, nix::Tag, getSource));
+            .reg("openSource", GETBYSTR(nix::Source, nix::Tag, getSource))
+            .reg("openMetadataSection", GETCONTENT(nix::Section, nix::Tag, metadata));
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .reg("references", GETTER(std::vector<nix::DataArray>, nix::MultiTag, references))
@@ -196,7 +196,8 @@ void mexFunction(int            nlhs,
             .reg("openExtents", GETCONTENT(nix::DataArray, nix::MultiTag, extents))
             .reg("openReferences", GETBYSTR(nix::DataArray, nix::MultiTag, getReference))
             .reg("openFeature", GETBYSTR(nix::Feature, nix::MultiTag, getFeature))
-            .reg("openSource", GETBYSTR(nix::Source, nix::MultiTag, getSource));
+            .reg("openSource", GETBYSTR(nix::Source, nix::MultiTag, getSource))
+            .reg("openMetadataSection", GETCONTENT(nix::Section, nix::MultiTag, metadata));
 
         classdef<nix::Section>("Section", methods)
             .reg("sections", &nix::Section::sections)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -123,6 +123,8 @@ static void on_exit() {
 #define GETBYSTR(type, class, name) static_cast<type(class::*)(const std::string &)const>(&class::name)
 #define GETCONTENT(type, class, name) static_cast<type(class::*)()const>(&class::name)
 #define GETSOURCES(base__) static_cast<std::vector<nix::Source>(nix::base::EntityWithSources<nix::base::base__>::*)(std::function<bool(const nix::Source &)>)const>(&nix::base::EntityWithSources<nix::base::base__>::sources)
+//required to open nix::Section from DataArray, normal GETCONTENT leads to a compiler error with Visual Studio 12
+#define GETMETADATA(base__) static_cast<nix::Section(nix::base::EntityWithMetadata<nix::base::base__>::*)()const>(&nix::base::EntityWithMetadata<nix::base::base__>::metadata)
 #define REMOVER(type, class, name) static_cast<bool(class::*)(const std::string&)>(&class::name)
 
 // main entry point
@@ -171,7 +173,6 @@ void mexFunction(int            nlhs,
 
         classdef<nix::DataArray>("DataArray", methods)
             .reg("sources", GETSOURCES(IDataArray));
-//            .reg("openMetadataSection", GETCONTENT(nix::Section, nix::DataArray, metadata));
 
         classdef<nix::Source>("Source", methods)
             .reg("sources", &nix::Source::sources)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -74,7 +74,6 @@ const std::vector<fendpoint> funcs = {
     // Data Array
     { "DataArray::describe", nixdataarray::describe },
     { "DataArray::readAll", nixdataarray::read_all },
-    { "DataArray::openMetadataSection", nixdataarray::open_metadata_section },
 
     // Tag
     { "Tag::describe", nixtag::describe },
@@ -172,7 +171,8 @@ void mexFunction(int            nlhs,
             .reg("openMetadataSection", GETCONTENT(nix::Section, nix::Block, metadata));
 
         classdef<nix::DataArray>("DataArray", methods)
-            .reg("sources", GETSOURCES(IDataArray));
+            .reg("sources", GETSOURCES(IDataArray))
+            .reg("openMetadataSection", GETMETADATA(IDataArray));
 
         classdef<nix::Source>("Source", methods)
             .reg("sources", &nix::Source::sources)

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -77,10 +77,4 @@ namespace nixblock {
         output.set(0, sb.array());
     }
 
-    void open_metadata_section(const extractor &input, infusor &output)
-    {
-        nix::Block currObj = input.entity<nix::Block>(1);
-        output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
 } // namespace nixblock

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -15,8 +15,6 @@ namespace nixblock {
 
     void list_multi_tags(const extractor &input, infusor &output);
 
-    void open_metadata_section(const extractor &input, infusor &output);
-
 } // namespace nixblock
 
 #endif

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -63,10 +63,4 @@ namespace nixdataarray {
         output.set(0, data);
     }
 
-    void open_metadata_section(const extractor &input, infusor &output)
-    {
-        nix::DataArray currObj = input.entity<nix::DataArray>(1);
-        output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
 } // namespace nixdataarray

--- a/src/nixdataarray.h
+++ b/src/nixdataarray.h
@@ -9,8 +9,6 @@ namespace nixdataarray {
     
     void read_all(const extractor &input, infusor &output);
 
-    void open_metadata_section(const extractor &input, infusor &output);
-
 } // namespace nixdataarray
 
 #endif

--- a/src/nixfeature.cc
+++ b/src/nixfeature.cc
@@ -19,12 +19,6 @@ namespace nixfeature {
         output.set(0, sb.array());
     }
 
-    void open_data(const extractor &input, infusor &output)
-    {
-        nix::Feature currFeat = input.entity < nix::Feature >(1);
-        output.set(0, nixgen::open_data_array(currFeat.data()));
-    }
-
     void link_type(const extractor &input, infusor &output)
     {
         nix::Feature currFeat = input.entity<nix::Feature>(1);

--- a/src/nixfeature.h
+++ b/src/nixfeature.h
@@ -7,8 +7,6 @@ namespace nixfeature {
 
     void describe(const extractor &input, infusor &output);
 
-    void open_data(const extractor &input, infusor &output);
-
     void link_type(const extractor &input, infusor &output);
 
 } // namespace nixfeature

--- a/src/nixgen.cc
+++ b/src/nixgen.cc
@@ -10,13 +10,6 @@
 
 namespace nixgen {
 
-    handle open_data_array(nix::DataArray inDa)
-    {
-        nix::DataArray da = inDa;
-        handle h = handle(da);
-        return h;
-    }
-
     mxArray* list_data_arrays(std::vector<nix::DataArray> daIn)
     {
         std::vector<nix::DataArray> arr = daIn;
@@ -57,21 +50,6 @@ namespace nixgen {
         }
         return sb.array();
     }
-
-    handle open_source(nix::Source sourceIn)
-    {
-        nix::Source currSource = sourceIn;
-        handle currSourceHandle = handle(currSource);
-        return currSourceHandle;
-    }
-
-    handle open_feature(nix::Feature featIn)
-    {
-        nix::Feature currFeat = featIn;
-        handle currTagFeatHandle = handle(currFeat);
-        return currTagFeatHandle;
-    }
-
 
 mxArray *dataset_read_all(const nix::DataSet &da) {
     nix::NDSize size = da.dataExtent();

--- a/src/nixgen.h
+++ b/src/nixgen.h
@@ -6,28 +6,11 @@
 
 namespace nixgen {
 
-    handle open_data_array(nix::DataArray inDa);
-
     mxArray* list_data_arrays(std::vector<nix::DataArray> daIn);
 
     mxArray* list_features(std::vector<nix::Feature> featIn);
 
     mxArray* list_sources(std::vector<nix::Source> sourceIn);
-
-    handle open_source(nix::Source sourceIn);
-
-    handle open_feature(nix::Feature featIn);
-
-    template<typename T>
-    uint64_t get_handle_or_none(T &&obj) {
-        if (obj) {
-            return handle(std::forward<T>(obj)).address();
-        }
-        else
-        {
-            return uint64_t(0);
-        }
-    }
 
     mxArray *dataset_read_all(const nix::DataSet &da);
 

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -43,12 +43,6 @@ namespace nixmultitag {
         output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
-    void open_metadata_section(const extractor &input, infusor &output)
-    {
-        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
     void retrieve_data(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
         double p_index = input.num<double>(2);

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -13,8 +13,6 @@ namespace nixmultitag {
 
     void list_sources(const extractor &input, infusor &output);
 
-    void open_metadata_section(const extractor &input, infusor &output);
-
     void retrieve_data(const extractor &input, infusor &output);
 
     void retrieve_feature_data(const extractor &input, infusor &output);

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -28,10 +28,4 @@ namespace nixsource {
         output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
-    void open_metadata_section(const extractor &input, infusor &output)
-    {
-        nix::Source currObj = input.entity<nix::Source>(1);
-        output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
 } // namespace nixsource

--- a/src/nixsource.h
+++ b/src/nixsource.h
@@ -9,8 +9,6 @@ namespace nixsource {
 
     void list_sources(const extractor &input, infusor &output);
 
-    void open_metadata_section(const extractor &input, infusor &output);
-
 } // namespace nixsource
 
 #endif

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -46,12 +46,6 @@ namespace nixtag {
         output.set(0, nixgen::list_sources(currObj.sources()));
     }
 
-    void open_metadata_section(const extractor &input, infusor &output)
-    {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        output.set(0, nixgen::get_handle_or_none(currObj.metadata()));
-    }
-
     void retrieve_data(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         double index = input.num<double>(2);

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -13,8 +13,6 @@ namespace nixtag {
 
     void list_sources(const extractor &input, infusor &output);
 
-    void open_metadata_section(const extractor &input, infusor &output);
-
     void retrieve_data(const extractor &input, infusor &output);
 
     void retrieve_feature_data(const extractor &input, infusor &output);


### PR DESCRIPTION
- migrate Feature entity to glue
- migrate all openMetadata functions to glue
- fix required to open DataArray metadata while using glue
- removed generic functions now obsolete due to migration