### PR TITLE
Add Win32 and Win64 build batch file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(nix_mx CXX)
 
-set(VERSION_MAJOR 0)
+set(VERSION_MAJOR 1)
 set(VERSION_MINOR 1)
 set(VERSION_PATCH 0)
 

--- a/README.md
+++ b/README.md
@@ -7,26 +7,26 @@ The *NIX-MX* project is an extension to [NIX] (https://github.com/G-Node/nix) an
 Development Status
 ------------------
 
-The *NIX-MX* project has been developed and tested solely under Windows 32 and Windows 64 and is in an alpha stage of development. Specifically all of the features of NIX have been implemented and unit tests for all of the methods exist and pass, but extensive testing and some refactoring of existing code has to be done as of yet.
+The *NIX-MX* project has been developed and tested solely under Windows 32 and Windows 64 and is in a beta stage of development. Specifically all of the features of NIX have been implemented and unit tests for all of the methods exist and pass, but extensive testing and some refactoring of existing code has to be done as of yet.
 
 
 Getting Started (Windows 32/64)
 -------------------------------
 
-**Quick start packages, Pre-Release 1.01**
+**Quick start packages, Beta-Release 1.1.0**
 
-The [quick start packages] (https://github.com/G-Node/nix-mx/releases/tag/v1.01-Pre-Release) are compiled under Windows 32/64 and contain all dlls, binary and Matlab files required to use NIX-MX with the respective Windows OS.
-To use the packages, unzip them into a folder of your choice and run the `startup.m` script from the root folder. Do not change the file/folder structure.
+The [quick start packages] (https://github.com/G-Node/nix-mx/releases) are compiled under Windows 32/64 and contain all dlls, binary and Matlab files required to use NIX-MX with the respective Windows OS.
+The included *NIX* dll is a [stable release 1.1.0 build] (https://github.com/G-Node/nix/releases/tag/1.1.0) . To use the packages, unzip them into a folder of your choice and run the `startup.m` script from the root folder. Do not change the file/folder structure.
 
 The Windows 32 package contains:
 - HDF5 dlls (Release 1.8.14)
-- NIX dll (build commit f357124d0ec5028d4574e4f5816cca7b8d7c9e8b, compiled using BOOST 1.57.0 and CPPUNIT 1.13.2)
-- NIX-MX (Pre-Release 1.01, 22.06.2015)
+- NIX dll (stable release 1.1.0 build, compiled using BOOST 1.57.0 and CPPUNIT 1.13.2)
+- NIX-MX (Beta-Release 1.1.0, 26.01.2016)
 
 The Windows 64 package contains:
 - HDF5 dlls (Release 1.8.14)
-- NIX dll (build commit f357124d0ec5028d4574e4f5816cca7b8d7c9e8b, compiled using BOOST 1.57.0 and CPPUNIT 1.13.2)
-- NIX-MX (Pre-Release 1.01, 22.06.2015)
+- NIX dll (stable release 1.1.0 build, compiled using BOOST 1.57.0 and CPPUNIT 1.13.2)
+- NIX-MX (Beta-Release 1.1.0, 26.01.2016)
 
 
 **Build NIX-MX under Windows**

--- a/WinBuild.md
+++ b/WinBuild.md
@@ -5,49 +5,57 @@ Follow these steps to set up the development environment for the NIX Matlab bind
 
 **Dependencies**
 - download and install Visual Studio 12
-- make sure you have a fork of [NIX](https://github.com/G-Node/nix) and [NIX-MX](https://github.com/G-Node/nix-mx)
+- make sure you have a clone of [NIX](https://github.com/G-Node/nix) and [NIX-MX](https://github.com/G-Node/nix-mx)
 - get the latest [NIX Windows dependencies](https://projects.g-node.org/nix/), extract to [your path]/nix-dep/
 
-- IMPORTANT: if you need the DEBUG instead of the RELEASE build, make sure you use the corresponding debug folders instead of the release folders and settings in all subsequent paths and scripts of these set up notes:
+**Build process**
+- open [your path]/nix-mx/win_build.bat with an editor of your choice.
+- adjust the first three lines of the batch file to the corresponding directories on your system (NIX_DEP, NIX_ROOT, NIX_MX_ROOT).
+- NOTE: If you need the "Debug" instead of the "Release" build, change the corresponding line in the batch file.
+- start cmd (NOT powershell!)
+- run [your path]/nix-mx/win_build.bat
 
-**Build process for RELEASE build**
-- start cmd (NOT powershell!), move to [your path]/nix; create "build" directory, move inside
-- if you need any other build than DEBUG (in our case RELEASE) on a 32bit windows, edit [your path]/nix-dep/nixenv.bat:
-	edit PLATFORM from x86 to x64 if required
-	edit CONFIGURATION from Debug to Release if required
-- to set up dependencies path variables for NIX cmake, run:
+
+**Step by step build process**
+
+If you want to build nix-mx step by step use the following guidelines:
+
+***Build process for "Release" build***
+
+1. start cmd (NOT powershell!), move to [your path]/nix; create "build" directory, move inside.
+2. to set up dependencies path variables for NIX cmake, build type Release, run:
 	`[your path]/nix-dep/nixenv.bat`
-- if working on a 32bit Windows, run:
+3. if working on a 32bit Windows, run:
 	`cmake .. -G "Visual Studio 12"`
-- if working on a 64bit Windows, run:
+4. if working on a 64bit Windows, run:
 	`cmake .. -G "Visual Studio 12 Win64"`
-- with Visual Studio open [your path]/nix/build/nix.sln
-
-IMPORTANT NOTE! Visual Studio builds by default with configuration "Debug" and "32bit"!
-- If some other build is required (in our case we need at least configuration "Release"), set BUILD->ConfigurationManager->Active solution configuration!
-- Build "ALL_BUILD"
-- within the cmd shell move to [your path]/nix/build/Release
-- run
+5. with Visual Studio open [your path]/nix/build/nix.sln
+	IMPORTANT NOTE! Visual Studio builds by default with configuration "Debug" and "32bit"!
+6. If some other build is required (in our case we need at least configuration "Release"), set BUILD->ConfigurationManager->Active solution configuration!
+7. Build "ALL_BUILD".
+8. within the cmd shell move to [your path]/nix/build/Release.
+9. run
 	`[your path]/nix/build/Release/TestRunner.exe`
-- within the cmd shell move to [your path]/nix-mx, create and move into "build" folder
-- set the NIX root path;
+10. within the cmd shell move to [your path]/nix-mx, create and move into "build" folder.
+11. set the NIX root path;
 	`set NIX_ROOT=[your path]/nix`
 
     IMPORTANT:
     - do not use quotes in cmd!
     - do not use backslashes, only slashes! e.g. c:/work/nix; c:\work\nix will not work!
 
-- check, if the nix.dll library has been created in [your path]/nix/build/Release
-- if yes, open [your path]/nix-mx/cmake/FindNIX.cmake
-- add "HINTS $ENV{NIX_ROOT}/build/Release" to the "find_library(NIX_LIBRARY NAMES" statement
-- if working on Windows 32bit, run
+12. check, if the nix.dll library has been created in [your path]/nix/build/Release
+13. if yes, run
+	`SET NIX_BUILD_DIR=%NIX_ROOT%/build/Release`
+	
+14. if working on Windows 32bit, run
 	`cmake .. -G "Visual Studio 12"`
-- if working on Windows 64bit, run
+15. if working on Windows 64bit, run
 	`cmake .. -G "Visual Studio 12 Win64"`
-- with Visual Studio open [your path]/nix-mx/build/nix-mx.sln
-- Set BUILD->ConfigurationManager->Active solution configuration to Release and the correct bit version!
-- Build "ALL_BUILD"
-- copy all of the following files into the [your path]/nix-mx/build folder; simply providing the directories to MatLab using "addpath" does not work
+16. with Visual Studio open [your path]/nix-mx/build/nix-mx.sln.
+17. Set BUILD->ConfigurationManager->Active solution configuration to Release and the correct bit version!
+18. Build "ALL_BUILD".
+19. copy all of the following files into the [your path]/nix-mx/build folder; simply providing the directories to MatLab using "addpath" does not work.
 
 	from [your path]/nix-dep/[x86/x64]/hdf5-1.8.14/bin (path dependent on the Windows 32/64 bit version)
 	
@@ -61,25 +69,33 @@ IMPORTANT NOTE! Visual Studio builds by default with configuration "Debug" and "
 	
 		`nix_mx.mexw32 or nix_mx.mexw64`
 		
-- get some NIX files from the [your path]/nix/build/ test folder and NIX away!
+20. get some NIX files from the [your path]/nix/build/ test folder and NIX away!
 
 
-**Alternate build process for DEBUG build**
+***Alternate build process for "Debug" build***
 
-The build described above is for RELEASE which requires the usage of msvcp120d.dll and msvcr120d.dll and prevents the usage of msvcp120.dll and msvcr120.dll
+The build described above is for "Release" which requires the usage of msvcp120d.dll and msvcr120d.dll and prevents the usage of msvcp120.dll and msvcr120.dll.
 
-To use the hdf5 debug dlls, nix and nix-mx have to be built in DEBUG mode! For this:
-- replace "Release" with "Debug" in the nixenv.bat, use this to setup environmental variables
-- run cmake
-- open sln, in Visual Studio set BUILD->ConfigurationManager->Active solution configuration to "Debug" instead of "Release"
-- re-run TestRunner.exe in folder "Debug" instead of "Release"
-- move to the [your path]/nix-mx/build folder
-- re-run the modified nixenv.bat
-- run
-	`$env:NIX_ROOT="c:/work/nix"`
-- open [your path]/nix-mx/cmake/FindNIX.cmake and add
+To use the hdf5 debug dlls, nix and nix-mx have to be built with build type "Debug"! For this change the following steps in the guideline above:
+- Step 0. Delete everything from the nix/build and nix-mx/build directories.
+- Step 2. setup the environmental variables by using:
+	`[your path]/nix-dep/nixenv.bat Debug`
+- Step 6. open nix sln, in Visual Studio set BUILD->ConfigurationManager->Active solution configuration to "Debug" instead of "Release".
+- Step 8. re-run TestRunner.exe in folder "Debug" instead of "Release".
+- Step 12. check, if the nix.dll library has been created in [your path]/nix/build/Debug.
+- Step 13. run
+	`SET NIX_BUILD_DIR=%NIX_ROOT%/build/Debug`
+- Step 16. open nix-mx sln, in Visual Studio set BUILD->ConfigurationManager->Active solution configuration to "Debug" instead of "Release".
+- Step 19. copy all of the following files into the [your path]/nix-mx/build folder; simply providing the directories to MatLab using "addpath" does not work.
 
-	"HINTS $ENV{NIX_ROOT}/build/Debug" to the "find_library(NIX_LIBRARY NAMES" statement
-- run cmake
-- open sln, in Visual Studio set BUILD->ConfigurationManager->Active solution configuration to "Debug" instead of "Release"
-- setup the rest like in debug mode
+	from [your path]/nix-dep/[x86/x64]/hdf5-1.8.14/bin (path dependent on the Windows 32/64 bit version)
+	
+		`hdf5.dll, msvcp120.dll, msvcr120.dll, szip.dll, zlib.dll`
+		
+	from [your path]/nix/build/Debug
+	
+		`nix.dll`
+		
+	from [your path]/nix-mx/build/Debug
+	
+		`nix_mx.mexw32 or nix_mx.mexw64`

--- a/cmake/FindNIX.cmake
+++ b/cmake/FindNIX.cmake
@@ -12,6 +12,7 @@ find_path(NIX_INCLUDE_DIR nix.hpp
   PATH_SUFFIXES nix)
 
 find_library(NIX_LIBRARY NAMES nix libnix
+  HINTS $ENV{NIX_BUILD_DIR}
   HINTS ${NIX_INCLUDE_DIR}/../lib
   HINTS ${NIX_INCLUDE_DIR}/../build
   /usr/local/lib

--- a/win_build.bat
+++ b/win_build.bat
@@ -1,0 +1,48 @@
+SET NIX_DEP=c:\work\nix-dep
+SET NIX_ROOT=c:\work\nix
+SET NIX_MX_ROOT=c:\work\nix-mx
+REM Use only build types "Release" or "Debug"
+SET BUILD_TYPE=Release
+
+IF NOT %BUILD_TYPE% == Release (IF NOT %BUILD_TYPE% == Debug (ECHO Please use only Release or Debug as BUILD_TYPE))
+IF NOT %BUILD_TYPE% == Release (IF NOT %BUILD_TYPE% == Debug (EXIT /b))
+REM Set NIX_BUILD_DIR for nix-mx FindNIX.cmake
+SET NIX_BUILD_DIR=%NIX_ROOT%\build\%BUILD_TYPE%
+
+IF %BUILD_TYPE% == Debug (CALL %NIX_DEP%\nixenv.bat Debug) ELSE (CALL %NIX_DEP%\nixenv.bat)
+
+IF NOT EXIST %NIX_ROOT%\build (MKDIR %NIX_ROOT%\build)
+CD %NIX_ROOT%\build
+REM Clean up build folder to ensure clean build.
+DEL * /S /Q
+RD /S /Q "CMakeFiles" "Testing" "Debug" "Release" "nix-tool.dir" "x64" "TestRunner.dir" "nix.dir"
+
+IF %PROCESSOR_ARCHITECTURE% == x86 ( cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
+
+REM Start %NIX_ROOT%\build\nix.sln
+cmake --build . --config %CONFIGURATION% --target nix
+
+%NIX_BUILD_DIR%\TestRunner.exe
+
+IF NOT EXIST %NIX_MX_ROOT%\build (MKDIR %NIX_MX_ROOT%\build)
+CD %NIX_MX_ROOT%\build
+REM Clean up build folder to ensure clean build.
+DEL * /S /Q
+RD /S /Q "CMakeFiles" "Debug" "nix_mx.dir" "Release" "Win32" "x64"
+
+COPY %NIX_BUILD_DIR%\nix.dll %NIX_MX_ROOT%\build\ /Y
+COPY %HDF5_BASE%\bin\hdf5.dll %NIX_MX_ROOT%\build\ /Y
+COPY %HDF5_BASE%\bin\msvcp120.dll %NIX_MX_ROOT%\build\ /Y
+COPY %HDF5_BASE%\bin\msvcr120.dll %NIX_MX_ROOT%\build\ /Y
+COPY %HDF5_BASE%\bin\szip.dll %NIX_MX_ROOT%\build\ /Y
+COPY %HDF5_BASE%\bin\zlib.dll %NIX_MX_ROOT%\build\ /Y
+
+IF %PROCESSOR_ARCHITECTURE% == x86 (cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
+
+cmake --build . --config %CONFIGURATION%
+
+COPY %NIX_MX_ROOT%\build\%BUILD_TYPE%\nix_mx.mexw* %NIX_MX_ROOT%\build\ /Y
+
+CD %NIX_MX_ROOT%
+
+Start %NIX_MX_ROOT%\startup.m


### PR DESCRIPTION
- Added a batch file for Windows 32 and Windows 64 that builds nix and nix-mx.
- Successfully tested batch files under both systems for build types "Release" and "Debug".
- Updated README and WinBuild.
- Set version to 1.1.0.