### PR TITLE
Add missing file functions

### DIFF
--- a/+nix/File.m
+++ b/+nix/File.m
@@ -38,24 +38,24 @@ classdef File < nix.Entity
         % Block methods
         % ----------------
 
-        function newBlock = createBlock(obj, name, type)
+        function newBlock = create_block(obj, name, type)
             newBlock = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
         end;
 
-        function c = blockCount(obj)
+        function c = block_count(obj)
             c = nix_mx('File::blockCount', obj.nix_handle);
         end
 
-        function hasBlock = hasBlock(obj, id_or_name)
+        function hasBlock = has_block(obj, id_or_name)
             hasBlock = nix_mx('File::hasBlock', obj.nix_handle, id_or_name);
         end;
 
-        function retObj = openBlock(obj, id_or_name)
+        function retObj = open_block(obj, id_or_name)
             retObj = nix.Utils.open_entity(obj, ...
                 'File::openBlock', id_or_name, @nix.Block);
         end
 
-        function delCheck = deleteBlock(obj, del)
+        function delCheck = delete_block(obj, del)
             delCheck = nix.Utils.delete_entity(obj, ...
                 del, 'nix.Block', 'File::deleteBlock');
         end;
@@ -64,24 +64,24 @@ classdef File < nix.Entity
         % Section methods
         % ----------------
 
-        function newSec = createSection(obj, name, type)
+        function newSec = create_section(obj, name, type)
             newSec = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
         end;
 
-        function c = sectionCount(obj)
+        function c = section_count(obj)
             c = nix_mx('File::sectionCount', obj.nix_handle);
         end
 
-        function hasSec = hasSection(obj, id_or_name)
+        function hasSec = has_section(obj, id_or_name)
             hasSec = nix_mx('File::hasSection', obj.nix_handle, id_or_name);
         end;
 
-        function retObj = openSection(obj, id_or_name)
+        function retObj = open_section(obj, id_or_name)
             retObj = nix.Utils.open_entity(obj, ...
                 'File::openSection', id_or_name, @nix.Section);
         end
 
-        function delCheck = deleteSection(obj, del)
+        function delCheck = delete_section(obj, del)
             delCheck = nix.Utils.delete_entity(obj, del, 'nix.Section', 'File::deleteSection');
         end;
     end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -25,10 +25,15 @@ classdef File < nix.Entity
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'blocks', @nix.Block);
             nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
-            
+
             obj.info = nix_mx('File::describe', obj.nix_handle);
         end
-        
+
+        % braindead...
+        function check = is_open(obj)
+            check = nix_mx('File::isOpen', obj.nix_handle);
+        end
+
         % ----------------
         % Block methods
         % ----------------

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -38,6 +38,10 @@ classdef File < nix.Entity
             mode = nix_mx('File::fileMode', obj.nix_handle);
         end
 
+        function res = validate(obj)
+            res = nix_mx('File::validate', obj.nix_handle);
+        end
+
         % ----------------
         % Block methods
         % ----------------

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -34,6 +34,10 @@ classdef File < nix.Entity
             check = nix_mx('File::isOpen', obj.nix_handle);
         end
 
