### PR TITLE
Various build fixes for boost 1.58.0/MATLAB 2014{a,b}

### DIFF
--- a/cmake/FindMATLAB.cmake
+++ b/cmake/FindMATLAB.cmake
@@ -126,7 +126,7 @@ ELSE(WIN32)
     IF((NOT DEFINED MATLAB_ROOT) OR ("${MATLAB_ROOT}" STREQUAL ""))
 
     # Search for a version of Matlab available, starting from the most modern one to older versions
-      FOREACH(MATVER "R2013b" "R2013a" "R2012b" "R2012a" "R2011b" "R2011a" "R2010b" "R2010a" "R2009b" "R2009a" "R2008b")
+      FOREACH(MATVER "R2014b" "R2014a" "R2013b" "R2013a" "R2012b" "R2012a" "R2011b" "R2011a" "R2010b" "R2010a" "R2009b" "R2009a" "R2008b")
         SET(MATLAB_VERSION ${MATVER})
         IF((NOT DEFINED MATLAB_ROOT) OR ("${MATLAB_ROOT}" STREQUAL ""))
           IF(EXISTS /Applications/MATLAB_${MATVER}.app)

--- a/src/utils/arguments.h
+++ b/src/utils/arguments.h
@@ -69,11 +69,6 @@ public:
         return mx_to_vector<T>(array[pos]);
     }
 
-    template<>
-    std::vector<std::string> vec(size_t pos) const {
-        return mx_to_strings(array[pos]);
-    }
-
     std::vector<nix::Value> vec(size_t pos) const {
         return mx_to_values(array[pos]);
     }
@@ -121,6 +116,11 @@ public:
 
 private:
 };
+
+template<>
+inline std::vector<std::string> extractor::vec(size_t pos) const {
+	return mx_to_strings(array[pos]);
+}
 
 
 class infusor : public argument_helper<mxArray> {

--- a/src/utils/glue.h
+++ b/src/utils/glue.h
@@ -40,8 +40,7 @@ struct ex_getter < std::string > {
 template<>
 struct ex_getter < boost::none_t > {
     static boost::none_t get(const extractor &input, int pos) {
-        boost::none_t t = nullptr;
-        return t;
+        return boost::none;
     }
 };
 

--- a/src/utils/mkarray.h
+++ b/src/utils/mkarray.h
@@ -72,17 +72,6 @@ inline mxArray* make_mx_array(const std::vector<nix::Value> &v) {
 	return data;
 }
 
-
-template<typename T>
-mxArray* make_mx_array(const boost::optional<T> &opt) {
-    if (opt) {
-        return make_mx_array(*opt);
-    }
-    else {
-        return nullptr;
-    }
-}
-
 template<typename T>
 typename std::enable_if<std::is_arithmetic<T>::value, mxArray>::type* make_mx_array(T val) {
 	DType2 dtype = dtype_nix2mex(nix::to_data_type<T>::value);
@@ -154,6 +143,16 @@ inline mxArray* make_mx_array(const std::vector<nix::Dimension> &dims) {
     }
 
     return data;
+}
+
+template<typename T>
+mxArray* make_mx_array(const boost::optional<T> &opt) {
+    if (opt) {
+        return make_mx_array(*opt);
+    }
+    else {
+        return nullptr;
+    }
 }
 
 

--- a/src/utils/mknix.cc
+++ b/src/utils/mknix.cc
@@ -152,7 +152,7 @@ nix::Value mx_to_value_from_struct(const mxArray *arr) {
         case 3: val.encoder = mx_to_str(field_array_ptr); break;
         case 4: val.filename = mx_to_str(field_array_ptr); break;
         case 5: val.reference = mx_to_str(field_array_ptr); break;
-        default: throw std::invalid_argument(strcat("Field is not supported: ", field_name));
+        default: throw std::invalid_argument(std::string("Field is not supported: ") + std::string(field_name));
         }
     }
 


### PR DESCRIPTION
* Detect MATLAB versions 2014{a,b}
* Remove `boost::none_t t = nullptr;` (not legal in boost 1.58.0)
* Specialise member function template outside of the class
* Change order of make_mx_array to fix the build