### PR TITLE
Completify bindings

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -44,6 +44,10 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             da.write_all(data);
         end
 
+        function hasDA = has_data_array(obj, id_or_name)
+            hasDA = nix_mx('Block::hasDataArray', obj.nix_handle, id_or_name);
+        end;
+        
         function delCheck = delete_data_array(obj, del)
             [delCheck, obj.dataArraysCache] = nix.Utils.delete_entity(obj, ...
                 del, 'nix.DataArray', 'Block::deleteDataArray', obj.dataArraysCache);
@@ -56,6 +60,10 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function s = create_source(obj, name, type)
             s = nix.Source(nix_mx('Block::createSource', obj.nix_handle, name, type));
             obj.sourcesCache.lastUpdate = 0;
+        end;
+        
+        function hasSource = has_source(obj, id_or_name)
+            hasSource = nix_mx('Block::hasSource', obj.nix_handle, id_or_name);
         end;
         
         function delCheck = delete_source(obj, del)

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -21,11 +21,22 @@ classdef Feature < nix.Entity
         end;
 
         function linkType = get.linkType(obj)
-            linkType = obj.info.linkType;
+            linkType = nix_mx('Feature::getLinkType', obj.nix_handle);
+        end;
+
+        function [] = set.linkType(obj, linkType)
+            nix_mx('Feature::setLinkType', obj.nix_handle, linkType);
         end;
 
         function dataArray = open_data(obj)
            dataArray = nix.DataArray(nix_mx('Feature::openData', obj.nix_handle));
+        end;
+        
+        function [] = set_data(obj, setData)
+            if(strcmp(class(setData), 'nix.DataArray'))
+                setData = setData.id;
+            end;
+            nix_mx('Feature::setData', obj.nix_handle, setData);
         end;
     end;
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -24,16 +24,20 @@ classdef File < nix.Entity
         % ----------------
         % Block methods
         % ----------------
-        
-        function retObj = openBlock(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'File::openBlock', id_or_name, @nix.Block);
-        end
-        
+
         function newBlock = createBlock(obj, name, type)
             newBlock = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
             obj.blocksCache.lastUpdate = 0;
         end;
+
+        function hasBlock = hasBlock(obj, id_or_name)
+            hasBlock = nix_mx('File::hasBlock', obj.nix_handle, id_or_name);
+        end;
+
+        function retObj = openBlock(obj, id_or_name)
+            retObj = nix.Utils.open_entity(obj, ...
+                'File::openBlock', id_or_name, @nix.Block);
+        end
 
         function delCheck = deleteBlock(obj, del)
             [delCheck, obj.blocksCache] = nix.Utils.delete_entity(obj, ...
@@ -43,16 +47,20 @@ classdef File < nix.Entity
         % ----------------
         % Section methods
         % ----------------
-        
-        function retObj = openSection(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'File::openSection', id_or_name, @nix.Section);
-        end
 
         function newSec = createSection(obj, name, type)
             newSec = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
             obj.sectionsCache.lastUpdate = 0;
         end;
+
+        function hasSec = hasSection(obj, id_or_name)
+            hasSec = nix_mx('File::hasSection', obj.nix_handle, id_or_name);
+        end;
+
+        function retObj = openSection(obj, id_or_name)
+            retObj = nix.Utils.open_entity(obj, ...
+                'File::openSection', id_or_name, @nix.Section);
+        end
 
         function delCheck = deleteSection(obj, del)
             delCheck = nix.Utils.delete_entity(obj, del, 'nix.Section', 'File::deleteSection');

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -29,6 +29,10 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 add_this, 'nix.DataArray', 'MultiTag::addReference', obj.referencesCache);
         end;
 
+        function hasRef = has_reference(obj, id_or_name)
+            hasRef = nix_mx('MultiTag::hasReference', obj.nix_handle, id_or_name);
+        end;
+        
         function delCheck = remove_reference(obj, del)
             [delCheck, obj.referencesCache] = nix.Utils.delete_entity(obj, ...
                 del, 'nix.DataArray', 'MultiTag::removeReference', obj.referencesCache);
@@ -65,6 +69,10 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj.featuresCache.lastUpdate = 0;
         end;
 
+        function hasFeature = has_feature(obj, id_or_name)
+            hasFeature = nix_mx('MultiTag::hasFeature', obj.nix_handle, id_or_name);
+        end;
+        
         function delCheck = remove_feature(obj, del)
             [delCheck, obj.featuresCache] = nix.Utils.delete_entity(obj, ...
                 del, 'nix.Feature', 'MultiTag::deleteFeature', obj.featuresCache);
