### PR TITLE
Fix Tag/MultiTag units bug

### DIFF
--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -22,15 +22,21 @@ classdef Dynamic
                       prop, class(obj)));
                     throwAsCaller(ME);
                 end
-                
+
                 if (isempty(val))
                     nix_mx(strcat(obj.alias, '::set_none_', prop), obj.nix_handle, 0);
+                elseif(strcmp(prop, 'units') && (~iscell(val)))
+                %-- BUGFIX: Matlab crashes, if units in Tags and MultiTags 
+                %-- are set using anything else than a cell.
+                    ME = MException('MATLAB:class:SetProhibited', sprintf(...
+                      'Units can be only set by using cells.'));
+                    throwAsCaller(ME);
                 else
                     nix_mx(strcat(obj.alias, '::set_', prop), obj.nix_handle, val);
                 end
                 obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
             end
-            
+
             function val = get_method(obj)
                 val = obj.info.(prop);
             end

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -416,6 +416,17 @@ function [] = test_set_units( varargin )
     t = b.create_multi_tag('unitsTest', 'nixMultiTag', da);
 
     assert(isempty(t.units));
+    try
+        t.units = 'mV';
+    catch ME
+        assert(strcmp(ME.identifier, 'MATLAB:class:SetProhibited'));
+    end;
+    try
+        t.units = ['mV', 'uA'];
+    catch ME
+        assert(strcmp(ME.identifier, 'MATLAB:class:SetProhibited'));
+    end;
+
     units = {'mV'};
     t.units = {'mV'};
     assert(isequal(t.units,units));

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -316,6 +316,17 @@ function [] = test_attrs( varargin )
     assert(isempty(t1.definition));
 
     assert(isempty(t1.units));
+    try
+        t1.units = 'mV';
+    catch ME
+        assert(strcmp(ME.identifier, 'MATLAB:class:SetProhibited'));
+    end;
+    try
+        t1.units = ['mV', 'uA'];
+    catch ME
+        assert(strcmp(ME.identifier, 'MATLAB:class:SetProhibited'));
+    end;
+
     t1.units = {'ms', 'mV'};
     assert(isequal(t1.units, {'ms', 'mV'}));
 


### PR DESCRIPTION
When trying to set Tag or MultiTag units using anything else than a cell array, Matlab crashes.

- Added a check to make sure only cell arrays can be used to set Tag and MultiTag units.
- Successfully tested under win32 (Matlab R2011a), win64 (Matlab R2011a) and Ubuntu 14.04 (Matlab R2013b).

Fixes #98.