### PR TITLE
Fix data type errors

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -53,18 +53,28 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 'Block::openDataArray', id_or_name, @nix.DataArray);
         end;
         
-        %-- As "datatype" provide one of the nix.DataTypes. Alternatively
-        %-- a string stating one of the datatypes supported by nix can be provided.
         function da = create_data_array(obj, name, nixtype, datatype, shape)
-            handle = nix_mx('Block::createDataArray', obj.nix_handle, ...
-                name, nixtype, datatype, shape);
-            da = nix.DataArray(handle);
-            obj.dataArraysCache.lastUpdate = 0;
+            if(~isa(datatype, 'nix.DataType'))
+                error('Please provide a valid nix.DataType');
+            else
+                handle = nix_mx('Block::createDataArray', obj.nix_handle, ...
+                    name, nixtype, lower(datatype.char), shape);
+                da = nix.DataArray(handle);
+                obj.dataArraysCache.lastUpdate = 0;
+            end;
         end
         
         function da = create_data_array_from_data(obj, name, nixtype, data)
             shape = size(data);
-            dtype = class(data);
+            if(ischar(data))
+                dtype = nix.DataType.String;
+            elseif(islogical(data))
+                dtype = nix.DataType.Bool;
+            elseif(isnumeric(data))
+                dtype = nix.DataType.Double;
+            else
+                error('Could not determine DataType of data');
+            end;
             
             da = obj.create_data_array(name, nixtype, dtype, shape);
             da.write_all(data);

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -155,7 +155,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 'Block::openMultiTag', id_or_name, @nix.MultiTag);
         end;
 
-        %-- creating a multitag requires an already existing data array
+        %-- Creating a multitag requires an already existing data array
         function multitag = create_multi_tag(obj, name, type, add_data_array)
             if(strcmp(class(add_data_array), 'nix.DataArray'))
                 addID = add_data_array.id;

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -54,8 +54,13 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end;
         
         function da = create_data_array(obj, name, nixtype, datatype, shape)
+            errorStruct.identifier = 'Block:unsupportedDataType';
             if(~isa(datatype, 'nix.DataType'))
-                error('Please provide a valid nix.DataType');
+                errorStruct.message = 'Please provide a valid nix.DataType';
+                error(errorStruct);
+            elseif(isequal(datatype, nix.DataType.String))
+                errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
+                error(errorStruct);
             else
                 handle = nix_mx('Block::createDataArray', obj.nix_handle, ...
                     name, nixtype, lower(datatype.char), shape);
@@ -65,17 +70,20 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
         
         function da = create_data_array_from_data(obj, name, nixtype, data)
-            shape = size(data);
+            errorStruct.identifier = 'Block:unsupportedDataType';
             if(ischar(data))
-                dtype = nix.DataType.String;
+                errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
+                error(errorStruct);
             elseif(islogical(data))
                 dtype = nix.DataType.Bool;
             elseif(isnumeric(data))
                 dtype = nix.DataType.Double;
             else
-                error('Could not determine DataType of data');
+                errorStruct.message = 'DataType of provided data is not supported.';
+                error(errorStruct);
             end;
-            
+
+            shape = size(data);            
             da = obj.create_data_array(name, nixtype, dtype, shape);
             da.write_all(data);
         end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -89,17 +89,26 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end;
         
         %-- TODO add (optional) offset
+        %-- If a DataArray has been created as boolean or numeric,
+        %-- provide that only values of the proper DataType can be written.
         function write_all(obj, data)
-            %-- Bugifx: if a data array has been created as
-            %-- boolean or char, provide check that only logical or char
-            %-- values can be written, otherwise the
-            %-- error message from nix is too cryptic.
+            errorStruct.identifier = 'DataArray:improperDataType';
             if(islogical(obj.read_all) && ~islogical(data))
-                error(strcat('Trying to write', 32, class(data), ...
-                	' to a logical DataArray. Provide data as logical.'));
-            elseif(ischar(obj.read_all) && ~ischar(data))
-                error(strcat('Trying to write', 32, class(data), ...
-                	' to a char DataArray. Provide data as char.'));
+                errorStruct.message = strcat('Trying to write', ...
+                    32, class(data), ' to a logical DataArray.');
+                error(errorStruct);
+            elseif(isnumeric(obj.read_all) && ~isnumeric(data))
+                errorStruct.message = strcat('Trying to write', ...
+                    32, class(data), ' to a ', 32, class(obj.read_all), ...
+                    ' DataArray.');
+                error(errorStruct);
+            elseif(ischar(data))
+                %-- Should actually not be reachable at the moment, 
+                %-- since writing Strings to DataArrays is not supported,
+                %-- but safety first.
+                errorStruct.identifier = 'DataArray:unsupportedDataType';
+                errorStruct.message = ('Writing char/string DataArrays is not supported as of yet.');
+                error(errorStruct);
             else
                 % data must agree with file & dimensions
                 % see mkarray.cc(42)

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -88,11 +88,24 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
            data = permute(tmp, length(size(tmp)):-1:1);
         end;
         
-        function write_all(obj, data)  % TODO add (optional) offset
-           % data must agree with file & dimensions
-           % see mkarray.cc(42)
-           tmp = permute(data, length(size(data)):-1:1);
-           nix_mx('DataArray::writeAll', obj.nix_handle, tmp);
+        %-- TODO add (optional) offset
+        function write_all(obj, data)
+            %-- Bugifx: if a data array has been created as
+            %-- boolean or char, provide check that only logical or char
+            %-- values can be written, otherwise the
+            %-- error message from nix is too cryptic.
+            if(islogical(obj.read_all) && ~islogical(data))
+                error(strcat('Trying to write', 32, class(data), ...
+                	' to a logical DataArray. Provide data as logical.'));
+            elseif(ischar(obj.read_all) && ~ischar(data))
+                error(strcat('Trying to write', 32, class(data), ...
+                	' to a char DataArray. Provide data as char.'));
+            else
+                % data must agree with file & dimensions
+                % see mkarray.cc(42)
+                tmp = permute(data, length(size(data)):-1:1);
+                nix_mx('DataArray::writeAll', obj.nix_handle, tmp);
+            end;
         end;
 
     end;

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -92,6 +92,10 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         %-- If a DataArray has been created as boolean or numeric,
         %-- provide that only values of the proper DataType can be written.
         function write_all(obj, data)