@@ -124,13 +132,17 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             end;
         end;
 
-        function [] = add_extents(obj, add_this)
-            if(strcmp(class(add_this), 'nix.DataArray'))
-                addID = add_this.id;
+        function [] = set_extents(obj, add_this)
+            if(isempty(add_this))
+                nix_mx('MultiTag::set_none_extents', obj.nix_handle, 0);
             else
-                addID = add_this;
+                if(strcmp(class(add_this), 'nix.DataArray'))
+                    addID = add_this.id;
+                else
+                    addID = add_this;
+                end;
+                nix_mx('MultiTag::set_extents', obj.nix_handle, addID);
             end;
-            nix_mx('MultiTag::addExtents', obj.nix_handle, addID);
         end;
 
     end;

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -24,6 +24,10 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             obj.sourcesCache.lastUpdate = 0;
         end;
 
+        function hasSource = has_source(obj, id_or_name)
+            hasSource = nix_mx('Source::hasSource', obj.nix_handle, id_or_name);
+        end;
+        
         function delCheck = delete_source(obj, del)
             [delCheck, obj.sourcesCache] = nix.Utils.delete_entity(obj, ...
                 del, 'nix.Source', 'Source::deleteSource', obj.sourcesCache);

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -31,6 +31,10 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 add_this, 'nix.DataArray', 'Tag::addReference', obj.referencesCache);
         end;
 
+        function hasRef = has_reference(obj, id_or_name)
+            hasRef = nix_mx('Tag::hasReference', obj.nix_handle, id_or_name);
+        end;
+        
         function delCheck = remove_reference(obj, del)
             [delCheck, obj.referencesCache] = nix.Utils.delete_entity(obj, ...
                 del, 'nix.DataArray', 'Tag::removeReference', obj.referencesCache);
@@ -65,6 +69,10 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj.featuresCache.lastUpdate = 0;
         end;
 
