### PR TITLE
Add alias range dimension

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -64,6 +64,14 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         
         function da = create_data_array_from_data(obj, name, nixtype, data)
             shape = size(data);
+            %-- Quick fix to enable alias range dimension with
+            %-- 1D data arrays created with this function.
+            %-- e.g. size([1 2 3]) returns shape [1 3], which would not
+            %-- be accepted when trying to add an alias range dimension.
+            %-- TODO Remove this when a cleverer solution presents itself.
+            if(size(data, 1) == 1)
+                shape = size(data, 2);
+            end;
             dtype = class(data);
             
             da = obj.create_data_array(name, nixtype, dtype, shape);

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -73,7 +73,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             %-- 1D data arrays created with this function.
             %-- e.g. size([1 2 3]) returns shape [1 3], which would not
             %-- be accepted when trying to add an alias range dimension.
-            if(size(data, 1) == 1)
+            if(shape(1) == 1)
                 shape = size(data, 2);
             end;
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -63,8 +63,6 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function dim = append_alias_range_dimension(obj)
             func_name = strcat(obj.alias, '::append_alias_range_dimension');
             dim = nix.RangeDimension(nix_mx(func_name, obj.nix_handle));
-            %-- TODO purge once merged into removeCache branch.
-            obj.dimsCache.lastUpdate = 0;
         end
         
         function delCheck = delete_dimension(obj, index)

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -71,6 +71,13 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj.dimsCache.lastUpdate = 0;
         end
 
+        function dim = append_alias_range_dimension(obj)
+            func_name = strcat(obj.alias, '::append_alias_range_dimension');
+            dim = nix.RangeDimension(nix_mx(func_name, obj.nix_handle));
+            %-- TODO purge once merged into removeCache branch.
+            obj.dimsCache.lastUpdate = 0;
+        end
+        
         function delCheck = delete_dimension(obj, index)
             func_name = strcat(obj.alias, '::delete_dimension');
             delCheck = nix_mx(func_name, obj.nix_handle, index);

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -12,6 +12,7 @@ classdef RangeDimension < nix.Entity
             
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
+            nix.Dynamic.add_dyn_attr(obj, 'isAlias', 'r');
             nix.Dynamic.add_dyn_attr(obj, 'label', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'ticks', 'rw');
@@ -35,6 +36,6 @@ classdef RangeDimension < nix.Entity
             func_name = strcat(obj.alias, '::axis');
             axis = nix_mx(func_name, obj.nix_handle, count, startIndex);
         end
+
     end
 end
-   

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -335,8 +335,7 @@ void mexFunction(int            nlhs,
             .reg("set_ticks", SETTER(const std::vector<double>&, nix::RangeDimension, ticks))
             .reg("index_of", &nix::RangeDimension::indexOf)
             .reg("tick_at", &nix::RangeDimension::tickAt)
-            .reg("axis", &nix::RangeDimension::axis)
-            .reg("alias", &nix::RangeDimension::alias);
+            .reg("axis", &nix::RangeDimension::axis);
 
         mexAtExit(on_exit);
     });

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -178,9 +178,11 @@ void mexFunction(int            nlhs,
             .reg("dimensions", FILTER(std::vector<nix::Dimension>, nix::DataArray, , dimensions))
             .reg("append_set_dimension", &nix::DataArray::appendSetDimension)
             .reg("append_range_dimension", &nix::DataArray::appendRangeDimension)
+            .reg("append_alias_range_dimension", &nix::DataArray::appendAliasRangeDimension)
             .reg("append_sampled_dimension", &nix::DataArray::appendSampledDimension)
             .reg("create_set_dimension", &nix::DataArray::createSetDimension)
             .reg("create_range_dimension", &nix::DataArray::createRangeDimension)
+            .reg("create_alias_range_dimension", &nix::DataArray::createAliasRangeDimension)
             .reg("create_sampled_dimension", &nix::DataArray::createSampledDimension);
         methods->add("DataArray::delete_dimension", nixdataarray::delete_dimension);
         methods->add("DataArray::readAll", nixdataarray::read_all);
@@ -333,7 +335,8 @@ void mexFunction(int            nlhs,
             .reg("set_ticks", SETTER(const std::vector<double>&, nix::RangeDimension, ticks))
             .reg("index_of", &nix::RangeDimension::indexOf)
             .reg("tick_at", &nix::RangeDimension::tickAt)
-            .reg("axis", &nix::RangeDimension::axis);
+            .reg("axis", &nix::RangeDimension::axis)
+            .reg("alias", &nix::RangeDimension::alias);
 
         mexAtExit(on_exit);
     });

