### PR TITLE
Refactor write / update Property values

### DIFF
--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -30,6 +30,23 @@ classdef Property < nix.NamedEntity
         end
 
         function [] = set.values(obj, val)
+
+            %-- when an update occurs, check, if the datatype of the
+            %-- data within a normal array is consistent with the
+            %-- datatype of the property
+            checkDType = obj.datatype;
+            if(~iscell(val) && ~isstruct(val) && ~isempty(val))
+                checkDType = strrep(strrep(class(val),'char','string'),'logical','bool');
+                %-- convert any values to cell array
+                val = num2cell(val);
+            elseif (iscell(val) && ~isstruct(val{1}))
+                checkDType = strrep(strrep(class(val{1}),'char','string'),'logical','bool');
+            end;
+
+            if(isempty(find(strcmpi(checkDType, obj.datatype),1)))
+                error('Values do not match property data type!');
+            end;
+
             nix_mx('Property::updateValues', obj.nix_handle, val);
             obj.valuesCache.lastUpdate = 0;
 

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -53,6 +53,9 @@ classdef Property < nix.NamedEntity
             dispStr = 'Note: nix only supports updating the actual value at the moment.';
             dispStr = [dispStr, char(10), 'Attributes like uncertainty or checksum cannot be set at the moment.'];
             disp(dispStr);
+            
+            %-- TODO: clearing existing values using obj.values = '' works,
+            %-- but is a hack. Refactor in good time.
         end
     end
     

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -96,6 +96,9 @@ classdef Section < nix.NamedEntity
         end;
 
         function p = create_property_with_value(obj, name, val)
+            if(~iscell(val))
+                val = num2cell(val);
+            end;
             p = nix.Property(nix_mx('Section::createPropertyWithValue', ...
                 obj.nix_handle, name, val));
             obj.propsCache.lastUpdate = 0;

--- a/src/nixgen.cc
+++ b/src/nixgen.cc
@@ -39,4 +39,23 @@ mxArray *dataset_read_all(const nix::DataSet &da) {
     return data;
 }
 
+std::vector<nix::Value> extract_property_values(const extractor &input, int idx) {
+    std::vector<nix::Value> currVec;
+
+    mxClassID currID = input.class_id(idx);
+    if (currID == mxCELL_CLASS) {
+        const mxArray *cell_element_ptr = input.cellElemPtr(idx, 0);
+
+        if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS) {
+            currVec = input.extractFromStruct(idx);
+        } else {
+            currVec = input.vec(idx);
+        }
+    } else {
+        mexPrintf("Unsupported data type\n");
+    }
+
+    return currVec;
+}
+
 } // namespace nixgen

--- a/src/nixgen.h
+++ b/src/nixgen.h
@@ -8,6 +8,8 @@ namespace nixgen {
 
     mxArray *dataset_read_all(const nix::DataSet &da);
 
+    std::vector<nix::Value> extract_property_values(const extractor &input, int idx);
+
 } // namespace nixgen
 
 #endif

--- a/src/nixproperty.cc
+++ b/src/nixproperty.cc
@@ -55,7 +55,27 @@ namespace nixproperty {
     {
         nix::Property prop = input.entity<nix::Property>(1);
         prop.deleteValues();
-        std::vector<nix::Value> getVals = input.extractFromStruct(2);
+
+        std::vector<nix::Value> getVals;
+
+        mxClassID currID = input.class_id(2);
+        if (currID == mxCELL_CLASS)
+        {
+            const mxArray *cell_element_ptr = input.cellElemPtr(2, 0);
+            if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS)
+            {
+                getVals = input.extractFromStruct(2);
+            }
+            else
+            {
+                getVals = input.vec(2);
+            }
+        }
+        else
+        {
+            mexPrintf("Unsupported data type\n");
+        }
+
         prop.values(getVals);
     }
 

--- a/src/nixproperty.cc
+++ b/src/nixproperty.cc
@@ -1,4 +1,5 @@
 #include "nixproperty.h"
+#include "nixgen.h"
 
 #include "mex.h"
 