+        function mode = file_mode(obj)
+            mode = nix_mx('File::fileMode', obj.nix_handle);
+        end
+
         % ----------------
         % Block methods
         % ----------------

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -118,6 +118,7 @@ void mexFunction(int            nlhs,
             .reg("sectionCount", GETTER(nix::ndsize_t, nix::File, sectionCount))
             .reg("isOpen", GETTER(bool, nix::File, isOpen));
         methods->add("File::fileMode", nixfile::fileMode);
+        methods->add("File::validate", nixfile::validate);
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -115,7 +115,8 @@ void mexFunction(int            nlhs,
             .reg("createBlock", &nix::File::createBlock)
             .reg("createSection", &nix::File::createSection)
             .reg("blockCount", GETTER(nix::ndsize_t, nix::File, blockCount))
-            .reg("sectionCount", GETTER(nix::ndsize_t, nix::File, sectionCount));
+            .reg("sectionCount", GETTER(nix::ndsize_t, nix::File, sectionCount))
+            .reg("isOpen", GETTER(bool, nix::File, isOpen));
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -117,6 +117,7 @@ void mexFunction(int            nlhs,
             .reg("blockCount", GETTER(nix::ndsize_t, nix::File, blockCount))
             .reg("sectionCount", GETTER(nix::ndsize_t, nix::File, sectionCount))
             .reg("isOpen", GETTER(bool, nix::File, isOpen));
+        methods->add("File::fileMode", nixfile::fileMode);
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -36,6 +36,21 @@ namespace nixfile {
         output.set(0, h);
     }
 
+    void fileMode(const extractor &input, infusor &output) {
+        nix::File currObj = input.entity<nix::File>(1);
+        nix::FileMode mode = currObj.fileMode();
+        uint8_t omode;
+
+        switch (mode) {
+        case nix::FileMode::ReadOnly: omode = 0; break;
+        case nix::FileMode::ReadWrite: omode = 1; break;
+        case nix::FileMode::Overwrite: omode = 2; break;
+        default: throw std::invalid_argument("unknown open mode");
+        }
+
+        output.set(0, omode);
+    }
+
     mxArray *describe(const nix::File &fd) {
         struct_builder sb({ 1 }, { "format", "version", "location", "createdAt", "updatedAt" });
         sb.set(fd.format());

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -17,6 +17,8 @@ namespace nixfile {
 
     void fileMode(const extractor &input, infusor &output);
 
+    void validate(const extractor &input, infusor &output);
+
     mxArray *describe(const nix::File &f);
 
 } // namespace nixfile

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -15,6 +15,8 @@ namespace nixfile {
 
     void open(const extractor &input, infusor &output);
 
+    void fileMode(const extractor &input, infusor &output);
+
     mxArray *describe(const nix::File &f);
 
 } // namespace nixfile

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -49,7 +49,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'test nixBlock');
+    b = f.create_block('tagtest', 'test nixBlock');
 
     assert(~isempty(b.id));
     assert(strcmp(b.name, 'tagtest'));
@@ -70,7 +70,7 @@ end
 function [] = test_create_data_array( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('arraytest', 'nixblock');
+    b = f.create_block('arraytest', 'nixblock');
     
     assert(isempty(b.dataArrays));
     
@@ -115,7 +115,7 @@ function [] = test_create_data_array_from_data( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('arraytest', 'nixblock');
+    b = f.create_block('arraytest', 'nixblock');
     
     assert(isempty(b.dataArrays));
     
@@ -155,7 +155,7 @@ end
 %% Test: delete dataArray by entity and id
 function [] = test_delete_data_array( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('arraytest', 'nixBlock');
+    b = f.create_block('arraytest', 'nixBlock');
     tmp = b.create_data_array('dataArrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('dataArrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
@@ -170,7 +170,7 @@ end
 function [] = test_create_tag( varargin )
 %% Test: Create Tag
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'nixblock');
+    b = f.create_block('tagtest', 'nixblock');
     
     assert(isempty(b.tags));
 
@@ -186,7 +186,7 @@ end
 %% Test: delete tag by entity and id
 function [] = test_delete_tag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'nixBlock');
+    b = f.create_block('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
     tmp = b.create_tag('tagtest1', 'nixTag', position);
     tmp = b.create_tag('tagtest2', 'nixTag', position);
@@ -203,7 +203,7 @@ end
 function [] = test_create_multi_tag( varargin )
 %% Test: Create multitag by data_array entity and data_array id
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('mTagTestBlock', 'nixBlock');
+    b = f.create_block('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     assert(isempty(b.multiTags));
@@ -222,7 +222,7 @@ end
 %% Test: delete multitag by entity and id
 function [] = test_delete_multi_tag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('mTagTestBlock', 'nixBlock');
+    b = f.create_block('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
     tmp = b.create_multi_tag('mTagTest2', 'nixMultiTag2', b.dataArrays{1});
@@ -240,7 +240,7 @@ end
 %% Test: create source
 function [] = test_create_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixblock');
+    getBlock = test_file.create_block('sourcetest', 'nixblock');
     assert(isempty(getBlock.sources));
 
     createSource = getBlock.create_source('sourcetest','nixsource');
@@ -252,7 +252,7 @@ end
 %% Test: delete source by entity and id
 function [] = test_delete_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixblock');
+    getBlock = test_file.create_block('sourcetest', 'nixblock');
     tmp = getBlock.create_source('sourcetest1','nixsource');
     tmp = getBlock.create_source('sourcetest2','nixsource');
     tmp = getBlock.create_source('sourcetest3','nixsource');
@@ -269,7 +269,7 @@ end
 function [] = test_list_arrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('arraytest', 'nixBlock');
+    b = f.create_block('arraytest', 'nixBlock');
 
     assert(isempty(b.dataArrays));
     tmp = b.create_data_array('arrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -286,7 +286,7 @@ end
 function [] = test_list_sources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('sourcetest', 'nixBlock');
+    b = f.create_block('sourcetest', 'nixBlock');
 
     assert(isempty(b.sources));
     tmp = b.create_source('sourcetest1','nixSource');
@@ -305,7 +305,7 @@ end
 function [] = test_list_tags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'nixBlock');
+    b = f.create_block('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
 
     assert(isempty(b.tags));
@@ -325,7 +325,7 @@ end
 function [] = test_list_multitags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('mTagTestBlock', 'nixBlock');
+    b = f.create_block('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(b.multiTags));
@@ -344,7 +344,7 @@ end
 function [] = test_open_array( varargin )
 %% Test: Open data array by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('arraytest', 'nixBlock');
+    b = f.create_block('arraytest', 'nixBlock');
     daName = 'arrayTest1';
     
     assert(isempty(b.dataArrays));
@@ -364,7 +364,7 @@ end
 function [] = test_open_tag( varargin )
 %% Test: Open tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'nixBlock');
+    b = f.create_block('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
     tagName = 'tagtest1';
     tmp = b.create_tag(tagName, 'nixTag', position);
@@ -383,7 +383,7 @@ end
 function [] = test_open_multitag( varargin )
 %% Test: Open multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('mTagTestBlock', 'nixBlock');
+    b = f.create_block('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTagName = 'mTagTest1';
     tmp = b.create_multi_tag(mTagName, 'nixMultiTag', b.dataArrays{1});
@@ -402,7 +402,7 @@ end
 function [] = test_open_source( varargin )
 %% Test: Open source by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('sourcetest', 'nixBlock');
+    b = f.create_block('sourcetest', 'nixBlock');
     sName = 'sourcetest1';
     tmp = b.create_source(sName, 'nixSource');
     
@@ -420,7 +420,7 @@ end
 function [] = test_has_multitag( varargin )
 %% Test: Block has multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('mTagTestBlock', 'nixBlock');
+    b = f.create_block('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
 
@@ -433,7 +433,7 @@ end
 function [] = test_has_tag( varargin )
 %% Test: Block has tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'nixBlock');
+    b = f.create_block('tagtest', 'nixBlock');
     tmp = b.create_tag('tagtest1', 'nixTag', [1.0 1.2 1.3 15.9]);
 
     assert(b.has_tag(b.tags{1,1}.id));
@@ -448,9 +448,9 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.createSection(secName1, 'nixSection');
-    tmp = f.createSection(secName2, 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section(secName1, 'nixSection');
+    tmp = f.create_section(secName2, 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     
     assert(isempty(b.open_metadata));
     assert(isempty(f.blocks{1}.open_metadata));
@@ -475,8 +475,8 @@ end
 function [] = test_open_metadata( varargin )
 %% Test: Open metadata
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     b.set_metadata(f.sections{1});
 
     assert(strcmp(b.open_metadata.name, 'testSection'));
@@ -487,7 +487,7 @@ function [] = test_has_data_array( varargin )
     fileName = 'testRW.h5';
     daName = 'hasDataArrayTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     daID = da.id;
     
@@ -504,7 +504,7 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     s = b.create_source(sName, 'nixSource');
     sID = s.id;
 
@@ -523,7 +523,7 @@ function [] = test_create_group( varargin )
     groupType = 'nixGroup';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('grouptest', 'nixBlock');
+    b = f.create_block('grouptest', 'nixBlock');
 
     assert(isempty(b.groups));
 
@@ -542,7 +542,7 @@ end
 function [] = test_has_group( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('grouptest', 'nixBlock');
+    b = f.create_block('grouptest', 'nixBlock');
 
     assert(~b.has_group('I do not exist'));
     
@@ -558,7 +558,7 @@ end
 function [] = test_get_group( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('grouptest', 'nixBlock');
+    b = f.create_block('grouptest', 'nixBlock');
     g = b.create_group(groupName, 'nixGroup');
     gID = g.id;
 
@@ -574,7 +574,7 @@ function [] = test_delete_group( varargin )
     groupType = 'nixGroup';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('grouptest', 'nixBlock');
+    b = f.create_block('grouptest', 'nixBlock');
     g1 = b.create_group('testGroup1', groupType);
     g2 = b.create_group('testGroup2', groupType);
 
@@ -595,7 +595,7 @@ end
 function [] = test_group_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     assert(b.group_count() == 0);
     g = b.create_group('testGroup', 'nixGroup');
     assert(b.group_count() == 1);
@@ -610,7 +610,7 @@ end
 function [] = test_data_array_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
 
     assert(b.data_array_count() == 0);
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -626,7 +626,7 @@ end
 function [] = test_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
 
     assert(b.tag_count() == 0);
     t = b.create_tag('testTag1', 'nixTag', [1.0 1.2 1.3 15.9]);
@@ -642,7 +642,7 @@ end
 function [] = test_multi_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     d = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(b.multi_tag_count() == 0);
@@ -659,7 +659,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
 
     assert(b.source_count() == 0);
     s = b.create_source('testSource1', 'nixSource');

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -32,7 +32,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('daTestBlock', 'test nixBlock');
+    b = f.create_block('daTestBlock', 'test nixBlock');
     da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(~isempty(da.id));
@@ -69,7 +69,7 @@ function [] = test_open_data( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nix.Block');
+    b = f.create_block('testBlock', 'nix.Block');
 
     da = b.create_data_array('logicalArray', daType, nix.DataType.Bool, [3 3]);
     assert(islogical(da.read_all));
@@ -101,10 +101,10 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.createSection(secName1, 'nixSection');
-    tmp = f.createSection(secName2, 'nixSection');
+    tmp = f.create_section(secName1, 'nixSection');
+    tmp = f.create_section(secName2, 'nixSection');
 
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(da.open_metadata));
@@ -131,8 +131,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     da.set_metadata(f.sections{1});
 
@@ -154,7 +154,7 @@ function [] = test_write_data_double( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('testDataArray', 'nixblock');
+    b = f.create_block('testDataArray', 'nixblock');
 
     numData = [1 2 3 4 5];
     logData = logical([1 0 1 0 1]);
@@ -191,7 +191,7 @@ function [] = test_write_data_logical( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('testDataArray', 'nixblock');
+    b = f.create_block('testDataArray', 'nixblock');
 
     logData = logical([1 0 1 0 1]);
     numData = [1 2 3 4 5];
@@ -221,7 +221,7 @@ function [] = test_write_data_float( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('testDataArray', 'nixblock');
+    b = f.create_block('testDataArray', 'nixblock');
 
     numData = [1.3 2.4143 3.9878 4.1239 5];
     
@@ -239,7 +239,7 @@ function [] = test_write_data_integer( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('testDataArray', 'nixblock');
+    b = f.create_block('testDataArray', 'nixblock');
 
     numData = [1 2 3; 4 5 6; 7 8 9];
     
@@ -283,7 +283,7 @@ end
 %% Test: Add sources by entity and id
 function [] = test_add_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('sourceTest', 'nixBlock');
+    b = f.create_block('sourceTest', 'nixBlock');
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -298,7 +298,7 @@ end
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+    b = test_file.create_block('test', 'nixBlock');
     s = b.create_source('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
@@ -319,7 +319,7 @@ end
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('sourceTest', 'nixBlock');
+    b = f.create_block('sourceTest', 'nixBlock');
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -340,7 +340,7 @@ end
 function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     s = b.create_source('sourceTest1', 'nixSource');
     sID = s.id;
     d = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -358,7 +358,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(d.source_count() == 0);
@@ -375,7 +375,7 @@ end
 function [] = test_dimensions( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('daTestBlock', 'test nixBlock');
+    b = f.create_block('daTestBlock', 'test nixBlock');
     da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(isempty(da.dimensions));
@@ -444,7 +444,7 @@ end
 function [] = test_dimension_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(da.dimension_count == 0);

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -19,7 +19,7 @@ end
 function [] = test_set_dimension( varargin )
 %% Test: set dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('daTestBlock', 'test nixBlock');
+    b = f.create_block('daTestBlock', 'test nixBlock');
     da = b.create_data_array(...
         'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_set_dimension();
@@ -54,7 +54,7 @@ end
 function [] = test_sample_dimension( varargin )
 %% Test: sampled dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('daTestBlock', 'test nixBlock');
+    b = f.create_block('daTestBlock', 'test nixBlock');
     da = b.create_data_array(...
         'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_sampled_dimension(200);
@@ -108,7 +108,7 @@ end
 function [] = test_range_dimension( varargin )
 %% Test: range dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('daTestBlock', 'test nixBlock');
+    b = f.create_block('daTestBlock', 'test nixBlock');
     da = b.create_data_array(...
         'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     ticks = [1 2 3 4];

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -19,7 +19,7 @@ end
 %% Test: Open data from feature
 function [] = test_open_data ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getTag = b.create_tag('featureTest', 'nixTag', [1, 2]);
     tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -32,7 +32,7 @@ end
 function [] = test_get_set_link_type ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_tag('featureTest', 'nixTag', [1, 2]);
     feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -74,7 +74,7 @@ function [] = test_set_data ( varargin )
     daType = 'nixDataArray';
     daData = [1 2 3 4 5 6];
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     da1 = b.create_data_array(daName1, daType, nix.DataType.Double, daData);
     da2 = b.create_data_array(daName2, daType, nix.DataType.Double, daData);
     da3 = b.create_data_array(daName3, daType, nix.DataType.Double, daData);

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -15,6 +15,7 @@ function funcs = TestFile
     funcs{end+1} = @test_read_write;
     funcs{end+1} = @test_overwrite;
     funcs{end+1} = @test_is_open;
+    funcs{end+1} = @test_file_mode;
     funcs{end+1} = @test_create_block;
     funcs{end+1} = @test_block_count;
     funcs{end+1} = @test_create_section;
@@ -48,6 +49,21 @@ end
 function [] = test_is_open( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadOnly);
     assert(f.is_open());
+end
+
+%% Test: File is open
+function [] = test_file_mode( varargin )
+    testFile = fullfile(pwd,'tests','testRW.h5');
+    f = nix.File(testFile, nix.FileMode.ReadOnly);
+    assert(f.file_mode() == nix.FileMode.ReadOnly);
+
+    clear f;
+    f = nix.File(testFile, nix.FileMode.ReadWrite);
+    assert(f.file_mode() == nix.FileMode.ReadWrite);
+
+    clear f;
+    f = nix.File(testFile, nix.FileMode.Overwrite);
+    assert(f.file_mode() == nix.FileMode.Overwrite);
 end
 
 %% Test: Create Block

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -14,6 +14,7 @@ function funcs = TestFile
     funcs{end+1} = @test_read_only;
     funcs{end+1} = @test_read_write;
     funcs{end+1} = @test_overwrite;
+    funcs{end+1} = @test_is_open;
     funcs{end+1} = @test_create_block;
     funcs{end+1} = @test_block_count;
     funcs{end+1} = @test_create_section;
@@ -41,6 +42,12 @@ end
 %% Test: Open HDF5 file in Overwrite mode
 function [] = test_overwrite( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+end
+
+%% Test: File is open
+function [] = test_is_open( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadOnly);
+    assert(f.is_open());
 end
 
 %% Test: Create Block

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -16,6 +16,7 @@ function funcs = TestFile
     funcs{end+1} = @test_overwrite;
     funcs{end+1} = @test_is_open;
     funcs{end+1} = @test_file_mode;
+    funcs{end+1} = @test_validate;
     funcs{end+1} = @test_create_block;
     funcs{end+1} = @test_block_count;
     funcs{end+1} = @test_create_section;
@@ -32,28 +33,28 @@ end
 
 %% Test: Open HDF5 file in ReadOnly mode
 function [] = test_read_only( varargin )
-    f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
+    f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
 end
 
 %% Test: Open HDF5 file in ReadWrite mode
 function [] = test_read_write( varargin )
-    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadWrite);
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.ReadWrite);
 end
 
 %% Test: Open HDF5 file in Overwrite mode
 function [] = test_overwrite( varargin )
-    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
 end
 
 %% Test: File is open
 function [] = test_is_open( varargin )
-    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.ReadOnly);
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.ReadOnly);
     assert(f.is_open());
 end
 
-%% Test: File is open
+%% Test: File mode
 function [] = test_file_mode( varargin )
-    testFile = fullfile(pwd,'tests','testRW.h5');
+    testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.ReadOnly);
     assert(f.file_mode() == nix.FileMode.ReadOnly);
 
@@ -64,6 +65,19 @@ function [] = test_file_mode( varargin )
     clear f;
     f = nix.File(testFile, nix.FileMode.Overwrite);
     assert(f.file_mode() == nix.FileMode.Overwrite);
+end
+
+%% Test: Validate
+function [] = test_validate( varargin )
+    testFile = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(testFile, nix.FileMode.Overwrite);
+    validation = f.validate();
+
+    assert(validation.ok());
+    assert(~validation.hasErrors());
+    assert(~validation.hasWarnings());
+    assert(~size(validation.errors, 1));
+    assert(~size(validation.warnings, 1));
 end
 
 %% Test: Create Block

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -54,7 +54,7 @@ end
 function [] = test_create_block( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testBlock 1';
-    newBlock = test_file.createBlock(useName, 'testType 1');
+    newBlock = test_file.create_block(useName, 'testType 1');
     assert(strcmp(newBlock.name(), useName));
 end
 
@@ -62,21 +62,21 @@ end
 function [] = test_block_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    assert(f.blockCount() == 0);
-    b = f.createBlock('testBlock 1', 'testType 1');
-    assert(f.blockCount() == 1);
-    b = f.createBlock('testBlock 2', 'testType 2');
+    assert(f.block_count() == 0);
+    b = f.create_block('testBlock 1', 'testType 1');
+    assert(f.block_count() == 1);
+    b = f.create_block('testBlock 2', 'testType 2');
 
     clear b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blockCount() == 2);
+    assert(f.block_count() == 2);
 end
 
 %% Test: Create Section
 function [] = test_create_section( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testSection 1';
-    newSection = test_file.createSection(useName, 'testType 1');
+    newSection = test_file.create_section(useName, 'testType 1');
     assert(strcmp(newSection.name(), useName));
 end
 
@@ -84,14 +84,14 @@ end
 function [] = test_section_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    assert(f.sectionCount() == 0);
-    b = f.createSection('testSection 1', 'testType 1');
-    assert(f.sectionCount() == 1);
-    b = f.createSection('testSection 2', 'testType 2');
+    assert(f.section_count() == 0);
+    b = f.create_section('testSection 1', 'testType 1');
+    assert(f.section_count() == 1);
+    b = f.create_section('testSection 2', 'testType 2');
 
     clear b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.sectionCount() == 2);
+    assert(f.section_count() == 2);
 end
 
 %% Test: Fetch Block
@@ -102,11 +102,11 @@ function [] = test_fetch_block( varargin )
     f = nix.File(testFile, nix.FileMode.Overwrite);
     assert(isempty(f.blocks));
 
-    b1 = f.createBlock(strcat(blockName, '1'), blockType);
+    b1 = f.create_block(strcat(blockName, '1'), blockType);
     assert(size(f.blocks, 1) == 1);
 
     check_file = f;
-    b2 = f.createBlock(strcat(blockName, '2'), blockType);
+    b2 = f.create_block(strcat(blockName, '2'), blockType);
     assert(size(f.blocks, 1) == 2);
     assert(size(check_file.blocks, 1) == 2);
 
@@ -123,11 +123,11 @@ function [] = test_fetch_section( varargin )
     f = nix.File(testFile, nix.FileMode.Overwrite);
     assert(isempty(f.sections));
 
-    s1 = f.createSection(strcat(sectionName, '1'), sectionType);
+    s1 = f.create_section(strcat(sectionName, '1'), sectionType);
     assert(size(f.sections, 1) == 1);
 
     check_file = f;
-    s2 = f.createSection(strcat(sectionName, '2'), sectionType);
+    s2 = f.create_section(strcat(sectionName, '2'), sectionType);
     assert(size(f.sections, 1) == 2);
     assert(size(check_file.sections, 1) == 2);
 
@@ -140,22 +140,22 @@ end
 function [] = test_delete_block( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testBlock 1';
-    newBlock = test_file.createBlock(useName, 'testType 1');
+    newBlock = test_file.create_block(useName, 'testType 1');
     assert(strcmp(newBlock.name(), useName));
     
     %-- test delete block by object
-    checkDelete = test_file.deleteBlock(test_file.blocks{1});
+    checkDelete = test_file.delete_block(test_file.blocks{1});
     assert(checkDelete);
     assert(size(test_file.blocks, 1) == 0);
     
     %-- test delete block by id
-    newBlock = test_file.createBlock('name', 'type');
-    checkDelete = test_file.deleteBlock(newBlock.id);
+    newBlock = test_file.create_block('name', 'type');
+    checkDelete = test_file.delete_block(newBlock.id);
     assert(checkDelete);
     assert(size(test_file.blocks, 1) == 0);
 
     %-- test delete non existing block
-    checkDelete = test_file.deleteBlock('I do not exist');
+    checkDelete = test_file.delete_block('I do not exist');
     assert(~checkDelete);
 end
 
@@ -163,33 +163,33 @@ end
 function [] = test_delete_section( varargin )
     test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testSection 1';
-    newSection = test_file.createSection(useName, 'testType 1');
+    newSection = test_file.create_section(useName, 'testType 1');
     assert(strcmp(newSection.name(), useName));
     
     %-- test delete section by object
-    checkDelete = test_file.deleteSection(test_file.sections{1});
+    checkDelete = test_file.delete_section(test_file.sections{1});
     assert(checkDelete);
     assert(size(test_file.sections, 1) == 0);
     
     %-- test delete section by id
-    newSection = test_file.createSection('name', 'type');
-    checkDelete = test_file.deleteSection(newSection.id);
+    newSection = test_file.create_section('name', 'type');
+    checkDelete = test_file.delete_section(newSection.id);
     assert(checkDelete);
     assert(size(test_file.sections, 1) == 0);
 
     %-- test delete non existing section
-    checkDelete = test_file.deleteSection('I do not exist');
+    checkDelete = test_file.delete_section('I do not exist');
     assert(~checkDelete);
 end
 
 function [] = test_open_section( varargin )
 %% Test open section
     test_file = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
-    getSection = test_file.openSection(test_file.sections{1,1}.id);
+    getSection = test_file.open_section(test_file.sections{1,1}.id);
     assert(strcmp(getSection.name, 'General'));
     
     %-- test open non existing section
-    getSection = test_file.openSection('I dont exist');
+    getSection = test_file.open_section('I dont exist');
     assert(isempty(getSection));
 end
 
@@ -197,45 +197,45 @@ function [] = test_open_block( varargin )
 %% Test Open Block by ID or name
     test_file = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
 
-    getBlockByID = test_file.openBlock(test_file.blocks{1,1}.id);
+    getBlockByID = test_file.open_block(test_file.blocks{1,1}.id);
     assert(strcmp(getBlockByID.id, '7b59c0b9-b200-4b53-951d-6851dbd1cdc8'));
 
-    getBlockByName = test_file.openBlock(test_file.blocks{1,1}.name);
+    getBlockByName = test_file.open_block(test_file.blocks{1,1}.name);
     assert(strcmp(getBlockByName.name, 'joe097'));
 
     %-- test open non existing block
-    getBlock = test_file.openBlock('I dont exist');
+    getBlock = test_file.open_block('I dont exist');
     assert(isempty(getBlock));
 end
 
 %% Test: nix.File has nix.Block by ID or name
 function [] = test_has_block( varargin )
     fileName = 'testRW.h5';
-    blockName = 'hasBlockTest';
+    blockName = 'has_blockTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock(blockName, 'nixBlock');
+    b = f.create_block(blockName, 'nixBlock');
     bID = b.id;
 
-    assert(~f.hasBlock('I do not exist'));
-    assert(f.hasBlock(blockName));
+    assert(~f.has_block('I do not exist'));
+    assert(f.has_block(blockName));
 
     clear b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.hasBlock(bID));
+    assert(f.has_block(bID));
 end
 
 %% Test: nix.File has nix.Section by ID or name
 function [] = test_has_section( varargin )
     fileName = 'testRW.h5';
-    secName = 'hasSectionTest';
+    secName = 'has_sectionTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    s = f.createSection(secName, 'nixSection');
+    s = f.create_section(secName, 'nixSection');
     sID = s.id;
 
-    assert(~f.hasSection('I do not exist'));
-    assert(f.hasSection(secName));
+    assert(~f.has_section('I do not exist'));
+    assert(f.has_section(secName));
 
     clear s f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.hasSection(sID));
+    assert(f.has_section(sID));
 end

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -44,7 +44,7 @@ function [] = test_attrs( varargin )
     defOW = 'group definition';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     b.create_group(groupName, groupType);
 
     testGroup = b.groups{1};
@@ -78,7 +78,7 @@ function [] = test_add_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
     g = b.create_group('testGroup', 'nixGroup');
 
@@ -100,7 +100,7 @@ function [] = test_get_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
     daID = da.id;
     g = b.create_group('testGroup', 'nixGroup');
@@ -125,7 +125,7 @@ function [] = test_remove_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     da1 = b.create_data_array(daName1, daType, nix.DataType.Double, 1);
     da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
     da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
@@ -161,7 +161,7 @@ function [] = test_update_linked_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     da1 = b.create_data_array(daName1, daType, nix.DataType.Double, [1]);
     da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
     da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
@@ -196,7 +196,7 @@ end
 function [] = test_data_array_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     
     assert(g.data_array_count() == 0);
@@ -216,7 +216,7 @@ function [] = test_add_tag( varargin )
     tagName2 = 'testTag2';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     t1 = b.create_tag(tagName1, 'nixTag', [1.0 1.2 1.3 15.9]);
     t2 = b.create_tag(tagName2, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t2.id;
@@ -242,7 +242,7 @@ function [] = test_has_tag( varargin )
     tagName = 'testTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t = b.create_tag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     g.add_tag(t);
@@ -258,7 +258,7 @@ function [] = test_get_tag( varargin )
     tagName = 'testTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t = b.create_tag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t.id;
@@ -281,7 +281,7 @@ function [] = test_remove_tag( varargin )
     tagType = 'nixTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t1 = b.create_tag(tagName1, tagType, [1.0 1.2 1.3 15.9]);
     t2 = b.create_tag(tagName2, tagType, [1.0 1.2 1.3 15.9]);
@@ -317,7 +317,7 @@ end
 function [] = test_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     
     assert(g.tag_count() == 0);
@@ -338,7 +338,7 @@ function [] = test_add_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     tmp = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array(...
@@ -371,7 +371,7 @@ function [] = test_has_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     tmp = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array(...
@@ -394,7 +394,7 @@ function [] = test_get_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     da = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag(tagName, tagType, b.dataArrays{1});
@@ -419,7 +419,7 @@ function [] = test_remove_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('test', 'nixBlock');
+    b = f.create_block('test', 'nixBlock');
     da = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t1 = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
@@ -463,7 +463,7 @@ end
 function [] = test_multi_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
@@ -482,7 +482,7 @@ end
 function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('sourceTest', 'nixBlock');
+    b = f.create_block('sourceTest', 'nixBlock');
     s = b.create_source('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -503,7 +503,7 @@ end
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+    b = test_file.create_block('test', 'nixBlock');
     s = b.create_source('test', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -527,7 +527,7 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     s = b.create_source(sName, 'nixSource');
     g.add_source(b.sources{1}.id)
@@ -544,7 +544,7 @@ end
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+    b = test_file.create_block('test', 'nixBlock');
     s = b.create_source('test','nixSource');
     tmp = s.create_source('nestedsource1', 'nixSource');
     tmp = s.create_source('nestedsource2', 'nixSource');
@@ -560,7 +560,7 @@ end
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+    b = test_file.create_block('test', 'nixBlock');
     s = b.create_source('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
@@ -583,7 +583,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     
     assert(g.source_count() == 0);
@@ -604,9 +604,9 @@ function [] = test_set_metadata ( varargin )
     secName2 = 'testGroupSection2';
 
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.createSection(secName1, 'nixSection');
-    tmp = f.createSection(secName2, 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section(secName1, 'nixSection');
+    tmp = f.create_section(secName2, 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     assert(isempty(g.open_metadata));
     assert(isempty(f.blocks{1}.groups{1}.open_metadata))
@@ -631,8 +631,8 @@ end
 function [] = test_open_metadata( varargin )
 %% Test: Open metadata
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     g.set_metadata(f.sections{1});
 

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -45,7 +45,7 @@ end
 function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('sourceTest', 'nixBlock');
+    b = f.create_block('sourceTest', 'nixBlock');
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.create_source('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
@@ -71,7 +71,7 @@ end
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('sourceTest', 'nixBlock');
+    b = test_file.create_block('sourceTest', 'nixBlock');
     tmp = b.create_data_array(...
         'sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
@@ -94,7 +94,7 @@ end
 function [] = test_add_reference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('referenceTest', 'nixBlock');
+    b = f.create_block('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
@@ -122,7 +122,7 @@ end
 %% Test: Remove references by entity and id
 function [] = test_remove_reference ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('referenceTest', 'nixBlock');
+    b = test_file.create_block('referenceTest', 'nixBlock');
     tmp = b.create_data_array(...
         'referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
@@ -146,7 +146,7 @@ end
 function [] = test_add_feature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
@@ -182,7 +182,7 @@ end
 %% Test: Remove features by entity and id
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
 	tmp = b.create_data_array(...
         'featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
@@ -206,7 +206,7 @@ end
 %% Test: fetch references
 function [] = test_fetch_references( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('referenceTest', 'nixBlock');
+    b = test_file.create_block('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
@@ -220,7 +220,7 @@ end
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('sourceTest', 'nixBlock');
+    b = test_file.create_block('sourceTest', 'nixBlock');
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
@@ -235,7 +235,7 @@ end
 %% Test: fetch features
 function [] = test_fetch_features( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('featureTest', 'nixBlock');
+    b = test_file.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
@@ -248,7 +248,7 @@ end
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('sourceTest', 'nixBlock');
+    b = test_file.create_block('sourceTest', 'nixBlock');
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     sName = 'nestedSource';
@@ -271,7 +271,7 @@ end
 function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     s = b.create_source('sourceTest1', 'nixSource');
     sID = s.id;
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -290,7 +290,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 
@@ -307,7 +307,7 @@ end
 %% Test: Open feature by ID
 function [] = test_open_feature( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('featureTest', 'nixBlock');
+    b = test_file.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
@@ -323,7 +323,7 @@ end
 %% Test: Open reference by ID or name
 function [] = test_open_reference( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('referenceTest', 'nixBlock');
+    b = test_file.create_block('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     refName = 'referenceTest';
@@ -345,7 +345,7 @@ end
 function [] = test_feature_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da);
 
@@ -365,7 +365,7 @@ end
 function [] = test_reference_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da);
 
@@ -386,7 +386,7 @@ function [] = test_add_positions ( varargin )
     posName2 = 'positionsTest2';
     
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('positionsTest', 'nixBlock');
+    b = f.create_block('positionsTest', 'nixBlock');
     tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     mTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
 
@@ -409,7 +409,7 @@ end
 %% Test: Has positions
 function [] = test_has_positions( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('positionsTest', 'nixBlock');
+    b = test_file.create_block('positionsTest', 'nixBlock');
     tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
@@ -421,7 +421,7 @@ end
 %% Test: Open positions
 function [] = test_open_positions( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('positionsTest', 'nixBlock');
+    b = test_file.create_block('positionsTest', 'nixBlock');
     tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
@@ -434,7 +434,7 @@ end
 function [] = test_set_open_extents ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('extentsTest', 'nixBlock');
+    b = f.create_block('extentsTest', 'nixBlock');
     da = b.create_data_array('extentsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6; 1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('extentstest', 'nixMultiTag', da);
 
@@ -472,10 +472,10 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.createSection(secName1, 'nixSection');
-    tmp = f.createSection(secName2, 'nixSection');
+    tmp = f.create_section(secName1, 'nixSection');
+    tmp = f.create_section(secName2, 'nixSection');
 
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
 
@@ -503,8 +503,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
     t.set_metadata(f.sections{1});
@@ -532,7 +532,7 @@ end
 function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('featureTest', 'nixMultiTag', da);
     daf = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -552,7 +552,7 @@ function [] = test_has_reference( varargin )
     fileName = 'testRW.h5';
     daName = 'refTestDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('referenceTestBlock', 'nixBlock');
+    b = f.create_block('referenceTestBlock', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('referenceTest', 'nixMultiTag', da);
     refName = 'referenceTest';
@@ -572,7 +572,7 @@ function [] = test_set_units( varargin )
     fileName = 'testRW.h5';
     daName = 'testDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('unitsTest', 'nixMultiTag', da);
 
@@ -605,7 +605,7 @@ end
 function [] = test_attrs( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     tmp = b.create_data_array('attributeTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -20,7 +20,7 @@ end
 %% Test: Access Attributes
 function [] = test_attrs( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('testSectionProperty', 'nixSection');
+    s = f.create_section('testSectionProperty', 'nixSection');
     p = s.create_property('testProperty1', nix.DataType.String);
 
     assert(~isempty(p.id));
@@ -53,7 +53,7 @@ end
 %% Test: Access values
 function [] = test_values( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
     currProp = s.create_property_with_value('booleanProperty', {true, false, true});
 
     assert(size(currProp.values, 1) == 3);
@@ -68,7 +68,7 @@ end
 %% Test: Update values
 function [] = test_update_values( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
 
     %-- test update boolean
     updateBool = s.create_property_with_value('booleanProperty', {true, false, true});
@@ -115,7 +115,7 @@ end
 function [] = test_value_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.createSection('testSection', 'nixSection');
+    s = f.create_section('testSection', 'nixSection');
     p = s.create_property_with_value('booleanProperty', {true, false, true});
 
     assert(p.value_count() == 3);

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -31,7 +31,7 @@ end
 %% Test: Create Section
 function [] = test_create_section( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
 
     assert(isempty(s.sections));
     tmp = s.create_section('testSection1', 'nixSection');
@@ -42,7 +42,7 @@ end
 %% Test: Delete Section by entity or ID
 function [] = test_delete_section( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
     tmp = s.create_section('testSection1', 'nixSection');
     tmp = s.create_section('testSection2', 'nixSection');
 
@@ -105,7 +105,7 @@ end
 function [] = test_section_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
 
     assert(s.section_count() == 0);
     tmp = s.create_section('testSection1', 'nixSection');
@@ -121,7 +121,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes / Links
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('foo', 'bar');
+    s = f.create_section('foo', 'bar');
 
     assert(~isempty(s.id));
 
@@ -166,7 +166,7 @@ end
 %% Test: Create property by data type
 function [] = test_create_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
 
     tmp = s.create_property('newProperty1', nix.DataType.Double);
     tmp = s.create_property('newProperty2', nix.DataType.Bool);
@@ -178,7 +178,7 @@ end
 %% Test: Create property with value
 function [] = test_create_property_with_value( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
 
     tmp = s.create_property_with_value('doubleProperty1', [5, 6, 7, 8]);
     assert(strcmp(s.allProperties{end}.name, 'doubleProperty1'));
@@ -244,7 +244,7 @@ end
 %% Test: Delete property by entity, propertyStruct, ID and name
 function [] = test_delete_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
     tmp = s.create_property('newProperty1', nix.DataType.Double);
     tmp = s.create_property('newProperty2', nix.DataType.Bool);
     tmp = s.create_property('newProperty3', nix.DataType.String);
@@ -272,7 +272,7 @@ end
 function [] = test_property_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.createSection('mainSection', 'nixSection');
+    s = f.create_section('mainSection', 'nixSection');
 
     assert(s.property_count() == 0);
     tmp = s.create_property('newProperty1', nix.DataType.Double);
@@ -287,9 +287,9 @@ end
 %% Test: set, open and remove section link
 function [] = test_link( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    mainSec = f.createSection('mainSection', 'nixSection');
-    tmp = f.createSection('linkSection1', 'nixSection');
-    tmp = f.createSection('linkSection2', 'nixSection');
+    mainSec = f.create_section('mainSection', 'nixSection');
+    tmp = f.create_section('linkSection1', 'nixSection');
+    tmp = f.create_section('linkSection2', 'nixSection');
     
     assert(isempty(mainSec.openLink));
     mainSec.set_link(f.sections{3}.id);

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -26,7 +26,7 @@ end
 function [] = test_fetch_sources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('sourcetest', 'nixBlock');
+    b = f.create_block('sourcetest', 'nixBlock');
     s = b.create_source('sourcetest', 'nixSource');
 
     assert(isempty(s.sources));
@@ -47,7 +47,7 @@ end
 function [] = test_open_source( varargin )
 
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
+    getBlock = test_file.create_block('sourcetest', 'nixBlock');
     getSource = getBlock.create_source('sourcetest', 'nixSource');
     assert(isempty(getSource.sources));
 
@@ -68,7 +68,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
 
     assert(s.source_count() == 0);
@@ -87,9 +87,9 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection1', 'nixSection');
-    tmp = f.createSection('testSection2', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection1', 'nixSection');
+    tmp = f.create_section('testSection2', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
 
     assert(isempty(s.open_metadata));
@@ -116,8 +116,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
     s.set_metadata(f.sections{1});
 
@@ -127,7 +127,7 @@ end
 %% Test: create source
 function [] = test_create_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
+    getBlock = test_file.create_block('sourcetest', 'nixBlock');
     getSource = getBlock.create_source('sourcetest', 'nixSource');
     assert(isempty(getSource.sources));
 
@@ -140,7 +140,7 @@ end
 %% Test: delete source
 function [] = test_delete_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
+    getBlock = test_file.create_block('sourcetest', 'nixBlock');
     getSource = getBlock.create_source('sourcetest', 'nixSource');
     assert(isempty(getSource.sources));
 
@@ -155,7 +155,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('tagtest', 'test nixBlock');
+    b = f.create_block('tagtest', 'test nixBlock');
     s = b.create_source('sourcetest', 'test nixSource');
 
     assert(~isempty(s.id));
@@ -178,7 +178,7 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     sName = 'nestedsource';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     s = b.create_source('sourcetest', 'nixSource');
     nested = s.create_source(sName, 'nixSource');
     nestedID = nested.id;

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -40,7 +40,7 @@ end
 function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('sourceTest', 'nixBlock');
+    b = f.create_block('sourceTest', 'nixBlock');
     s = b.create_source('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -62,7 +62,7 @@ end
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('test', 'nixBlock');
+    getBlock = test_file.create_block('test', 'nixBlock');
     getSource = getBlock.create_source('test', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -84,7 +84,7 @@ end
 function [] = test_add_reference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('referenceTest', 'nixBlock');
+    b = f.create_block('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
@@ -107,7 +107,7 @@ end
 %% Test: Remove references by entity and id
 function [] = test_remove_reference ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('referenceTest', 'nixBlock');
+    getBlock = test_file.create_block('referenceTest', 'nixBlock');
     getRefDA1 = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     getRefDA2 = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
@@ -129,7 +129,7 @@ end
 function [] = test_add_feature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.create_data_array('featureTestDataArray3', 'nixDataArray', nix.DataType.Double, [5 6]);
@@ -158,7 +158,7 @@ end
 %% Test: Remove features by entity and id
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
@@ -177,7 +177,7 @@ end
 %% Test: fetch references
 function [] = test_fetch_references( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('referenceTest', 'nixBlock');
+    getBlock = test_file.create_block('referenceTest', 'nixBlock');
     tmp = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = getBlock.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
@@ -194,7 +194,7 @@ end
 function [] = test_reference_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2]);
 
     assert(t.reference_count() == 0);
@@ -210,7 +210,7 @@ end
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('test', 'nixBlock');
+    getBlock = test_file.create_block('test', 'nixBlock');
     getSource = getBlock.create_source('test','nixSource');
     tmp = getSource.create_source('nestedsource1', 'nixSource');
     tmp = getSource.create_source('nestedsource2', 'nixSource');
@@ -227,7 +227,7 @@ end
 %% Test: fetch features
 function [] = test_fetch_features( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
@@ -243,7 +243,7 @@ end
 function [] = test_feature_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2]);
 
     assert(t.feature_count() == 0);
@@ -261,7 +261,7 @@ end
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('test', 'nixBlock');
+    getBlock = test_file.create_block('test', 'nixBlock');
     getSource = getBlock.create_source('test', 'nixSource');
     sourceName = 'nestedsource';
     createSource = getSource.create_source(sourceName, 'nixSource');
@@ -284,7 +284,7 @@ end
 function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testblock', 'nixBlock');
+    b = f.create_block('testblock', 'nixBlock');
     s = b.create_source('sourceTest1', 'nixSource');
     sID = s.id;
     position = [1.0 1.2 1.3 15.9];
@@ -303,7 +303,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1.0 1.2]);
 
     assert(t.source_count() == 0);
@@ -319,7 +319,7 @@ end
 %% Test: Open feature by ID
 function [] = test_open_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
     getTag = b.create_tag('featureTest', 'nixTag', position);
@@ -336,7 +336,7 @@ end
 %% Test: Open reference by ID or name
 function [] = test_open_reference( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('referenceTest', 'nixBlock');
+    getBlock = test_file.create_block('referenceTest', 'nixBlock');
     tmp = getBlock.create_data_array('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
     getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
@@ -359,10 +359,10 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.createSection(secName1, 'nixSection');
-    tmp = f.createSection(secName2, 'nixSection');
+    tmp = f.create_section(secName1, 'nixSection');
+    tmp = f.create_section(secName2, 'nixSection');
 
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1, 2, 3, 4]);
 
     assert(isempty(t.open_metadata));
@@ -389,8 +389,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.createSection('testSection', 'nixSection');
-    b = f.createBlock('testBlock', 'nixBlock');
+    tmp = f.create_section('testSection', 'nixSection');
+    b = f.create_block('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1, 2, 3, 4]);
 
     t.set_metadata(f.sections{1});
@@ -417,7 +417,7 @@ end
 function [] = test_attrs( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('testBlock', 'nixBlock');
+    b = f.create_block('testBlock', 'nixBlock');
     pos = [1, 2, 3, 4];
     t1 = b.create_tag('testTag', 'nixTag', pos);
 
@@ -482,7 +482,7 @@ end
 function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('featureTest', 'nixBlock');
+    b = f.create_block('featureTest', 'nixBlock');
     da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_tag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     feature = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -501,7 +501,7 @@ function [] = test_has_reference( varargin )
     fileName = 'testRW.h5';
     daName = 'referenceTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.createBlock('referenceTest', 'nixBlock');
+    b = f.create_block('referenceTest', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_tag('referenceTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     t.add_reference(b.dataArrays{1});


### PR DESCRIPTION
- Closes #126.
- Changes the `file` method names on the Matlab side to snake case, since it is feature wise a small pull request... I already had that one lined up before [the issue](https://github.com/G-Node/nix-mx/pull/134#issuecomment-307825348) arose... ;)

Successfully built under win32 (Matlab R2011a) and win64 (Matlab R2011a).
