### PR TITLE
Add missing 'Source' functions

### DIFF
--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -63,5 +63,10 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             retObj = nix.Utils.fetchObjList('Source::referringTags', ...
                 obj.nix_handle, @nix.Tag);
         end
+
+        function retObj = referring_multi_tags(obj)
+            retObj = nix.Utils.fetchObjList('Source::referringMultiTags', ...
+                obj.nix_handle, @nix.MultiTag);
+        end
     end;
 end

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -48,6 +48,10 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             retObj = nix.Utils.open_entity(obj, ...
                 'Source::openSource', id_or_name, @nix.Source);
         end;
-        
+
+        function retObj = parent_source(obj)
+            retObj = nix.Utils.fetchObj('Source::parentSource', ...
+                obj.nix_handle, @nix.Source);
+        end
     end;
 end

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -53,5 +53,10 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             retObj = nix.Utils.fetchObj('Source::parentSource', ...
                 obj.nix_handle, @nix.Source);
         end
+
+        function retObj = referring_data_arrays(obj)
+            retObj = nix.Utils.fetchObjList('Source::referringDataArrays', ...
+                obj.nix_handle, @nix.DataArray);
+        end
     end;
 end

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -58,5 +58,10 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             retObj = nix.Utils.fetchObjList('Source::referringDataArrays', ...
                 obj.nix_handle, @nix.DataArray);
         end
+
+        function retObj = referring_tags(obj)
+            retObj = nix.Utils.fetchObjList('Source::referringTags', ...
+                obj.nix_handle, @nix.Tag);
+        end
     end;
 end

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -245,7 +245,8 @@ void mexFunction(int            nlhs,
             .reg("setNoneDefinition", SETTER(const boost::none_t, nix::Source, definition))
             .reg("parentSource", GETTER(nix::Source, nix::Source, parentSource))
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::Source, sourceCount))
-            .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Source, referringDataArrays));
+            .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Source, referringDataArrays))
+            .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Source, referringTags));
 
         classdef<nix::Tag>("Tag", methods)
             .desc(&nixtag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -244,7 +244,8 @@ void mexFunction(int            nlhs,
             .reg("setDefinition", SETTER(const std::string&, nix::Source, definition))
             .reg("setNoneDefinition", SETTER(const boost::none_t, nix::Source, definition))
             .reg("parentSource", GETTER(nix::Source, nix::Source, parentSource))
-            .reg("sourceCount", GETTER(nix::ndsize_t, nix::Source, sourceCount));
+            .reg("sourceCount", GETTER(nix::ndsize_t, nix::Source, sourceCount))
+            .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Source, referringDataArrays));
 
         classdef<nix::Tag>("Tag", methods)
             .desc(&nixtag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -246,7 +246,8 @@ void mexFunction(int            nlhs,
             .reg("parentSource", GETTER(nix::Source, nix::Source, parentSource))
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::Source, sourceCount))
             .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Source, referringDataArrays))
-            .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Source, referringTags));
+            .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Source, referringTags))
+            .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Source, referringMultiTags));
 
         classdef<nix::Tag>("Tag", methods)
             .desc(&nixtag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -243,6 +243,7 @@ void mexFunction(int            nlhs,
             .reg("setType", SETTER(const std::string&, nix::Source, type))
             .reg("setDefinition", SETTER(const std::string&, nix::Source, definition))
             .reg("setNoneDefinition", SETTER(const boost::none_t, nix::Source, definition))
+            .reg("parentSource", GETTER(nix::Source, nix::Source, parentSource))
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::Source, sourceCount));
 
         classdef<nix::Tag>("Tag", methods)

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -23,6 +23,7 @@ function funcs = TestSource
     funcs{end+1} = @test_open_metadata;
     funcs{end+1} = @test_referring_data_arrays;
     funcs{end+1} = @test_referring_tags;