@@ -56,27 +57,7 @@ namespace nixproperty {
         nix::Property prop = input.entity<nix::Property>(1);
         prop.deleteValues();
 
-        std::vector<nix::Value> getVals;
-
-        mxClassID currID = input.class_id(2);
-        if (currID == mxCELL_CLASS)
-        {
-            const mxArray *cell_element_ptr = input.cellElemPtr(2, 0);
-            if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS)
-            {
-                getVals = input.extractFromStruct(2);
-            }
-            else
-            {
-                getVals = input.vec(2);
-            }
-        }
-        else
-        {
-            mexPrintf("Unsupported data type\n");
-        }
-
-        prop.values(getVals);
+        prop.values(nixgen::extract_property_values(input, 2));
     }
 
 } // namespace nixproperty

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -68,7 +68,33 @@ void create_property(const extractor &input, infusor &output)
 void create_property_with_value(const extractor &input, infusor &output)
 {
     nix::Section currObj = input.entity<nix::Section>(1);
-    std::vector<nix::Value> currVec = input.vec(3);
+
+    std::vector<nix::Value> currVec;
+
+    mxClassID currID = input.class_id(3);
+    if (currID == mxCELL_CLASS){
+        mexPrintf("Cell\n");
+        const mxArray *cell_element_ptr = input.cellElemPtr(3, 0);
+
+        if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS){
+            mexPrintf("Struct\n");
+            currVec = input.extractFromStruct(3);
+        }
+        else
+        {
+            mexPrintf("Cell with normal values\n");
+            currVec = input.vec(3);
+        }
+    }
+    else if (currID == mxCHAR_CLASS){
+        mexPrintf("Just char\n");
+    }
+    else if (currID == mxDOUBLE_CLASS){
+        mexPrintf("Just double\n");
+    }
+    else if (currID == mxLOGICAL_CLASS){
+        mexPrintf("Just logical\n");
+    }
 
     nix::Property p = currObj.createProperty(input.str(2), currVec);
     output.set(0, handle(p));

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -1,4 +1,5 @@
 #include "nixsection.h"
+#include "nixgen.h"
 
 #include "mex.h"
 #include <nix.hpp>
@@ -69,28 +70,7 @@ void create_property_with_value(const extractor &input, infusor &output)
 {
     nix::Section currObj = input.entity<nix::Section>(1);
 
-    std::vector<nix::Value> currVec;
-
-    mxClassID currID = input.class_id(3);
-    if (currID == mxCELL_CLASS)
-    {
-        const mxArray *cell_element_ptr = input.cellElemPtr(3, 0);
-
-        if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS)
-        {
-            currVec = input.extractFromStruct(3);
-        }
-        else
-        {
-            currVec = input.vec(3);
-        }
-    }
-    else
-    {
-        mexPrintf("Unsupported data type\n");
-    }
-
-    nix::Property p = currObj.createProperty(input.str(2), currVec);
+    nix::Property p = currObj.createProperty(input.str(2), nixgen::extract_property_values(input, 3));
     output.set(0, handle(p));
 }
 

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -72,28 +72,22 @@ void create_property_with_value(const extractor &input, infusor &output)
     std::vector<nix::Value> currVec;
 
     mxClassID currID = input.class_id(3);
-    if (currID == mxCELL_CLASS){
-        mexPrintf("Cell\n");
+    if (currID == mxCELL_CLASS)
+    {
         const mxArray *cell_element_ptr = input.cellElemPtr(3, 0);
 
-        if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS){
-            mexPrintf("Struct\n");
+        if (mxGetClassID(cell_element_ptr) == mxSTRUCT_CLASS)
+        {
             currVec = input.extractFromStruct(3);
         }
         else
         {
-            mexPrintf("Cell with normal values\n");
             currVec = input.vec(3);
         }
     }
-    else if (currID == mxCHAR_CLASS){
-        mexPrintf("Just char\n");
-    }
-    else if (currID == mxDOUBLE_CLASS){
-        mexPrintf("Just double\n");
-    }
-    else if (currID == mxLOGICAL_CLASS){
-        mexPrintf("Just logical\n");
+    else
+    {
+        mexPrintf("Unsupported data type\n");
     }
 
     nix::Property p = currObj.createProperty(input.str(2), currVec);

--- a/src/utils/arguments.h
+++ b/src/utils/arguments.h
@@ -65,6 +65,11 @@ public:
         return mx_array_to_str(array[pos]);
     }
 
+    const mxArray * cellElemPtr(size_t pos, int index) const {
+        const mxArray *cell_element_ptr = mxGetCell(array[pos], index);
+        return cell_element_ptr;
+    }
+
     template<typename T>
     T num(size_t pos) const {
         check_arg_type(pos, nix::to_data_type<T>::value);

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -78,4 +78,26 @@ function [] = test_update_values( varargin )
     assert(updateDouble.values{1}.value == 2);
     updateDouble.values{1}.value = 2.2;
     assert(updateDouble.values{1}.value == 2.2);
+    
+    %-- test remove values from property
+    delValues = s.open_property(s.allProperties{3}.id);
+    assert(size(delValues.values, 1) == 4);
+    delValues.values = '';
+    assert(size(delValues.values, 1) == 0);
+    clear delValues;
+    
+    %-- test add new values to empty value property
+    newValues = s.open_property(s.allProperties{3}.id);
+    newValues.values = [1,2,3,4,5];
+    assert(newValues.values{5}.value == 5);
+    newValues.values = '';
+    newValues.values = {6,7,8};
+    assert(newValues.values{3}.value == 8);
+    
+    %-- test add new values by value structure
+    val1 = newValues.values{1};
+    val2 = newValues.values{2};
+    updateNewDouble = s.create_property('doubleProperty2', nix.DataType.Double);
+    updateNewDouble.values = {val1, val2};
+    assert(s.open_property(s.allProperties{end}.id).values{2}.value == val2.value);
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -156,24 +156,58 @@ function [] = test_create_property_with_value( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
-    tmp = s.create_property_with_value('doubleProperty', {5, 6, 7, 8});
-    assert(strcmp(s.allProperties{1}.name, 'doubleProperty'));
-    assert(s.open_property(s.allProperties{1}.id).values{1}.value == 5);
-    assert(size(s.open_property(s.allProperties{1}.id).values, 1) == 4);
+    tmp = s.create_property_with_value('doubleProperty1', [5, 6, 7, 8]);
+    assert(strcmp(s.allProperties{end}.name, 'doubleProperty1'));
+    assert(s.open_property(s.allProperties{end}.id).values{1}.value == 5);
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 4);
+    assert(strcmpi(tmp.datatype,'double'));
+    
+    tmp = s.create_property_with_value('doubleProperty2', {5, 6, 7, 8});
+    assert(strcmp(s.allProperties{end}.name, 'doubleProperty2'));
+    assert(s.open_property(s.allProperties{end}.id).values{1}.value == 5);
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 4);
     assert(strcmpi(tmp.datatype,'double'));
 
-    tmp = s.create_property_with_value('stringProperty', {'this', 'has', 'strings'});
-    assert(strcmp(s.allProperties{2}.name, 'stringProperty'));
-    assert(strcmp(s.open_property(s.allProperties{2}.id).values{1}.value, 'this'));
-    assert(size(s.open_property(s.allProperties{2}.id).values, 1) == 3);
+    tmp = s.create_property_with_value('stringProperty1', ['a', 'string']);
+    assert(strcmp(s.allProperties{end}.name, 'stringProperty1'));
+    assert(strcmp(s.open_property(s.allProperties{end}.id).values{1}.value, 'a'));
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 7);
+    assert(strcmpi(tmp.datatype, 'string'));
+    
+    tmp = s.create_property_with_value('stringProperty2', {'this', 'has', 'strings'});
+    assert(strcmp(s.allProperties{end}.name, 'stringProperty2'));
+    assert(strcmp(s.open_property(s.allProperties{end}.id).values{1}.value, 'this'));
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
     assert(strcmpi(tmp.datatype, 'string'));
 