+            if(isinteger(obj.read_all) && isfloat(data))
+                disp('Warning: Writing Float data to an Integer DataArray');
+            end;
+            
             errorStruct.identifier = 'DataArray:improperDataType';
             if(islogical(obj.read_all) && ~islogical(data))
                 errorStruct.message = strcat('Trying to write', ...

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -94,6 +94,6 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
            tmp = permute(data, length(size(data)):-1:1);
            nix_mx('DataArray::writeAll', obj.nix_handle, tmp);
         end;
-        
+
     end;
 end

--- a/+nix/DataType.m
+++ b/+nix/DataType.m
@@ -5,8 +5,6 @@ classdef DataType
         Bool;
         String;
         Double;
-        %-- remove
-        Char;
         Float;
         Int8;
         Int16;

--- a/+nix/DataType.m
+++ b/+nix/DataType.m
@@ -5,6 +5,7 @@ classdef DataType
         Bool;
         String;
         Double;
+        %-- remove
         Char;
         Float;
         Int8;

--- a/+nix/DataType.m
+++ b/+nix/DataType.m
@@ -1,20 +1,21 @@
 classdef DataType
-    %DATATYPE datatypes supported by nix
+    % DataTypes supported by nix.
 
-    properties (Constant)
-        Boolean = 'bool';
-        String = 'string';
-        Double = 'double';
-        Char = 'char';
-        Float = 'float';
-        Int8 = 'int8';
-        Int16 = 'int16';
-        Int32 = 'int32';
-        Int64 = 'int64';
-        UInt8 = 'uint8';
-        UInt16 = 'uint16';
-        UInt32 = 'uint32';
-        UInt64 = 'uint64';
+    enumeration
+        Bool;
+        String;
+        Double;
+        Char;
+        Float;
+        Int8;
+        Int16;
+        Int32;
+        Int64;
+        UInt8;
+        UInt16;
+        UInt32;
+        UInt64;
     end
-
+    
 end
+

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -130,5 +130,5 @@ classdef Section < nix.NamedEntity
             end
         end;
 
-    end
+    end;
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -87,12 +87,14 @@ classdef Section < nix.NamedEntity
         % Property methods
         % ----------------
 
-        %-- As "datatype" provide one of the nix.DataTypes. Alternatively
-        %-- a string stating one of the datatypes supported by nix can be provided.
         function p = create_property(obj, name, datatype)
-            p = nix.Property(nix_mx('Section::createProperty', ...
-                obj.nix_handle, name, datatype));
-            obj.propsCache.lastUpdate = 0;
+            if(~isa(datatype, 'nix.DataType'))
+                error('Please provide a valid nix.DataType');
+            else
+                p = nix.Property(nix_mx('Section::createProperty', ...
+                    obj.nix_handle, name, lower(datatype.char)));
+                obj.propsCache.lastUpdate = 0;
+            end;
         end;
 
         function p = create_property_with_value(obj, name, val)

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -43,22 +43,29 @@ namespace nixdataarray {
     void read_all(const extractor &input, infusor &output)
     {
         //nix::DataArray da = input.entity<nix::DataArray>(1);
-
+        mexPrintf("[PURGE_ME] DA.cc read_all 01\n");
         nix::DataArray da = input.entity<nix::DataArray>(1);
+        mexPrintf("[PURGE_ME] DA.cc read_all 02\n");
         mxArray *data = make_mx_array_from_ds(da);
+        mexPrintf("[PURGE_ME] DA.cc read_all 03\n");
         output.set(0, data);
     }
 
     void write_all(const extractor &input, infusor &output)
     {
+        mexPrintf("[PURGE_ME] DA.cc write_all 01\n");
         nix::DataArray da = input.entity<nix::DataArray>(1);
-
+        mexPrintf("[PURGE_ME] DA.cc write_all 02\n");
         nix::DataType dtype = input.dtype(2);
+        mexPrintf("[PURGE_ME] DA.cc write_all 03\n");
         nix::NDSize count = input.ndsize(2);
+        mexPrintf("[PURGE_ME] DA.cc write_all 04\n");
         nix::NDSize offset(0);
+        mexPrintf("[PURGE_ME] DA.cc write_all 05\n");
         double *ptr = input.get_raw(2);
-
+        mexPrintf("[PURGE_ME] DA.cc write_all 06\n");
         da.setData(dtype, ptr, count, offset);
+        mexPrintf("[PURGE_ME] DA.cc write_all 07\n");
     }
 
     void delete_dimension(const extractor &input, infusor &output) {

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -42,30 +42,29 @@ namespace nixdataarray {
 
     void read_all(const extractor &input, infusor &output)
     {
-        //nix::DataArray da = input.entity<nix::DataArray>(1);
-        mexPrintf("[PURGE_ME] DA.cc read_all 01\n");
         nix::DataArray da = input.entity<nix::DataArray>(1);
-        mexPrintf("[PURGE_ME] DA.cc read_all 02\n");
         mxArray *data = make_mx_array_from_ds(da);
-        mexPrintf("[PURGE_ME] DA.cc read_all 03\n");
         output.set(0, data);
     }
 
     void write_all(const extractor &input, infusor &output)
     {
-        mexPrintf("[PURGE_ME] DA.cc write_all 01\n");
         nix::DataArray da = input.entity<nix::DataArray>(1);
-        mexPrintf("[PURGE_ME] DA.cc write_all 02\n");
         nix::DataType dtype = input.dtype(2);
-        mexPrintf("[PURGE_ME] DA.cc write_all 03\n");
+
         nix::NDSize count = input.ndsize(2);
-        mexPrintf("[PURGE_ME] DA.cc write_all 04\n");
         nix::NDSize offset(0);
-        mexPrintf("[PURGE_ME] DA.cc write_all 05\n");
         double *ptr = input.get_raw(2);
-        mexPrintf("[PURGE_ME] DA.cc write_all 06\n");
-        da.setData(dtype, ptr, count, offset);
-        mexPrintf("[PURGE_ME] DA.cc write_all 07\n");
+        
+        if (dtype == nix::DataType::String)
+        {
+            //da.setData(ptr);
+            throw std::domain_error("Writing strings is not supported as of yet.");
+        }
+        else
+        {
+            da.setData(dtype, ptr, count, offset);
+        }
     }
 
     void delete_dimension(const extractor &input, infusor &output) {

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -56,13 +56,9 @@ namespace nixdataarray {
         nix::NDSize offset(0);
         double *ptr = input.get_raw(2);
         
-        if (dtype == nix::DataType::String)
-        {
-            //da.setData(ptr);
-            throw std::domain_error("Writing strings is not supported as of yet.");
-        }
-        else
-        {
+        if (dtype == nix::DataType::String) {
+            throw std::domain_error("Writing Strings to DataArrays is not supported as of yet.");
+        } else {
             da.setData(dtype, ptr, count, offset);
         }
     }

--- a/src/utils/mkarray.cc
+++ b/src/utils/mkarray.cc
@@ -22,14 +22,9 @@ mxArray* make_mx_array_from_ds(const nix::DataSet &da) {
     }
 
     mxArray *data;
-    if (dtype.cid == mxCHAR_CLASS)
-    {
-        data = mxCreateCharArray(dims.size(), dims.data());
-//        double *ptr = mxGetPr(data);
-//        da.getData(ptr);
-    }
-    else
-    {
+    if (dtype.cid == mxCHAR_CLASS) {
+        throw std::domain_error("String DataArrays are not supported as of yet.");
+    } else {
         data = mxCreateNumericArray(dims.size(), dims.data(), dtype.cid, dtype.clx);
         double *ptr = mxGetPr(data);
         nix::NDSize offset(size.size(), 0);

--- a/src/utils/mkarray.cc
+++ b/src/utils/mkarray.cc
@@ -3,13 +3,9 @@
 #include <nix.hpp>
 
 mxArray* make_mx_array_from_ds(const nix::DataSet &da) {
-    mexPrintf("[PURGE_ME] mkArray.cc 01\n");
     nix::NDSize size = da.dataExtent();
-    mexPrintf("[PURGE_ME] mkArray.cc 02\n");
     const size_t len = size.size();
-    mexPrintf("[PURGE_ME] mkArray.cc 03\n");
     std::vector<mwSize> dims(len);
-    mexPrintf("[PURGE_ME] mkArray.cc 03\n");
 
     //NB: matlab is column-major, while HDF5 is row-major
     //    data is correct with this, but dimensions don't
@@ -18,26 +14,27 @@ mxArray* make_mx_array_from_ds(const nix::DataSet &da) {
     for (size_t i = 0; i < len; i++) {
         dims[len - (i + 1)] = static_cast<mwSize>(size[i]);
     }
-    mexPrintf("[PURGE_ME] mkArray.cc 04\n");
     nix::DataType da_type = da.dataType();
-    mexPrintf("[PURGE_ME] mkArray.cc 05\n");
     DType2 dtype = dtype_nix2mex(da_type);
-    mexPrintf("[PURGE_ME] mkArray.cc 06\n");
 
     if (!dtype.is_valid) {
-        mexPrintf("[PURGE_ME] mkArray.cc 07\n");
         throw std::domain_error("Unsupported data type");
     }
 
-    mexPrintf("[PURGE_ME] mkArray.cc 08\n");
-    mxArray *data = mxCreateNumericArray(dims.size(), dims.data(), dtype.cid, dtype.clx);
-    mexPrintf("[PURGE_ME] mkArray.cc 09\n");
-    double *ptr = mxGetPr(data);
-    mexPrintf("[PURGE_ME] mkArray.cc 10\n");
-    nix::NDSize offset(size.size(), 0);
-    mexPrintf("[PURGE_ME] mkArray.cc 11\n");
-    da.getData(da_type, ptr, size, offset);
-    mexPrintf("[PURGE_ME] mkArray.cc 12\n");
+    mxArray *data;
+    if (dtype.cid == mxCHAR_CLASS)
+    {
+        data = mxCreateCharArray(dims.size(), dims.data());
+//        double *ptr = mxGetPr(data);
+//        da.getData(ptr);
+    }
+    else
+    {
+        data = mxCreateNumericArray(dims.size(), dims.data(), dtype.cid, dtype.clx);
+        double *ptr = mxGetPr(data);
+        nix::NDSize offset(size.size(), 0);
+        da.getData(da_type, ptr, size, offset);
+    }
 
     return data;
 }
@@ -105,4 +102,3 @@ mxArray* make_mx_array(const nix::Value &v)
 	return res;
 
 }
-

--- a/src/utils/mkarray.cc
+++ b/src/utils/mkarray.cc
@@ -3,9 +3,13 @@
 #include <nix.hpp>
 
 mxArray* make_mx_array_from_ds(const nix::DataSet &da) {
+    mexPrintf("[PURGE_ME] mkArray.cc 01\n");
     nix::NDSize size = da.dataExtent();
+    mexPrintf("[PURGE_ME] mkArray.cc 02\n");
     const size_t len = size.size();
+    mexPrintf("[PURGE_ME] mkArray.cc 03\n");
     std::vector<mwSize> dims(len);
+    mexPrintf("[PURGE_ME] mkArray.cc 03\n");
 
     //NB: matlab is column-major, while HDF5 is row-major
     //    data is correct with this, but dimensions don't
@@ -14,19 +18,26 @@ mxArray* make_mx_array_from_ds(const nix::DataSet &da) {
     for (size_t i = 0; i < len; i++) {
         dims[len - (i + 1)] = static_cast<mwSize>(size[i]);
     }
-
+    mexPrintf("[PURGE_ME] mkArray.cc 04\n");
     nix::DataType da_type = da.dataType();
+    mexPrintf("[PURGE_ME] mkArray.cc 05\n");
     DType2 dtype = dtype_nix2mex(da_type);
+    mexPrintf("[PURGE_ME] mkArray.cc 06\n");
 
     if (!dtype.is_valid) {
+        mexPrintf("[PURGE_ME] mkArray.cc 07\n");
         throw std::domain_error("Unsupported data type");
     }
 
+    mexPrintf("[PURGE_ME] mkArray.cc 08\n");
     mxArray *data = mxCreateNumericArray(dims.size(), dims.data(), dtype.cid, dtype.clx);
+    mexPrintf("[PURGE_ME] mkArray.cc 09\n");
     double *ptr = mxGetPr(data);
-
+    mexPrintf("[PURGE_ME] mkArray.cc 10\n");
     nix::NDSize offset(size.size(), 0);
+    mexPrintf("[PURGE_ME] mkArray.cc 11\n");
     da.getData(da_type, ptr, size, offset);
+    mexPrintf("[PURGE_ME] mkArray.cc 12\n");
 
     return data;
 }

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -69,26 +69,35 @@ function [] = test_create_data_array( varargin )
     tmp = da.read_all();
     assert(all(tmp(:) == 0));
 
-    %-- TODO: add tests for all provided data types
     try
-        stringName = 'stringDataArray';
-        b.create_data_array(stringName, dtype, nix.DataType.String, [1 5]);
+        b.create_data_array('stringDataArray', dtype, nix.DataType.String, [1 5]);
     catch ME
         assert(strcmp(ME.identifier, 'Block:unsupportedDataType'));
     end;
     
     try
-        unsupportedName = 'I will crash and burn';
-        b.create_data_array(unsupportedName, dtype, 'Thou shalt not work!', [1 5]);
+        b.create_data_array('I will crash and burn', dtype, 'Thou shalt not work!', [1 5]);
     catch ME
         assert(strcmp(ME.identifier, 'Block:unsupportedDataType'));
     end;
 
-    assert(~isempty(b.dataArrays));
+    da = b.create_data_array('floatDataArray', dtype, nix.DataType.Float, [3 3]);
+    da = b.create_data_array('Int8DataArray', dtype, nix.DataType.Int8, [3 3]);
+    da = b.create_data_array('Int16DataArray', dtype, nix.DataType.Int16, [3 3]);
+    da = b.create_data_array('Int32DataArray', dtype, nix.DataType.Int32, [3 3]);
+    da = b.create_data_array('Int64DataArray', dtype, nix.DataType.Int64, [3 3]);
+    da = b.create_data_array('UInt8DataArray', dtype, nix.DataType.UInt8, [3 3]);
+    da = b.create_data_array('UInt16DataArray', dtype, nix.DataType.UInt16, [3 3]);
+    da = b.create_data_array('UInt32DataArray', dtype, nix.DataType.UInt32, [3 3]);
+    da = b.create_data_array('UInt64DataArray', dtype, nix.DataType.UInt64, [3 3]);
+    da = b.create_data_array('logicalArray', dtype, nix.DataType.Bool, [3 3]);
+    
+    clear da b f;
+    f = nix.File(fileName, nix.FileMode.ReadOnly);
+    assert(size(f.blocks{1}.dataArrays, 1) == 11);
 end
 
 %% Test: Create Data Array from data
-%-- TODO add tests for all supported datatypes
 function [] = test_create_data_array_from_data( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -60,7 +60,7 @@ function [] = test_create_data_array( varargin )
     
     assert(isempty(b.dataArrays));
     
-    d1 = b.create_data_array('foo', 'bar', 'double', [2 3]);
+    d1 = b.create_data_array('foo', 'bar', nix.DataType.Double, [2 3]);
 
     assert(strcmp(d1.name, 'foo'));
     assert(strcmp(d1.type, 'bar'));
@@ -95,7 +95,7 @@ end
 function [] = test_delete_data_array( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixBlock');
-    tmp = b.create_data_array('dataArrayTest1', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('dataArrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('dataArrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     assert(size(b.dataArrays, 1) == 2);
@@ -143,8 +143,8 @@ function [] = test_create_multi_tag( varargin )
 %% Test: Create multitag by data_array entity and data_array id
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     assert(isempty(b.multiTags));
 
     %-- create by data_array entity
@@ -162,7 +162,7 @@ end
 function [] = test_delete_multi_tag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
     tmp = b.create_multi_tag('mTagTest2', 'nixMultiTag2', b.dataArrays{1});
 
@@ -210,8 +210,8 @@ function [] = test_list_arrays( varargin )
     b = f.createBlock('arraytest', 'nixBlock');
 
     assert(isempty(b.dataArrays));
-    tmp = b.create_data_array('arrayTest1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('arrayTest2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array('arrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array('arrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     assert(size(b.dataArrays, 1) == 2);
 
 end
@@ -243,7 +243,7 @@ function [] = test_list_multitags( varargin )
 %% Test: fetch multitags
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(b.multiTags));
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
@@ -258,7 +258,7 @@ function [] = test_open_array( varargin )
     daName = 'arrayTest1';
     
     assert(isempty(b.dataArrays));
-    tmp = b.create_data_array(daName, 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
 
     getDataArrayByID = b.data_array(b.dataArrays{1,1}.id);
     assert(~isempty(getDataArrayByID));
@@ -294,7 +294,7 @@ function [] = test_open_multitag( varargin )
 %% Test: Open multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTagName = 'mTagTest1';
     tmp = b.create_multi_tag(mTagName, 'nixMultiTag', b.dataArrays{1});
 
@@ -331,7 +331,7 @@ function [] = test_has_multitag( varargin )
 %% Test: Block has multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
 
     assert(b.has_multi_tag(b.multiTags{1,1}.id));
@@ -384,7 +384,7 @@ function [] = test_has_data_array( varargin )
     daName = 'hasDataArrayTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     daID = da.id;
     
     assert(~b.has_data_array('I do not exist'));

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -8,7 +8,10 @@ function funcs = TestDataArray
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
     funcs{end+1} = @test_list_sources;
-    funcs{end+1} = @test_write_data;
+    funcs{end+1} = @test_write_data_double;
+    funcs{end+1} = @test_write_data_logical;
+    funcs{end+1} = @test_write_data_float;
+    funcs{end+1} = @test_write_data_integer;
     funcs{end+1} = @test_add_source;
     funcs{end+1} = @test_remove_source;
     funcs{end+1} = @test_dimensions;
@@ -52,11 +55,33 @@ end
 
 %% Test: Read all data from DataArray
 function [] = test_open_data( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
-    getBlock = test_file.openBlock(test_file.blocks{1,1}.name);
-    getDataArray = getBlock.data_array(getBlock.dataArrays{1,1}.id);
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    daType = 'nix.DataArray';
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.createBlock('testBlock', 'nix.Block');
 
-    assert(size(getDataArray.read_all(),2) == 36);
+    da = b.create_data_array('logicalArray', daType, nix.DataType.Bool, [3 3]);
+    assert(islogical(da.read_all));
+    da = b.create_data_array('doubleDataArray', daType, nix.DataType.Double, [3 3]);
+    assert(isa(da.read_all, 'double'));
+    da = b.create_data_array('floatDataArray', daType, nix.DataType.Float, [3 3]);
+    assert(isfloat(da.read_all));
+    da = b.create_data_array('Int8DataArray', daType, nix.DataType.Int8, [3 3]);
+    assert(isa(da.read_all, 'int8'));
+    da = b.create_data_array('Int16DataArray', daType, nix.DataType.Int16, [3 3]);
+    assert(isa(da.read_all, 'int16'));
+    da = b.create_data_array('Int32DataArray', daType, nix.DataType.Int32, [3 3]);
+    assert(isa(da.read_all, 'int32'));
+    da = b.create_data_array('Int64DataArray', daType, nix.DataType.Int64, [3 3]);
+    assert(isa(da.read_all, 'int64'));
+    da = b.create_data_array('UInt8DataArray', daType, nix.DataType.UInt8, [3 3]);
+    assert(isa(da.read_all, 'uint8'));
+    da = b.create_data_array('UInt16DataArray', daType, nix.DataType.UInt16, [3 3]);
+    assert(isa(da.read_all, 'uint16'));
+    da = b.create_data_array('UInt32DataArray', daType, nix.DataType.UInt32, [3 3]);
+    assert(isa(da.read_all, 'uint32'));
+    da = b.create_data_array('UInt64DataArray', daType, nix.DataType.UInt64, [3 3]);
+    assert(isa(da.read_all, 'uint64'));
 end
 
 %% Test: Set metadata
@@ -97,13 +122,12 @@ function [] = test_list_sources( varargin )
     assert(strcmp(d1.sources{1}.name, 'Unit 5'));
 end
 
-%% Test: Write Data
-%-- TODO: add tests for all provided data types
-function [] = test_write_data( varargin )
+%% Test: Write Data double
+function [] = test_write_data_double( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'nixblock');
+    b = f.createBlock('testDataArray', 'nixblock');
 
     numData = [1 2 3 4 5];
     logData = logical([1 0 1 0 1]);
@@ -111,9 +135,6 @@ function [] = test_write_data( varargin )
     cellData = {1 2 3 4 5};
     
     da = b.create_data_array('numericArray', typeDA, nix.DataType.Double, [1 5]);
-    tmp = da.read_all();
-    assert(all(tmp(:) == 0));
-
     da.write_all(numData);
     assert(isequal(da.read_all(), numData));
 
@@ -133,6 +154,22 @@ function [] = test_write_data( varargin )
         assert(strcmp(ME.identifier, 'DataArray:improperDataType'));
     end;
 
+    clear da b f;
+    f = nix.File(fileName, nix.FileMode.ReadOnly);
+    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, numData));
+end
+
+%% Test: Write Data logical
+function [] = test_write_data_logical( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    typeDA = 'nix.DataArray';
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.createBlock('testDataArray', 'nixblock');
+
+    logData = logical([1 0 1 0 1]);
+    numData = [1 2 3 4 5];
+    charData = ['a' 'b' 'c' 'd' 'e'];
+    
     da = b.create_data_array('logicalArray', typeDA, nix.DataType.Bool, [1 5]);
     da.write_all(logData);
     assert(isequal(da.read_all, logData));
@@ -149,8 +186,71 @@ function [] = test_write_data( varargin )
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
+    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, logData));
+end
+
+%% Test: Write Data float
+function [] = test_write_data_float( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    typeDA = 'nix.DataArray';
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.createBlock('testDataArray', 'nixblock');
+
+    numData = [1.3 2.4143 3.9878 4.1239 5];
+    
+    da = b.create_data_array('floatArray', typeDA, nix.DataType.Float, [1 5]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, single(numData)));
+
+    clear da b f;
+    f = nix.File(fileName, nix.FileMode.ReadOnly);
+    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, single(numData)));
+end
+
+%% Test: Write Data integer
+function [] = test_write_data_integer( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    typeDA = 'nix.DataArray';
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.createBlock('testDataArray', 'nixblock');
+
+    numData = [1 2 3; 4 5 6; 7 8 9];
+    
+    da = b.create_data_array('Int8DataArray', typeDA, nix.DataType.Int8, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('Int16DataArray', typeDA, nix.DataType.Int16, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('Int32DataArray', typeDA, nix.DataType.Int32, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('Int64DataArray', typeDA, nix.DataType.Int64, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('UInt8DataArray', typeDA, nix.DataType.UInt8, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('UInt16DataArray', typeDA, nix.DataType.UInt16, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('UInt32DataArray', typeDA, nix.DataType.UInt32, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+    da = b.create_data_array('UInt64DataArray', typeDA, nix.DataType.UInt64, [3 3]);
+    da.write_all(numData);
+    assert(isequal(da.read_all, numData));
+
+    clear da b f;
+    f = nix.File(fileName, nix.FileMode.ReadOnly);
     assert(isequal(f.blocks{1}.dataArrays{1}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{2}.read_all, logData));
+    assert(isequal(f.blocks{1}.dataArrays{2}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{3}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{4}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{5}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{6}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{7}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{8}.read_all, numData));
 end
 
 %% Test: Add sources by entity and id

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -18,7 +18,7 @@ function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', 'double', [1 2]);
+    da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(~isempty(da.id));
     assert(strcmp(da.name, 'daTest'));
@@ -65,7 +65,7 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection('testSection1', 'nixSection');
     tmp = f.createSection('testSection2', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(da.open_metadata));
     da.set_metadata(f.sections{1});
@@ -81,7 +81,7 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     da.set_metadata(f.sections{1});
 
     assert(strcmp(da.open_metadata.name, 'testSection'));
@@ -102,7 +102,7 @@ function [] = test_set_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixblock');
 
-    d1 = b.create_data_array('foo', 'bar', 'double', [2 3]);
+    d1 = b.create_data_array('foo', 'bar', nix.DataType.Double, [2 3]);
     tmp = d1.read_all();
     assert(all(tmp(:) == 0));
     
@@ -118,7 +118,7 @@ function [] = test_add_source ( varargin )
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
-    getDataArray = b.create_data_array('sourceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    getDataArray = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(getDataArray.sources));
     getDataArray.add_source(getSource.sources{1}.id);
@@ -133,7 +133,7 @@ function [] = test_remove_source ( varargin )
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
-    getDataArray = b.create_data_array('sourceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    getDataArray = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     getDataArray.add_source(getSource.sources{1}.id);
     getDataArray.add_source(getSource.sources{2});
@@ -150,7 +150,7 @@ end
 function [] = test_dimensions( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', 'double', [1 2]);
+    da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(isempty(da.dimensions));
     

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -12,7 +12,8 @@ function [] = test_set_dimension( varargin )
 %% Test: set dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(...
+        'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_set_dimension();
 
     assert(strcmp(d1.dimensionType, 'set'));
@@ -31,7 +32,8 @@ function [] = test_sample_dimension( varargin )
 %% Test: sampled dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(...
+        'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_sampled_dimension(200);
 
     assert(strcmp(d1.dimensionType, 'sample'));
@@ -64,7 +66,8 @@ function [] = test_range_dimension( varargin )
 %% Test: range dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(...
+        'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     ticks = [1 2 3 4];
     d1 = da.append_range_dimension(ticks);
 

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -12,7 +12,7 @@ end
 function [] = test_open_data ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getTag = b.create_tag('featureTest', 'nixTag', [1, 2]);
     tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     
@@ -25,7 +25,7 @@ function [] = test_get_set_link_type ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_tag('featureTest', 'nixTag', [1, 2]);
     feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     
@@ -67,10 +67,10 @@ function [] = test_set_data ( varargin )
     daData = [1 2 3 4 5 6];
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da1 = b.create_data_array(daName1, daType, 'double', daData);
-    da2 = b.create_data_array(daName2, daType, 'double', daData);
-    da3 = b.create_data_array(daName3, daType, 'double', daData);
-    da4 = b.create_data_array(daName4, daType, 'double', daData);
+    da1 = b.create_data_array(daName1, daType, nix.DataType.Double, daData);
+    da2 = b.create_data_array(daName2, daType, nix.DataType.Double, daData);
+    da3 = b.create_data_array(daName3, daType, nix.DataType.Double, daData);
+    da4 = b.create_data_array(daName4, daType, nix.DataType.Double, daData);
     t = b.create_tag('featureTest', 'nixTag', [1, 2]);
     feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -59,7 +59,7 @@ function [] = test_add_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array(daName, daType, 'double', [2 3]);
+    da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
     g = b.create_group('testGroup', 'nixGroup');
 
     assert(isempty(g.dataArrays));
@@ -80,7 +80,7 @@ function [] = test_get_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array(daName, daType, 'double', [2 3]);
+    da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
     daID = da.id;
     g = b.create_group('testGroup', 'nixGroup');
     g.add_data_array(da);
@@ -105,9 +105,9 @@ function [] = test_remove_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da1 = b.create_data_array(daName1, daType, 'double', [1]);
-    da2 = b.create_data_array(daName2, daType, 'double', [2 3]);
-    da3 = b.create_data_array(daName3, daType, 'double', [4 5 6]);
+    da1 = b.create_data_array(daName1, daType, nix.DataType.Double, 1);
+    da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
+    da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
     g = b.create_group('testGroup', 'nixGroup');
     g.add_data_array(da1);
     g.add_data_array(da2);
@@ -141,9 +141,9 @@ function [] = test_update_linked_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da1 = b.create_data_array(daName1, daType, 'double', [1]);
-    da2 = b.create_data_array(daName2, daType, 'double', [2 3]);
-    da3 = b.create_data_array(daName3, daType, 'double', [4 5 6]);
+    da1 = b.create_data_array(daName1, daType, nix.DataType.Double, [1]);
+    da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
+    da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
     g = b.create_group('testGroup', 'nixGroup');
     g.add_data_array(da1);
     g.add_data_array(da2);
@@ -282,8 +282,10 @@ function [] = test_add_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array(...
+        'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array(...
+        'mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
     tmp = b.create_multi_tag(tagName2, tagType, b.dataArrays{2});
     g = b.create_group('testGroup', 'nixGroup');
@@ -310,8 +312,10 @@ function [] = test_has_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array(...
+        'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array(...
+        'mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
     tmp = b.create_multi_tag(tagName2, tagType, b.dataArrays{2});
     g = b.create_group('testGroup', 'nixGroup');
@@ -331,7 +335,8 @@ function [] = test_get_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array('mTagTestDataArray1', 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(...
+        'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag(tagName, tagType, b.dataArrays{1});
     g = b.create_group('testGroup', 'nixGroup');
 
@@ -355,7 +360,8 @@ function [] = test_remove_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array('mTagTestDataArray1', 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(...
+        'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t1 = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
     t2 = b.create_multi_tag(tagName2, tagType, b.dataArrays{1});
     t3 = b.create_multi_tag(tagName3, tagType, b.dataArrays{1});

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -32,7 +32,8 @@ end
 function [] = test_add_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array(...
+        'sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -48,7 +49,8 @@ end
 function [] = test_remove_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array(...
+        'sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -69,11 +71,14 @@ end
 function [] = test_add_reference ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array(...
+        'referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', 'double', [3 4]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', 'double', [5 6]);
+    tmp = b.create_data_array(...
+        'referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.create_data_array(...
+        'referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
 
     assert(isempty(getMTag.references));
     getMTag.add_reference(b.dataArrays{2}.id);
@@ -85,11 +90,14 @@ end
 function [] = test_remove_reference ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array(...
+        'referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', 'double', [3 4]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', 'double', [5 6]);
+    tmp = b.create_data_array(...
+        'referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.create_data_array(...
+        'referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
     getMTag.add_reference(b.dataArrays{2}.id);
     getMTag.add_reference(b.dataArrays{3});
 
@@ -105,15 +113,22 @@ end
 function [] = test_add_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array(...
+        'featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array('featTestDA1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('featTestDA2', 'nixDataArray', 'double', [3 4]);
-    tmp = b.create_data_array('featTestDA3', 'nixDataArray', 'double', [5 6]);
-    tmp = b.create_data_array('featTestDA4', 'nixDataArray', 'double', [7 8]);
-    tmp = b.create_data_array('featTestDA5', 'nixDataArray', 'double', [9 10]);
-    tmp = b.create_data_array('featTestDA6', 'nixDataArray', 'double', [11 12]);
+    tmp = b.create_data_array(...
+        'featTestDA1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array(...
+        'featTestDA2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.create_data_array(...
+        'featTestDA3', 'nixDataArray', nix.DataType.Double, [5 6]);
+    tmp = b.create_data_array(...
+        'featTestDA4', 'nixDataArray', nix.DataType.Double, [7 8]);
+    tmp = b.create_data_array(...
+        'featTestDA5', 'nixDataArray', nix.DataType.Double, [9 10]);
+    tmp = b.create_data_array(...
+        'featTestDA6', 'nixDataArray', nix.DataType.Double, [11 12]);
 
     assert(isempty(getMTag.features));
     tmp = getMTag.add_feature(b.dataArrays{2}.id, nix.LinkType.Tagged);
@@ -129,11 +144,14 @@ end
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-	tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+	tmp = b.create_data_array(...
+        'featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array('featTestDA1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('featTestDA2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array(...
+        'featTestDA1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array(...
+        'featTestDA2', 'nixDataArray', nix.DataType.Double, [3 4]);
 
     tmp = getMTag.add_feature(b.dataArrays{2}.id, nix.LinkType.Tagged);
     tmp = getMTag.add_feature(b.dataArrays{3}, nix.LinkType.Tagged);
@@ -150,10 +168,10 @@ end
 function [] = test_fetch_references( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', 'double', [3 4]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', 'double', [5 6]);
+    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
     getMTag.add_reference(b.dataArrays{2}.id);
     getMTag.add_reference(b.dataArrays{3});
 
@@ -164,7 +182,7 @@ end
 function [] = test_fetch_sources( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -179,11 +197,11 @@ end
 function [] = test_fetch_features( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
     assert(isempty(getMTag.features));
-    tmp = b.create_data_array('featTestDA', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = getMTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
     assert(size(getMTag.features, 1) == 1);
 end
@@ -192,7 +210,7 @@ end
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     sName = 'nestedSource';
     tmp = getSource.create_source(sName, 'nixSource');
@@ -214,10 +232,10 @@ end
 function [] = test_open_feature( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array('featTestDA', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = getMTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
     assert(~isempty(getMTag.open_feature(getMTag.features{1}.id)));
 
@@ -230,10 +248,10 @@ end
 function [] = test_open_reference( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     refName = 'referenceTest';
-    tmp = b.create_data_array(refName, 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
     getMTag.add_reference(b.dataArrays{2}.id);
 
     getRefByID = getMTag.open_reference(getMTag.references{1,1}.id);
@@ -251,11 +269,11 @@ end
 function [] = test_add_positions ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('positionsTest', 'nixBlock');
-    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', 'double', [0 1]);
-    tmp = b.create_data_array('positionsTest2', 'nixDataArray', 'double', [2 4]);
+    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
+    tmp = b.create_data_array('positionsTest2', 'nixDataArray', nix.DataType.Double, [2 4]);
 
     getMTag.add_positions(b.dataArrays{2}.id);
     assert(strcmp(getMTag.open_positions.name, 'positionsTest1'));
@@ -268,9 +286,9 @@ end
 function [] = test_has_positions( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('positionsTest', 'nixBlock');
-    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', 'double', [0 1]);
+    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
     getMTag.add_positions(b.dataArrays{2}.id);
     assert(getMTag.has_positions);
@@ -280,9 +298,9 @@ end
 function [] = test_open_positions( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('positionsTest', 'nixBlock');
-    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', 'double', [0 1]);
+    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
     getMTag.add_positions(b.dataArrays{2}.id);
     assert(~isempty(getMTag.open_positions));
@@ -293,16 +311,16 @@ function [] = test_set_open_extents ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('extentsTest', 'nixBlock');
-    da = b.create_data_array('extentsTestDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6; 1 2 3 4 5 6]);
+    da = b.create_data_array('extentsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6; 1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('extentstest', 'nixMultiTag', da);
 
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', 'double', [1, 1]);
-    tmp = b.create_data_array('positionsTest2', 'nixDataArray', 'double', [1, 3]);
+    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [1, 1]);
+    tmp = b.create_data_array('positionsTest2', 'nixDataArray', nix.DataType.Double, [1, 3]);
 
     extName1 = 'extentsTest1';
     extName2 = 'extentsTest2';
-    tmp = b.create_data_array(extName1, 'nixDataArray', 'double', [1, 1]);
-    tmp = b.create_data_array(extName2, 'nixDataArray', 'double', [1, 3]);
+    tmp = b.create_data_array(extName1, 'nixDataArray', nix.DataType.Double, [1, 1]);
+    tmp = b.create_data_array(extName2, 'nixDataArray', nix.DataType.Double, [1, 3]);
 
     assert(isempty(getMTag.open_extents));
     
@@ -327,7 +345,7 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection('testSection1', 'nixSection');
     tmp = f.createSection('testSection2', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('testDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
 
     assert(isempty(t.open_metadata));
@@ -344,7 +362,7 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('testDataArray', 'nixDataArray', 'double', [1 2 3 4 5 6]);
+    tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
     t.set_metadata(f.sections{1});
 
@@ -372,9 +390,9 @@ function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('featureTest', 'nixMultiTag', da);
-    daf = b.create_data_array('featTestDA', 'nixDataArray', 'double', [1 2]);
+    daf = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
     feature = t.add_feature(daf, nix.LinkType.Tagged);
     featureID = feature.id;
 
@@ -392,10 +410,10 @@ function [] = test_has_reference( varargin )
     daName = 'refTestDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTestBlock', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('referenceTest', 'nixMultiTag', da);
     refName = 'referenceTest';
-    daRef = b.create_data_array(refName, 'nixDataArray', 'double', [3 4]);
+    daRef = b.create_data_array(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
     t.add_reference(daRef.id);
 
     assert(~t.has_reference('I do not exist'));
@@ -412,7 +430,7 @@ function [] = test_set_units( varargin )
     daName = 'testDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('unitsTest', 'nixMultiTag', da);
 
     assert(isempty(t.units));

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -142,12 +142,9 @@ function [] = test_create_property( varargin )
     s = f.createSection('mainSection', 'nixSection');
 
     tmp = s.create_property('newProperty1', nix.DataType.Double);
-    tmp = s.create_property('newProperty2', nix.DataType.Boolean);
+    tmp = s.create_property('newProperty2', nix.DataType.Bool);
     tmp = s.create_property('newProperty3', nix.DataType.String);
-    tmp = s.create_property('newProperty4', 'double');
-    tmp = s.create_property('newProperty5', 'bool');
-    tmp = s.create_property('newProperty6', 'string');
-    assert(size(s.allProperties, 1) == 6);
+    assert(size(s.allProperties, 1) == 3);
     assert(strcmp(s.allProperties{1}.name, 'newProperty1'));
 end
 
@@ -222,7 +219,7 @@ function [] = test_delete_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
     tmp = s.create_property('newProperty1', nix.DataType.Double);
-    tmp = s.create_property('newProperty2', nix.DataType.Boolean);
+    tmp = s.create_property('newProperty2', nix.DataType.Bool);
     tmp = s.create_property('newProperty3', nix.DataType.String);
     tmp = s.create_property('newProperty4', nix.DataType.Double);
 

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -65,8 +65,8 @@ end
 function [] = test_add_reference ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     getBlock = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = getBlock.create_data_array('referenceTest1', 'nixDataArray', 'double', [1 2]);
-    tmp = getBlock.create_data_array('referenceTest2', 'nixDataArray', 'double', [3 4]);
+    tmp = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     position = [1.0 1.2 1.3 15.9];
     getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
@@ -81,8 +81,8 @@ end
 function [] = test_remove_reference ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     getBlock = test_file.createBlock('referenceTest', 'nixBlock');
-    getRefDA1 = getBlock.create_data_array('referenceTest1', 'nixDataArray', 'double', [1 2]);
-    getRefDA2 = getBlock.create_data_array('referenceTest2', 'nixDataArray', 'double', [3 4]);
+    getRefDA1 = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    getRefDA2 = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     position = [1.0 1.2 1.3 15.9];
     getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
@@ -102,12 +102,12 @@ end
 function [] = test_add_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', 'double', [3 4]);
-    tmp = b.create_data_array('featureTestDataArray3', 'nixDataArray', 'double', [5 6]);
-    tmp = b.create_data_array('featureTestDataArray4', 'nixDataArray', 'double', [7 8]);
-    tmp = b.create_data_array('featureTestDataArray5', 'nixDataArray', 'double', [9 10]);
-    tmp = b.create_data_array('featureTestDataArray6', 'nixDataArray', 'double', [11 12]);
+    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.create_data_array('featureTestDataArray3', 'nixDataArray', nix.DataType.Double, [5 6]);
+    tmp = b.create_data_array('featureTestDataArray4', 'nixDataArray', nix.DataType.Double, [7 8]);
+    tmp = b.create_data_array('featureTestDataArray5', 'nixDataArray', nix.DataType.Double, [9 10]);
+    tmp = b.create_data_array('featureTestDataArray6', 'nixDataArray', nix.DataType.Double, [11 12]);
     position = [1.0 1.2 1.3 15.9];
     getTag = b.create_tag('featureTest', 'nixTag', position);
     
@@ -125,8 +125,8 @@ end
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
     getTag = b.create_tag('featureTest', 'nixTag', position);
     tmp = getTag.add_feature(b.dataArrays{1}.id, nix.LinkType.Tagged);
@@ -144,9 +144,9 @@ end
 function [] = test_fetch_references( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     getBlock = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = getBlock.create_data_array('referenceTest1', 'nixDataArray', 'double', [1 2]);
-    tmp = getBlock.create_data_array('referenceTest2', 'nixDataArray', 'double', [3 4]);
-    tmp = getBlock.create_data_array('referenceTest3', 'nixDataArray', 'double', [5 6]);
+    tmp = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = getBlock.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
     position = [1.0 1.2 1.3 15.9];
     getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
     
@@ -178,8 +178,8 @@ end
 function [] = test_fetch_features( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', 'double', [1 2]);
-    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', 'double', [3 4]);
+    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
     getTag = b.create_tag('featureTest', 'nixTag', position);
 
@@ -216,7 +216,7 @@ end
 function [] = test_open_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
     getTag = b.create_tag('featureTest', 'nixTag', position);
     tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -233,7 +233,7 @@ end
 function [] = test_open_reference( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     getBlock = test_file.createBlock('referenceTest', 'nixBlock');
-    tmp = getBlock.create_data_array('referenceTest', 'nixDataArray', 'double', [1 2]);
+    tmp = getBlock.create_data_array('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
     getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
     getTag.add_reference(getBlock.dataArrays{1});
@@ -352,7 +352,7 @@ function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da = b.create_data_array('featureTestDataArray', 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_tag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     feature = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     featureID = feature.id;
@@ -371,7 +371,7 @@ function [] = test_has_reference( varargin )
     daName = 'referenceTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', 'double', [1 2]);
+    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_tag('referenceTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     t.add_reference(b.dataArrays{1});
 


### PR DESCRIPTION
Resolve DataArray DataType issues

Trying to write Strings to a DataArray resulted in a Matlab crash, since this function was not properly implemented on the c++ side of the bindings. After a discussion with Christian Kellner it was decided, that writing String to a DataArray will not be supported at the moment.

- Fixed IO error when trying to write logical data to a DataArray.
- Refactored DataArray create and write functions in Block and DataArray to properly handle all available DataTypes.
- Added multiple checks to avoid errors due to writing data to DataArrays with mismatching DataTypes.
- Refactored existing tests, added tests for implemented checks and added missing tests for all supported DataTypes.
- Successfully tested under win32 (Matlab R2011a), win64 (Matlab R2011a) and Ubuntu 14.04 (Matlab R2013b).

Resolves #104 and resolves #105.