--- a/src/nixdimensions.cc
+++ b/src/nixdimensions.cc
@@ -30,13 +30,14 @@ namespace nixdimensions {
 
     mxArray *describe(const nix::RangeDimension &dim)
     {
-        struct_builder sb({ 1 }, { "dimensionType", "label", "unit", "ticks" });
+        struct_builder sb({ 1 }, { "dimensionType", "isAlias", "label", "unit", "ticks" });
 
         sb.set(dim.dimensionType());
+        sb.set(dim.alias());
         sb.set(dim.label());
         sb.set(dim.unit());
         sb.set(dim.ticks());
 
         return sb.array();
     }
-} // namespace nixtag
+} // namespace nixdimensions

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -148,7 +148,8 @@ end
 
 %% Test: Dimensions
 function [] = test_dimensions( varargin )
-    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array('daTest', 'test nixDataArray', 'double', [1 2]);
     
@@ -168,6 +169,7 @@ function [] = test_dimensions( varargin )
     assert(length(da.dimensions) == 3);
     assert(strcmp(da.dimensions{3}.dimensionType, 'range'));
     assert(isequal(da.dimensions{3}.ticks, ticks));
+    assert(~da.dimensions{3}.isAlias);
     
     da.delete_dimension(2);
     assert(length(da.dimensions) == 2);
@@ -180,4 +182,26 @@ function [] = test_dimensions( varargin )
     
     da.delete_dimension(1);
     assert(isempty(da.dimensions));
+    
+    try
+        da.append_alias_range_dimension;
+    catch ME
+        assert(strcmp(ME.identifier, 'nix:arg:inval'));
+    end;
+    
+    da.append_set_dimension();
+    try
+        da.append_alias_range_dimension();
+    catch ME
+        assert(strcmp(ME.identifier, 'nix:arg:inval'));
+    end;
+    
+    daAlias = b.create_data_array('aliasDimTest', 'nix.DataArray', ...
+        nix.DataType.Double, 25);
+    daAlias.append_alias_range_dimension();
+    assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
+    
+    clear daAlias da b f;
+    f = nix.File(fileName, nix.FileMode.ReadOnly);
+    assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
 end

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -202,6 +202,20 @@ function [] = test_dimensions( varargin )
     assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
     
     clear daAlias da b f;
-    f = nix.File(fileName, nix.FileMode.ReadOnly);
+    f = nix.File(fileName, nix.FileMode.ReadWrite);
     assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
+    
+    %-- Test for the alias dimension shape work around
+    daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWTest1', ...
+        'nix.DataArray', [1 2 3]);
+    daAliasWa.append_alias_range_dimension();
+    assert(daAliasWa.dimensions{1}.isAlias);
+    
+    daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWATest2', ...
+        'nix.DataArray', [1; 2; 3]);
+    assert(isequal(daAliasWa.shape, [3 1]));
+    
+    daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWATest3', ...
+        'nix.DataArray', [1 2 3; 2 4 5; 3 6 7]);
+    assert(isequal(daAliasWa.shape, [3 3]));
 end


### PR DESCRIPTION
Adding the alias range dimension to the Matlab bindings.

- Added required bindings.
- Added various tests for implemented features.
- Successfully tested under win32 (Matlab R2011a), win64 (Matlab R2011a) and Ubuntu 14.04 (Matlab R2013b).

Resolves #90.