-    tmp = s.create_property_with_value('booleanProperty', {true, false, true});
-    assert(strcmp(s.allProperties{3}.name, 'booleanProperty'));
-    assert(s.open_property(s.allProperties{3}.id).values{1}.value);
-    assert(~s.open_property(s.allProperties{3}.id).values{2}.value);
-    assert(size(s.open_property(s.allProperties{3}.id).values, 1) == 3);
+    tmp = s.create_property_with_value('booleanProperty1', [true, false, true]);
+    assert(strcmp(s.allProperties{end}.name, 'booleanProperty1'));
+    assert(s.open_property(s.allProperties{end}.id).values{1}.value);
+    assert(~s.open_property(s.allProperties{end}.id).values{2}.value);
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
     assert(strcmpi(tmp.datatype, 'bool'));
+
+    tmp = s.create_property_with_value('booleanProperty2', {true, false, true});
+    assert(strcmp(s.allProperties{end}.name, 'booleanProperty2'));
+    assert(s.open_property(s.allProperties{end}.id).values{1}.value);
+    assert(~s.open_property(s.allProperties{end}.id).values{2}.value);
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
+    assert(strcmpi(tmp.datatype, 'bool'));
+    
+    val1 = s.open_property(s.allProperties{1}.id).values{1};
+    val2 = s.open_property(s.allProperties{1}.id).values{2};
+    tmp = s.create_property_with_value('doubleByStrunct1', [val1, val2]);
+    assert(strcmp(s.allProperties{end}.name, 'doubleByStrunct1'));
+    assert(s.open_property(s.allProperties{end}.id).values{1}.value == 5);
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 2);
+    assert(strcmpi(tmp.datatype,'double'));
+    
+    val3 = s.open_property(s.allProperties{1}.id).values{3};
+    tmp = s.create_property_with_value('doubleByStrunct2', {val1, val2, val3});
+    assert(strcmp(s.allProperties{end}.name, 'doubleByStrunct2'));
+    assert(s.open_property(s.allProperties{end}.id).values{3}.value == 7);
+    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
+    assert(strcmpi(tmp.datatype,'double'));
 end
 
 %% Test: Delete property by entity, propertyStruct, ID and name


### PR DESCRIPTION
- Property values can now be written as Matlab arrays, cells or Value structs within cells
- Values of a property can be deleted
- added checks that only update values matching the Property datataype can be passed to nix (crashes otherwise)
- added Tests for all new methods