### PR TITLE
Add missing 'Property' functions

### DIFF
--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -65,6 +65,16 @@ classdef Property < nix.NamedEntity
         function [] = values_delete(obj)
             nix_mx('Property::deleteValues', obj.nix_handle);
         end
+        
+        % return value 0 means name and id of two properties are
+        % identical, any other value means either name or id differ.
+        function cmp_val = compare(obj, property)
+            if (~strcmp(class(property), class(obj)))
+               error('Function only supports comparison of Properties.');
+            end
+            cmp_val = nix_mx('Property::compare', obj.nix_handle, property.nix_handle);
+        end
+
     end
 
 end

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -61,6 +61,10 @@ classdef Property < nix.NamedEntity
         function c = value_count(obj)
             c = nix_mx('Property::valueCount', obj.nix_handle);
         end
+
+        function [] = values_delete(obj)
+            nix_mx('Property::deleteValues', obj.nix_handle);
+        end
     end
 
 end

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -362,9 +362,11 @@ void mexFunction(int            nlhs,
             .reg("setNoneUnit", SETTER(const boost::none_t, nix::Property, unit))
             .reg("setMapping", SETTER(const std::string&, nix::Property, mapping))
             .reg("setNoneMapping", SETTER(const boost::none_t, nix::Property, mapping))
-            .reg("valueCount", GETTER(nix::ndsize_t, nix::Property, valueCount));
+            .reg("valueCount", GETTER(nix::ndsize_t, nix::Property, valueCount))
+            .reg("setNoneValue", SETTER(const boost::none_t, nix::Property, values));
         methods->add("Property::values", nixproperty::values);
         methods->add("Property::updateValues", nixproperty::updateValues);
+        methods->add("Property::deleteValues", nixproperty::deleteValues);
 
         classdef<nix::SetDimension>("SetDimension", methods)
             .desc(&nixdimensions::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -367,6 +367,7 @@ void mexFunction(int            nlhs,
         methods->add("Property::values", nixproperty::values);
         methods->add("Property::updateValues", nixproperty::updateValues);
         methods->add("Property::deleteValues", nixproperty::deleteValues);
+        methods->add("Property::compare", nixproperty::compare);
 
         classdef<nix::SetDimension>("SetDimension", methods)
             .desc(&nixdimensions::describe)

--- a/src/nixproperty.cc
+++ b/src/nixproperty.cc
@@ -64,4 +64,9 @@ namespace nixproperty {
         prop.values(getVals);
     }
 
+    void deleteValues(const extractor &input, infusor &output) {
+        nix::Property prop = input.entity<nix::Property>(1);
+        prop.deleteValues();
+    }
+
 } // namespace nixproperty

--- a/src/nixproperty.cc
+++ b/src/nixproperty.cc
@@ -69,4 +69,10 @@ namespace nixproperty {
         prop.deleteValues();
     }
 
+    void compare(const extractor &input, infusor &output) {
+        nix::Property pm = input.entity<nix::Property>(1);
+        nix::Property pc = input.entity<nix::Property>(2);
+        output.set(0, pm.compare(pc));
+    }
+
 } // namespace nixproperty

--- a/src/nixproperty.h
+++ b/src/nixproperty.h
@@ -21,6 +21,8 @@ namespace nixproperty {
 
     void deleteValues(const extractor &input, infusor &output);
 
+    void compare(const extractor &input, infusor &output);
+
 } // namespace nixproperty
 
 #endif

--- a/src/nixproperty.h
+++ b/src/nixproperty.h
@@ -19,6 +19,8 @@ namespace nixproperty {
 
     void updateValues(const extractor &input, infusor &output);
 
+    void deleteValues(const extractor &input, infusor &output);
+
 } // namespace nixproperty
 
 #endif

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -16,6 +16,7 @@ function funcs = TestProperty
     funcs{end+1} = @test_values;
     funcs{end+1} = @test_value_count;
     funcs{end+1} = @test_values_delete;
+    funcs{end+1} = @test_property_compare;
 end
 
 %% Test: Access Attributes
@@ -144,4 +145,28 @@ function [] = test_values_delete( varargin )
     clear p s f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
     assert(isempty(f.sections{1}.allProperties{1}.values));
+end
+
+%% Test: Compare properties
+function [] = test_property_compare( varargin )
+    testFile = fullfile(pwd,'tests','testRW.h5');
+    f = nix.File(testFile, nix.FileMode.Overwrite);
+    s1 = f.create_section('testSection1', 'nixSection');
+    s2 = f.create_section('testSection2', 'nixSection');
+
+    p = s1.create_property_with_value('property', {true, false, true});
+
+    % test invalid property comparison
+    try
+        p.compare('I shall crash and burn');
+    catch ME
+        assert(strcmp(ME.message, 'Function only supports comparison of Properties.'));
+    end
+    
+    % test property equal comparison
+    assert(~p.compare(p));
+
+    % test property not eqal
+    pNEq = s2.create_property_with_value('property', {true, false});
+    assert(p.compare(pNEq)~=0);
 end

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -15,6 +15,7 @@ function funcs = TestProperty
     funcs{end+1} = @test_update_values;
     funcs{end+1} = @test_values;
     funcs{end+1} = @test_value_count;
+    funcs{end+1} = @test_values_delete;
 end
 
 %% Test: Access Attributes
@@ -127,4 +128,20 @@ function [] = test_value_count( varargin )
     f = nix.File(testFile, nix.FileMode.ReadOnly);
     pid = f.sections{1}.allProperties{1}.id;
     assert(f.sections{1}.open_property(pid).value_count() == 1);
+end
+
+%% Test: Delete values
+function [] = test_values_delete( varargin )
+    testFile = fullfile(pwd,'tests','testRW.h5');
+    f = nix.File(testFile, nix.FileMode.Overwrite);
+    s = f.create_section('testSection', 'nixSection');
+
+    p = s.create_property_with_value('property1', {true, false, true});
+    assert(~isempty(p.values));
+    p.values_delete();
+    assert(isempty(p.values));
+
+    clear p s f;
+    f = nix.File(testFile, nix.FileMode.ReadOnly);
+    assert(isempty(f.sections{1}.allProperties{1}.values));
 end


### PR DESCRIPTION
Closes #131.

Successfully built under win32 (Matlab R2011a) and win64 (Matlab R2011a).