+        function hasFeature = has_feature(obj, id_or_name)
+            hasFeature = nix_mx('Tag::hasFeature', obj.nix_handle, id_or_name);
+        end;
+        
         function delCheck = remove_feature(obj, del)
             [delCheck, obj.featuresCache] = nix.Utils.delete_entity(obj, ...
                 del, 'nix.Feature', 'Tag::deleteFeature', obj.featuresCache);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -181,6 +181,8 @@ void mexFunction(int            nlhs,
             .reg("references", GETTER(std::vector<nix::DataArray>, nix::Tag, references))
             .reg("features", &nix::Tag::features)
             .reg("sources", FILTER(std::vector<nix::Source>, nix::Tag, std::function<bool(const nix::Source &)>, sources))
+            .reg("hasReference", GETBYSTR(bool, nix::Tag, hasReference))
+            .reg("hasFeature", GETBYSTR(bool, nix::Tag, hasFeature))
             .reg("openReferenceDataArray", GETBYSTR(nix::DataArray, nix::Tag, getReference))
             .reg("openFeature", GETBYSTR(nix::Feature, nix::Tag, getFeature))
             .reg("openSource", GETBYSTR(nix::Source, nix::Tag, getSource))
@@ -192,6 +194,9 @@ void mexFunction(int            nlhs,
             .reg("set_type", SETTER(const std::string&, nix::Tag, type))
             .reg("set_definition", SETTER(const std::string&, nix::Tag, definition))
             .reg("set_none_definition", SETTER(const boost::none_t, nix::Tag, definition))
+            .reg("set_position", SETTER(const std::vector<double>&, nix::Tag, position))
+            .reg("set_extent", SETTER(const std::vector<double>&, nix::Tag, extent))
+            .reg("set_none_extent", SETTER(const boost::none_t, nix::Tag, extent))
             .reg("removeReference", REMOVER(nix::DataArray, nix::Tag, removeReference))
             .reg("removeSource", REMOVER(nix::Source, nix::Tag, removeSource))
             .reg("deleteFeature", REMOVER(nix::Feature, nix::Tag, deleteFeature));

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -212,12 +212,18 @@ void mexFunction(int            nlhs,
             .reg("features", &nix::MultiTag::features)
             .reg("sources", FILTER(std::vector<nix::Source>, nix::MultiTag, std::function<bool(const nix::Source &)>, sources))
             .reg("hasPositions", GETCONTENT(bool, nix::MultiTag, hasPositions))
+            .reg("hasReference", GETBYSTR(bool, nix::MultiTag, hasReference))
+            .reg("hasFeature", GETBYSTR(bool, nix::MultiTag, hasFeature))
             .reg("openPositions", GETCONTENT(nix::DataArray, nix::MultiTag, positions))
             .reg("openExtents", GETCONTENT(nix::DataArray, nix::MultiTag, extents))
             .reg("openReferences", GETBYSTR(nix::DataArray, nix::MultiTag, getReference))
             .reg("openFeature", GETBYSTR(nix::Feature, nix::MultiTag, getFeature))
             .reg("openSource", GETBYSTR(nix::Source, nix::MultiTag, getSource))
             .reg("openMetadataSection", GETCONTENT(nix::Section, nix::MultiTag, metadata))
+            .reg("set_units", SETTER(const std::vector<std::string>&, nix::MultiTag, units))
+            .reg("set_none_units", SETTER(const boost::none_t, nix::MultiTag, units))
+            .reg("set_extents", SETTER(const std::string&, nix::MultiTag, extents))
+            .reg("set_none_extents", SETTER(const boost::none_t, nix::MultiTag, extents))
             .reg("set_metadata", SETTER(const std::string&, nix::MultiTag, metadata))
             .reg("set_none_metadata", SETTER(const boost::none_t, nix::MultiTag, metadata))
             .reg("removeReference", REMOVER(nix::DataArray, nix::MultiTag, removeReference))
@@ -229,7 +235,6 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::addSource", nixmultitag::add_source);
         methods->add("MultiTag::createFeature", nixmultitag::create_feature);
         methods->add("MultiTag::addPositions", nixmultitag::add_positions);
-        methods->add("MultiTag::addExtents", nixmultitag::add_extents);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -167,6 +167,7 @@ void mexFunction(int            nlhs,
             .reg("createSource", &nix::Source::createSource)
             .reg("deleteSource", REMOVER(nix::Source, nix::Source, deleteSource))
             .reg("sources", &nix::Source::sources)
+            .reg("hasSource", GETBYSTR(bool, nix::Source, hasSource))
             .reg("openSource", GETBYSTR(nix::Source, nix::Source, getSource))
             .reg("openMetadataSection", GETCONTENT(nix::Section, nix::Source, metadata))
             .reg("set_metadata", SETTER(const std::string&, nix::Source, metadata))

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -97,6 +97,8 @@ void mexFunction(int            nlhs,
             .add("open", nixfile::open)
             .reg("blocks", GETTER(std::vector<nix::Block>, nix::File, blocks))
             .reg("sections", GETTER(std::vector<nix::Section>, nix::File, sections))
+            .reg("hasBlock", GETBYSTR(bool, nix::File, hasBlock))
+            .reg("hasSection", GETBYSTR(bool, nix::File, hasSection))
             .reg("deleteBlock", REMOVER(nix::Block, nix::File, deleteBlock))
             .reg("deleteSection", REMOVER(nix::Section, nix::File, deleteSection))
             .reg("openBlock", GETBYSTR(nix::Block, nix::File, getBlock))

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -290,7 +290,10 @@ void mexFunction(int            nlhs,
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)
-            .reg("openData", GETCONTENT(nix::DataArray, nix::Feature, data));
+            .reg("openData", GETCONTENT(nix::DataArray, nix::Feature, data))
+            .reg("setData", SETTER(const std::string&, nix::Feature, data))
+            .reg("getLinkType", GETCONTENT(nix::LinkType, nix::Feature, linkType));
+        methods->add("Feature::setLinkType", nixfeature::set_link_type);
 
         classdef<nix::Property>("Property", methods)
             .desc(&nixproperty::describe)
@@ -361,4 +364,3 @@ void mexFunction(int            nlhs,
         mexErrMsgIdAndTxt("nix:arg:dispatch", "Unkown command");
     }
 }
-

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -114,6 +114,8 @@ void mexFunction(int            nlhs,
             .reg("sources", &nix::Block::sources)
             .reg("tags", &nix::Block::tags)
             .reg("multiTags", &nix::Block::multiTags)
+            .reg("hasDataArray", GETBYSTR(bool, nix::Block, hasDataArray))
+            .reg("hasSource", GETBYSTR(bool, nix::Block, hasSource))
             .reg("hasTag", GETBYSTR(bool, nix::Block, hasTag))
             .reg("hasMultiTag", GETBYSTR(bool, nix::Block, hasMultiTag))
             .reg("openDataArray", GETBYSTR(nix::DataArray, nix::Block, getDataArray))

--- a/src/nixfeature.cc
+++ b/src/nixfeature.cc
@@ -18,4 +18,11 @@ namespace nixfeature {
         return sb.array();
     }
 
+    void set_link_type(const extractor &input, infusor &output)
+    {
+        nix::Feature feat = input.entity<nix::Feature>(1);
+
+        feat.linkType(input.ltype(2));
+    }
+
 } // namespace nixfeature

--- a/src/nixfeature.h
+++ b/src/nixfeature.h
@@ -7,6 +7,8 @@ namespace nixfeature {
 
     mxArray *describe(const nix::Feature &feat);
 
+    void set_link_type(const extractor &input, infusor &output);
+
 } // namespace nixfeature
 
 #endif

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -68,12 +68,4 @@ namespace nixmultitag {
         currObj.positions(input.str(2));
     }
 
-    void add_extents(const extractor &input, infusor &output)
-    {
-        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        currObj.extents(input.str(2));
-    }
-
-    void remove_extents(const extractor &input, infusor &output);
-
 } // namespace nixmultitag

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -19,8 +19,6 @@ namespace nixmultitag {
 
     void add_positions(const extractor &input, infusor &output);
 
-    void add_extents(const extractor &input, infusor &output);
-
 } // namespace nixmultitag
 
 #endif

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -21,6 +21,8 @@ function funcs = TestBlock
     funcs{end+1} = @test_open_tag;
     funcs{end+1} = @test_open_multitag;
     funcs{end+1} = @test_open_source;
+    funcs{end+1} = @test_has_data_array;
+    funcs{end+1} = @test_has_source;
     funcs{end+1} = @test_has_multitag;
     funcs{end+1} = @test_has_tag;
     funcs{end+1} = @test_set_metadata;
@@ -370,4 +372,38 @@ function [] = test_open_metadata( varargin )
     b.set_metadata(f.sections{1});
 
     assert(strcmp(b.open_metadata.name, 'testSection'));
+end
+
+%% Test: nix.Block has nix.DataArray by ID or name
+function [] = test_has_data_array( varargin )
+    fileName = 'testRW.h5';
+    daName = 'hasDataArrayTest';
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock('testblock', 'nixBlock');
+    da = b.create_data_array(daName, 'nixDataArray', 'double', [1 2]);
+    daID = da.id;
+    
+    assert(~b.has_data_array('I do not exist'));
+    assert(b.has_data_array(daName));
+
+    clear da b f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(f.blocks{1}.has_data_array(daID));
+end
+
+%% Test: nix.Block has nix.Source by ID or name
+function [] = test_has_source( varargin )
+    fileName = 'testRW.h5';
+    sName = 'sourcetest1';
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock('testblock', 'nixBlock');
+    s = b.create_source(sName, 'nixSource');
+    sID = s.id;
+
+    assert(~b.has_source('I do not exist'));
+    assert(b.has_source(sName));
+
+    clear s b f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(f.blocks{1}.has_source(sID));
 end

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -410,6 +410,7 @@ function [] = test_has_source( varargin )
     clear s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
     assert(f.blocks{1}.has_source(sID));
+end
 
 %% Test: Create nix.Group
 function [] = test_create_group( varargin )

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -4,6 +4,8 @@ function funcs = TestFeature
 
     funcs = {};
     funcs{end+1} = @test_open_data;
+    funcs{end+1} = @test_get_set_link_type;
+    funcs{end+1} = @test_set_data;
 end
 
 %% Test: Open data from feature
@@ -16,4 +18,70 @@ function [] = test_open_data ( varargin )
     
     getFeature = getTag.features{1};
     assert(~isempty(getFeature.open_data));
+end
+
+%% Test: Get and set nix.LinkType
+function [] = test_get_set_link_type ( varargin )
+    fileName = 'testRW.h5';
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock('featureTest', 'nixBlock');
+    da = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    t = b.create_tag('featureTest', 'nixTag', [1, 2]);
+    feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    
+    try
+        feat.linkType = '';
+    catch ME
+        assert(strcmp(ME.identifier, 'nix:arg:inval'));
+    end;
+    try
+        feat.linkType = {};
+    catch ME
+        assert(strcmp(ME.identifier, 'nix:arg:inval'));
+    end;
+    try
+        feat.linkType = 1;
+    catch ME
+        assert(strcmp(ME.identifier, 'nix:arg:inval'));
+    end;
+    assert(f.blocks{1}.tags{1}.features{1}.linkType == 0);
+
+    feat.linkType = nix.LinkType.Untagged;
+    assert(f.blocks{1}.tags{1}.features{1}.linkType == 1);
+
+    feat.linkType = nix.LinkType.Indexed;
+    
+    clear feat t da b f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(f.blocks{1}.tags{1}.features{1}.linkType == 2);
+end
+
+%% Test: Set data by entity, ID and name
+function [] = test_set_data ( varargin )
+    fileName = 'testRW.h5';
+    daName1 = 'featTestDA1';
+    daName2 = 'featTestDA2';
+    daName3 = 'featTestDA3';
+    daName4 = 'featTestDA4';
+    daType = 'nixDataArray';
+    daData = [1 2 3 4 5 6];
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock('featureTest', 'nixBlock');
+    da1 = b.create_data_array(daName1, daType, 'double', daData);
+    da2 = b.create_data_array(daName2, daType, 'double', daData);
+    da3 = b.create_data_array(daName3, daType, 'double', daData);
+    da4 = b.create_data_array(daName4, daType, 'double', daData);
+    t = b.create_tag('featureTest', 'nixTag', [1, 2]);
+    feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    
+    assert(strcmp(feat.open_data.name, daName1));
+    feat.set_data(da2);
+    assert(strcmp(f.blocks{1}.tags{1}.features{1}.open_data.name, daName2));
+    feat.set_data(da3.id);
+    assert(strcmp(f.blocks{1}.tags{1}.features{1}.open_data.name, daName3));
+    feat.set_data(da4.name);
+    
+    clear feat t da4 da3 da2 da1 b f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(strcmp(f.blocks{1}.tags{1}.features{1}.open_data.name, daName4));
 end

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -14,6 +14,8 @@ function funcs = testFile
     funcs{end+1} = @test_open_block;
     funcs{end+1} = @test_delete_block;
     funcs{end+1} = @test_delete_section;
+    funcs{end+1} = @test_has_block;
+    funcs{end+1} = @test_has_section;
 
 end
 
@@ -128,4 +130,36 @@ function [] = test_open_block( varargin )
     %-- test open non existing block
     getBlock = test_file.openBlock('I dont exist');
     assert(isempty(getBlock));
+end
+
+%% Test: nix.File has nix.Block by ID or name
+function [] = test_has_block( varargin )
+    fileName = 'testRW.h5';
+    blockName = 'hasBlockTest';
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock(blockName, 'nixBlock');
+    bID = b.id;
+
+    assert(~f.hasBlock('I do not exist'));
+    assert(f.hasBlock(blockName));
+
+    clear b f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(f.hasBlock(bID));
+end
+
+%% Test: nix.File has nix.Section by ID or name
+function [] = test_has_section( varargin )
+    fileName = 'testRW.h5';
+    secName = 'hasSectionTest';
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    s = f.createSection(secName, 'nixSection');
+    sID = s.id;
+
+    assert(~f.hasSection('I do not exist'));
+    assert(f.hasSection(secName));
+
+    clear s f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(f.hasSection(sID));
 end

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -7,6 +7,7 @@ function funcs = testSource
     funcs{end+1} = @test_delete_source;
     funcs{end+1} = @test_attrs;
     funcs{end+1} = @test_fetch_sources;
+    funcs{end+1} = @test_has_source;
     funcs{end+1} = @test_open_source;
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
@@ -119,4 +120,22 @@ function [] = test_attrs( varargin )
 
     s.definition = '';
     assert(isempty(s.definition));
+end
+
+%% Test: nix.Source has nix.Source by ID or name
+function [] = test_has_source( varargin )
+    fileName = 'testRW.h5';
+    sName = 'nestedsource';
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock('testblock', 'nixBlock');
+    s = b.create_source('sourcetest', 'nixSource');
+    nested = s.create_source(sName, 'nixSource');
+    nestedID = nested.id;
+
+    assert(~s.has_source('I do not exist'));
+    assert(s.has_source(sName));
+
+    clear nested s b f;
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
+    assert(f.blocks{1}.sources{1}.has_source(nestedID));
 end


### PR DESCRIPTION
- Checked all available functions in the current nix master branch and added most of the functions that where still missing in the bindings.
- Block: added hasDataArray and hasSource.
- Feature: added get- and setLinkType, setData.
- File: added hasBlock and hasSection.
- MultiTag: added hasFeature, hasReference, setUnits, setExtents.
- Source: added hasSource.
- Tag: added hasFeature, hasReference, setPosition, setExtent.
- Included new or rewrote existing tests for all of the implemented functions.
- All implemented features are successfully tested under win32 (Matlab R2011a), win64 (Matlab R2011a) and Ubuntu 14.04 (Matlab R2013b).