+    funcs{end+1} = @test_referring_multi_tags;
 end
 
 %% Test: fetch sources
@@ -245,4 +246,24 @@ function [] = test_referring_tags( varargin )
     t2 = b.create_tag('testTag2', 'nixTag', [1, 2]);
     t2.add_source(s);
     assert(size(s.referring_tags, 1) == 2);
+end
+
+%% Test: Referring multi tags
+function [] = test_referring_multi_tags( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.create_source('testSource', 'nixSource');
+
+    assert(isempty(s.referring_multi_tags));
+
+    t1 = b.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
+    t1.add_source(s);
+    assert(~isempty(s.referring_multi_tags));
+    assert(strcmp(s.referring_multi_tags{1}.name, t1.name));
+
+    t2 = b.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
+    t2.add_source(s);
+    assert(size(s.referring_multi_tags, 1) == 2);
 end

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -18,6 +18,7 @@ function funcs = TestSource
     funcs{end+1} = @test_has_source;
     funcs{end+1} = @test_open_source;
     funcs{end+1} = @test_source_count;
+    funcs{end+1} = @test_parent_source;
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
 end
@@ -189,4 +190,19 @@ function [] = test_has_source( varargin )
     clear nested s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
     assert(f.blocks{1}.sources{1}.has_source(nestedID));
+end
+
+%% Test: Get parent source
+function [] = test_parent_source( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.create_block('sourcetest', 'nixBlock');
+    sourceName1 = 'testSource1';
+    sourceName2 = 'testSource2';
+    s1 = b.create_source(sourceName1, 'nixSource');
+    s2 = s1.create_source(sourceName2, 'nixSource');
+    s3 = s2.create_source('testSource3', 'nixSource');
+
+    assert(strcmp(s3.parent_source.name, sourceName2));
+    assert(strcmp(s2.parent_source.name, sourceName1));
 end

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -22,6 +22,7 @@ function funcs = TestSource
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
     funcs{end+1} = @test_referring_data_arrays;
+    funcs{end+1} = @test_referring_tags;
 end
 
 %% Test: fetch sources
@@ -225,4 +226,23 @@ function [] = test_referring_data_arrays( varargin )
     d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2.add_source(s);
     assert(size(s.referring_data_arrays, 1) == 2);
+end
+
+%% Test: Referring tags
+function [] = test_referring_tags( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    s = b.create_source('testSource', 'nixSource');
+
+    assert(isempty(s.referring_tags));
+
+    t1 = b.create_tag('testTag1', 'nixTag', [1, 2]);
+    t1.add_source(s);
+    assert(~isempty(s.referring_tags));
+    assert(strcmp(s.referring_tags{1}.name, t1.name));
+
+    t2 = b.create_tag('testTag2', 'nixTag', [1, 2]);
+    t2.add_source(s);
+    assert(size(s.referring_tags, 1) == 2);
 end

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -21,6 +21,7 @@ function funcs = TestSource
     funcs{end+1} = @test_parent_source;
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
+    funcs{end+1} = @test_referring_data_arrays;
 end
 
 %% Test: fetch sources
@@ -205,4 +206,23 @@ function [] = test_parent_source( varargin )
 
     assert(strcmp(s3.parent_source.name, sourceName2));
     assert(strcmp(s2.parent_source.name, sourceName1));
+end
+
+%% Test: Referring data arrays
+function [] = test_referring_data_arrays( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    s = b.create_source('testSource', 'nixSource');
+
+    assert(isempty(s.referring_data_arrays));
+
+    d1 = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d1.add_source(s);
+    assert(~isempty(s.referring_data_arrays));
+    assert(strcmp(s.referring_data_arrays{1}.name, d1.name));
+
+    d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d2.add_source(s);
+    assert(size(s.referring_data_arrays, 1) == 2);
 end


### PR DESCRIPTION
- Closes #129

Successfully built under win32 (Matlab R2011a) and win64 (Matlab R2011a).