### PR TITLE
Add missing 'Section' functions

### DIFF
--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -169,5 +169,10 @@ classdef Section < nix.NamedEntity
             ret = nix.Utils.fetchObjList('Section::referringMultiTags', ...
                 obj.nix_handle, @nix.MultiTag);
         end
+
+        function ret = referring_sources(obj)
+            ret = nix.Utils.fetchObjList('Section::referringSources', ...
+                obj.nix_handle, @nix.Source);
+        end
     end;
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -151,5 +151,13 @@ classdef Section < nix.NamedEntity
             c = nix_mx('Section::propertyCount', obj.nix_handle);
         end
 
+        % ----------------
+        % Referring entity methods
+        % ----------------
+
+        function das = referring_data_arrays(obj)
+            das = nix.Utils.fetchObjList('Section::referringDataArrays', ...
+                obj.nix_handle, @nix.DataArray);
+        end
     end;
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -164,9 +164,8 @@ classdef Section < nix.NamedEntity
             ret = obj.referring_util(@nix.Tag, 'Tags', varargin{:});
         end
 
-        function ret = referring_multi_tags(obj)
-            ret = nix.Utils.fetchObjList('Section::referringMultiTags', ...
-                obj.nix_handle, @nix.MultiTag);
+        function ret = referring_multi_tags(obj, varargin)
+            ret = obj.referring_util(@nix.MultiTag, 'MultiTags', varargin{:});
         end
 
         function ret = referring_sources(obj, varargin)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -174,5 +174,10 @@ classdef Section < nix.NamedEntity
             ret = nix.Utils.fetchObjList('Section::referringSources', ...
                 obj.nix_handle, @nix.Source);
         end
+
+        function ret = referring_blocks(obj)
+            ret = nix.Utils.fetchObjList('Section::referringBlocks', ...
+                obj.nix_handle, @nix.Block);
+        end
     end;
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -160,9 +160,8 @@ classdef Section < nix.NamedEntity
                 obj.nix_handle, @nix.DataArray);
         end
 
-        function ret = referring_tags(obj)
-            ret = nix.Utils.fetchObjList('Section::referringTags', ...
-                obj.nix_handle, @nix.Tag);
+        function ret = referring_tags(obj, varargin)
+            ret = obj.referring_util(@nix.Tag, 'Tags', varargin{:});
         end
 
         function ret = referring_multi_tags(obj)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -65,6 +65,11 @@ classdef Section < nix.NamedEntity
            end;
         end;
 
+        function retList = inherited_properties(obj)
+            retList = nix.Utils.fetchObjList('Section::inheritedProperties', ...
+                obj.nix_handle, @nix.Property);
+        end
+
         % ----------------
         % Section methods
         % ----------------

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -170,9 +170,8 @@ classdef Section < nix.NamedEntity
                 obj.nix_handle, @nix.MultiTag);
         end
 
-        function ret = referring_sources(obj)
-            ret = nix.Utils.fetchObjList('Section::referringSources', ...
-                obj.nix_handle, @nix.Source);
+        function ret = referring_sources(obj, varargin)
+            ret = obj.referring_util(@nix.Source, 'Sources', varargin{:});
         end
 
         function ret = referring_blocks(obj)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -164,5 +164,10 @@ classdef Section < nix.NamedEntity
             ret = nix.Utils.fetchObjList('Section::referringTags', ...
                 obj.nix_handle, @nix.Tag);
         end
+
+        function ret = referring_multi_tags(obj)
+            ret = nix.Utils.fetchObjList('Section::referringMultiTags', ...
+                obj.nix_handle, @nix.MultiTag);
+        end
     end;
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -180,4 +180,26 @@ classdef Section < nix.NamedEntity
                 obj.nix_handle, @nix.Block);
         end
     end;
+
+    % ----------------
+    % Referring utility method
+    % ----------------
+
+    methods(Access=protected)
+        % referring_util receives a nix entityConstructor, part of a function
+        % name and varargin to provide abstract access to nix.Section
+        % referringXXX and referringXXX(Block) methods.
+        function ret = referring_util(obj, entityConstructor, funcName, varargin)
+            if (isempty(varargin))
+                ret = nix.Utils.fetchObjList(strcat('Section::referring', funcName), ...
+                    obj.nix_handle, entityConstructor);
+            elseif ((size(varargin, 2) > 1) || ...
+                    (~strcmp(class(varargin{1}), 'nix.Block')))
+                error('Provide either empty arguments or a single Block entity');
+            else
+                ret = nix.Utils.fetchObjListByEntity(strcat('Section::referringBlock', funcName), ...
+                    obj.nix_handle, varargin{1}.nix_handle, entityConstructor);
+            end
+        end
+    end
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -155,9 +155,8 @@ classdef Section < nix.NamedEntity
         % Referring entity methods
         % ----------------
 
-        function das = referring_data_arrays(obj)
-            das = nix.Utils.fetchObjList('Section::referringDataArrays', ...
-                obj.nix_handle, @nix.DataArray);
+        function ret = referring_data_arrays(obj, varargin)
+            ret = obj.referring_util(@nix.DataArray, 'DataArrays', varargin{:});
         end
 
         function ret = referring_tags(obj, varargin)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -159,5 +159,10 @@ classdef Section < nix.NamedEntity
             das = nix.Utils.fetchObjList('Section::referringDataArrays', ...
                 obj.nix_handle, @nix.DataArray);
         end
+
+        function ret = referring_tags(obj)
+            ret = nix.Utils.fetchObjList('Section::referringTags', ...
+                obj.nix_handle, @nix.Tag);
+        end
     end;
 end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -17,6 +17,19 @@ classdef Utils
             end;
         end;
 
+        % This method calls the nix-mx function specified by 'nixMxFunc', handing 
+        % over 'handle' as the main nix entity handle and 'related_handle' as a 
+        % second nix entity handle related to the first one.
+        % 'objConstrucor' requires the Matlab entity constructor of the expected 
+        % returned nix Entities.
+        function currData = fetchObjListByEntity(nixMxFunc, handle, related_handle, objConstructor)
+            currList = nix_mx(nixMxFunc, handle, related_handle);
+            currData = cell(length(currList), 1);
+            for i = 1:length(currList)
+                currData{i} = objConstructor(currList{i});
+            end;
+        end;
+
         function retCell = fetchObj(nixMxFunc, handle, objConstructor)
             sh = nix_mx(nixMxFunc, handle);
             if sh ~= 0

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -357,6 +357,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);
         methods->add("Section::referringBlockSources", nixsection::referringBlockSources);
+        methods->add("Section::referringBlockTags", nixsection::referringBlockTags);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -351,7 +351,8 @@ void mexFunction(int            nlhs,
             .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Section, referringDataArrays))
             .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Section, referringTags))
             .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags))
-            .reg("referringSources", GETTER(std::vector<nix::Source>, nix::Section, referringSources));
+            .reg("referringSources", GETTER(std::vector<nix::Source>, nix::Section, referringSources))
+            .reg("referringBlocks", GETTER(std::vector<nix::Block>, nix::Section, referringBlocks));
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -359,6 +359,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::referringBlockSources", nixsection::referringBlockSources);
         methods->add("Section::referringBlockTags", nixsection::referringBlockTags);
         methods->add("Section::referringBlockMultiTags", nixsection::referringBlockMultiTags);
+        methods->add("Section::referringBlockDataArrays", nixsection::referringBlockDataArrays);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -347,7 +347,8 @@ void mexFunction(int            nlhs,
             .reg("deleteProperty", REMOVER(nix::Property, nix::Section, deleteProperty))
             .reg("sectionCount", GETTER(nix::ndsize_t, nix::Section, sectionCount))
             .reg("propertyCount", GETTER(nix::ndsize_t, nix::Section, propertyCount))
-            .reg("inheritedProperties", GETTER(std::vector<nix::Property>, nix::Section, inheritedProperties));
+            .reg("inheritedProperties", GETTER(std::vector<nix::Property>, nix::Section, inheritedProperties))
+            .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Section, referringDataArrays));
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -349,7 +349,8 @@ void mexFunction(int            nlhs,
             .reg("propertyCount", GETTER(nix::ndsize_t, nix::Section, propertyCount))
             .reg("inheritedProperties", GETTER(std::vector<nix::Property>, nix::Section, inheritedProperties))
             .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Section, referringDataArrays))
-            .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Section, referringTags));
+            .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Section, referringTags))
+            .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags));
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -348,7 +348,8 @@ void mexFunction(int            nlhs,
             .reg("sectionCount", GETTER(nix::ndsize_t, nix::Section, sectionCount))
             .reg("propertyCount", GETTER(nix::ndsize_t, nix::Section, propertyCount))
             .reg("inheritedProperties", GETTER(std::vector<nix::Property>, nix::Section, inheritedProperties))
-            .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Section, referringDataArrays));
+            .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Section, referringDataArrays))
+            .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Section, referringTags));
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -350,7 +350,8 @@ void mexFunction(int            nlhs,
             .reg("inheritedProperties", GETTER(std::vector<nix::Property>, nix::Section, inheritedProperties))
             .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Section, referringDataArrays))
             .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Section, referringTags))
-            .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags));
+            .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags))
+            .reg("referringSources", GETTER(std::vector<nix::Source>, nix::Section, referringSources));
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -358,6 +358,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);
         methods->add("Section::referringBlockSources", nixsection::referringBlockSources);
         methods->add("Section::referringBlockTags", nixsection::referringBlockTags);
+        methods->add("Section::referringBlockMultiTags", nixsection::referringBlockMultiTags);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -356,6 +356,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);
+        methods->add("Section::referringBlockSources", nixsection::referringBlockSources);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -346,7 +346,8 @@ void mexFunction(int            nlhs,
             .reg("openProperty", GETBYSTR(nix::Property, nix::Section, getProperty))
             .reg("deleteProperty", REMOVER(nix::Property, nix::Section, deleteProperty))
             .reg("sectionCount", GETTER(nix::ndsize_t, nix::Section, sectionCount))
-            .reg("propertyCount", GETTER(nix::ndsize_t, nix::Section, propertyCount));
+            .reg("propertyCount", GETTER(nix::ndsize_t, nix::Section, propertyCount))
+            .reg("inheritedProperties", GETTER(std::vector<nix::Property>, nix::Section, inheritedProperties));
         methods->add("Section::properties", nixsection::properties);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -87,4 +87,10 @@ namespace nixsection {
         output.set(0, currSec.referringSources(currBlock));
     }
 
+    void referringBlockTags(const extractor &input, infusor &output) {
+        nix::Section currSec = input.entity<nix::Section>(1);
+        nix::Block currBlock = input.entity<nix::Block>(2);
+        output.set(0, currSec.referringTags(currBlock));
+    }
+
 } // namespace nixsection

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -99,4 +99,10 @@ namespace nixsection {
         output.set(0, currSec.referringMultiTags(currBlock));
     }
 
+    void referringBlockDataArrays(const extractor &input, infusor &output) {
+        nix::Section currSec = input.entity<nix::Section>(1);
+        nix::Block currBlock = input.entity<nix::Block>(2);
+        output.set(0, currSec.referringDataArrays(currBlock));
+    }
+
 } // namespace nixsection

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -93,4 +93,10 @@ namespace nixsection {
         output.set(0, currSec.referringTags(currBlock));
     }
 
+    void referringBlockMultiTags(const extractor &input, infusor &output) {
+        nix::Section currSec = input.entity<nix::Section>(1);
+        nix::Block currBlock = input.entity<nix::Block>(2);
+        output.set(0, currSec.referringMultiTags(currBlock));
+    }
+
 } // namespace nixsection

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -81,4 +81,10 @@ namespace nixsection {
         output.set(0, handle(p));
     }
 
+    void referringBlockSources(const extractor &input, infusor &output) {
+        nix::Section currSec = input.entity<nix::Section>(1);
+        nix::Block currBlock = input.entity<nix::Block>(2);
+        output.set(0, currSec.referringSources(currBlock));
+    }
+
 } // namespace nixsection

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -21,6 +21,8 @@ namespace nixsection {
 
     void createPropertyWithValue(const extractor &input, infusor &output);
 
+    void referringBlockSources(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -25,6 +25,8 @@ namespace nixsection {
 
     void referringBlockTags(const extractor &input, infusor &output);
 
+    void referringBlockMultiTags(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -23,6 +23,8 @@ namespace nixsection {
 
     void referringBlockSources(const extractor &input, infusor &output);
 
+    void referringBlockTags(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -27,6 +27,8 @@ namespace nixsection {
 
     void referringBlockMultiTags(const extractor &input, infusor &output);
 
+    void referringBlockDataArrays(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -27,6 +27,7 @@ function funcs = TestSection
     funcs{end+1} = @test_property_count;
     funcs{end+1} = @test_link;
     funcs{end+1} = @test_inherited_properties;
+    funcs{end+1} = @test_referring_data_arrays;
 end
 
 %% Test: Create Section
@@ -319,4 +320,26 @@ function [] = test_inherited_properties( varargin )
     
     s.create_property('testProperty1', nix.DataType.String);
     assert(size(s.inherited_properties, 1) == 2);
+end
+
+%% Test: referring data arrays
+function [] = test_referring_data_arrays( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    d1 = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    d2 = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = f.create_section('testSection', 'nixSection');
+    
+    assert(isempty(s.referring_data_arrays));
+
+    d1.set_metadata(s);
+    assert(~isempty(s.referring_data_arrays));
+    
+    d2.set_metadata(s);
+    assert(size(s.referring_data_arrays, 1) == 2);
+    
+    b2.delete_data_array(d2);
+    d1.set_metadata('');
+    assert(isempty(s.referring_data_arrays));
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -30,6 +30,7 @@ function funcs = TestSection
     funcs{end+1} = @test_referring_data_arrays;
     funcs{end+1} = @test_referring_tags;
     funcs{end+1} = @test_referring_multi_tags;
+    funcs{end+1} = @test_referring_sources;
 end
 
 %% Test: Create Section
@@ -390,4 +391,26 @@ function [] = test_referring_tags( varargin )
     b2.delete_multi_tag(t2);
     t1.set_metadata('');
     assert(isempty(s.referring_multi_tags));
+end
+
+%% Test: referring sources
+function [] = test_referring_sources( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    s1 = b1.create_source('testSource1', 'nixSource');
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    s2 = b2.create_source('testSource2', 'nixSource');
+    s = f.create_section('testSection', 'nixSection');
+    
+    assert(isempty(s.referring_sources));
+
+    s1.set_metadata(s);
+    assert(~isempty(s.referring_sources));
+    
+    s2.set_metadata(s);
+    assert(size(s.referring_sources, 1) == 2);
+    
+    b2.delete_source(s2);
+    s1.set_metadata('');
+    assert(isempty(s.referring_sources));
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -31,6 +31,7 @@ function funcs = TestSection
     funcs{end+1} = @test_referring_tags;
     funcs{end+1} = @test_referring_multi_tags;
     funcs{end+1} = @test_referring_sources;
+    funcs{end+1} = @test_referring_block_sources;
     funcs{end+1} = @test_referring_blocks;
 end
 
@@ -414,6 +415,41 @@ function [] = test_referring_sources( varargin )
     b2.delete_source(s2);
     s1.set_metadata('');
     assert(isempty(s.referring_sources));
+end
+
+%% Test: referring block sources
+function [] = test_referring_block_sources( varargin )
+    err = 'Provide either empty arguments or a single Block entity';
+    testName = 'testSource1';
+
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    s1 = b1.create_source(testName, 'nixSource');
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    s2 = b2.create_source('testSource2', 'nixSource');
+    s = f.create_section('testSection', 'nixSection');
+
+    s1.set_metadata(s);
+    s2.set_metadata(s);
+
+    % test multiple arguments fail
+    try
+        s.referring_sources('a', 'b');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test non block entity argument fail
+    try
+        s.referring_sources(s);
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test return only sources from block 1
+    testSource = s.referring_sources(b1);
+    assert(size(testSource, 2) == 1);
+    assert(strcmp(testSource{1}.name, testName));
 end
 
 %% Test: referring blocks

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -29,6 +29,7 @@ function funcs = TestSection
     funcs{end+1} = @test_inherited_properties;
     funcs{end+1} = @test_referring_data_arrays;
     funcs{end+1} = @test_referring_tags;
+    funcs{end+1} = @test_referring_multi_tags;
 end
 
 %% Test: Create Section
@@ -346,7 +347,7 @@ function [] = test_referring_data_arrays( varargin )
 end
 
 %% Test: referring tags
-function [] = test_referring_tags( varargin )
+function [] = test_referring_multi_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.create_block('testBlock1', 'nixBlock');
     t1 = b1.create_tag('testTag1', 'nixTag', [1, 2]);
@@ -365,4 +366,28 @@ function [] = test_referring_tags( varargin )
     b2.delete_tag(t2);
     t1.set_metadata('');
     assert(isempty(s.referring_tags));
+end
+
+%% Test: referring multi tags
+function [] = test_referring_tags( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    d = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t1 = b1.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    d = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t2 = b2.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
+    s = f.create_section('testSection', 'nixSection');
+    
+    assert(isempty(s.referring_multi_tags));
+
+    t1.set_metadata(s);
+    assert(~isempty(s.referring_multi_tags));
+    
+    t2.set_metadata(s);
+    assert(size(s.referring_multi_tags, 1) == 2);
+    
+    b2.delete_multi_tag(t2);
+    t1.set_metadata('');
+    assert(isempty(s.referring_multi_tags));
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -28,6 +28,7 @@ function funcs = TestSection
     funcs{end+1} = @test_link;
     funcs{end+1} = @test_inherited_properties;
     funcs{end+1} = @test_referring_data_arrays;
+    funcs{end+1} = @test_referring_tags;
 end
 
 %% Test: Create Section
@@ -342,4 +343,26 @@ function [] = test_referring_data_arrays( varargin )
     b2.delete_data_array(d2);
     d1.set_metadata('');
     assert(isempty(s.referring_data_arrays));
+end
+
+%% Test: referring tags
+function [] = test_referring_tags( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    t1 = b1.create_tag('testTag1', 'nixTag', [1, 2]);
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    t2 = b2.create_tag('testTag2', 'nixTag', [3, 4]);
+    s = f.create_section('testSection', 'nixSection');
+    
+    assert(isempty(s.referring_tags));
+
+    t1.set_metadata(s);
+    assert(~isempty(s.referring_tags));
+    
+    t2.set_metadata(s);
+    assert(size(s.referring_tags, 1) == 2);
+    
+    b2.delete_tag(t2);
+    t1.set_metadata('');
+    assert(isempty(s.referring_tags));
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -26,6 +26,7 @@ function funcs = TestSection
     funcs{end+1} = @test_open_property;
     funcs{end+1} = @test_property_count;
     funcs{end+1} = @test_link;
+    funcs{end+1} = @test_inherited_properties;
 end
 
 %% Test: Create Section
@@ -299,4 +300,23 @@ function [] = test_link( varargin )
     
     mainSec.set_link('');
     assert(isempty(mainSec.openLink));
+end
+
+%% Test: inherited properties
+function [] = test_inherited_properties( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    s = f.create_section('mainSection', 'nixSection');
+    ls = f.create_section('linkSection', 'nixSection');
+    
+    assert(isempty(s.inherited_properties));
+
+    s.set_link(ls);
+    assert(isempty(s.inherited_properties));
+
+    lp = ls.create_property('testProperty2', nix.DataType.String);
+    assert(~isempty(s.inherited_properties));
+    assert(strcmp(s.inherited_properties{1}.name, lp.name));
+    
+    s.create_property('testProperty1', nix.DataType.String);
+    assert(size(s.inherited_properties, 1) == 2);
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -29,6 +29,7 @@ function funcs = TestSection
     funcs{end+1} = @test_inherited_properties;
     funcs{end+1} = @test_referring_data_arrays;
     funcs{end+1} = @test_referring_tags;
+    funcs{end+1} = @test_referring_block_tags;
     funcs{end+1} = @test_referring_multi_tags;
     funcs{end+1} = @test_referring_sources;
     funcs{end+1} = @test_referring_block_sources;
@@ -350,7 +351,7 @@ function [] = test_referring_data_arrays( varargin )
 end
 
 %% Test: referring tags
-function [] = test_referring_multi_tags( varargin )
+function [] = test_referring_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.create_block('testBlock1', 'nixBlock');
     t1 = b1.create_tag('testTag1', 'nixTag', [1, 2]);
@@ -371,8 +372,44 @@ function [] = test_referring_multi_tags( varargin )
     assert(isempty(s.referring_tags));
 end
 
+%% Test: referring block tags
+function [] = test_referring_block_tags( varargin )
+    err = 'Provide either empty arguments or a single Block entity';
+    testName = 'testTag1';
+
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    t1 = b1.create_tag(testName, 'nixTag', [1, 2]);
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    t2 = b2.create_tag('testTag2', 'nixTag', [3, 4]);
+    s = f.create_section('testSection', 'nixSection');
+
+    t1.set_metadata(s);
+    t2.set_metadata(s);
+
+    % test multiple arguments fail
+    try
+        s.referring_tags('a', 'b');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test non block entity argument fail
+    try
+        s.referring_tags(s);
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test return only tags from block 1
+    testTag = s.referring_tags(b1);
+    assert(size(testTag, 2) == 1);
+    assert(strcmp(testTag{1}.name, testName));
+end
+
+
 %% Test: referring multi tags
-function [] = test_referring_tags( varargin )
+function [] = test_referring_multi_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.create_block('testBlock1', 'nixBlock');
     d = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -28,6 +28,7 @@ function funcs = TestSection
     funcs{end+1} = @test_link;
     funcs{end+1} = @test_inherited_properties;
     funcs{end+1} = @test_referring_data_arrays;
+    funcs{end+1} = @test_referring_block_data_arrays;
     funcs{end+1} = @test_referring_tags;
     funcs{end+1} = @test_referring_block_tags;
     funcs{end+1} = @test_referring_multi_tags;
@@ -349,6 +350,41 @@ function [] = test_referring_data_arrays( varargin )
     b2.delete_data_array(d2);
     d1.set_metadata('');
     assert(isempty(s.referring_data_arrays));
+end
+
+%% Test: referring block data arrays
+function [] = test_referring_block_data_arrays( varargin )
+    err = 'Provide either empty arguments or a single Block entity';
+    testName = 'testDataArray1';
+
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    d1 = b1.create_data_array(testName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    d2 = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = f.create_section('testSection', 'nixSection');
+    
+    d1.set_metadata(s);
+    d2.set_metadata(s);
+
+    % test multiple arguments fail
+    try
+        s.referring_data_arrays('a', 'b');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test non block entity argument fail
+    try
+        s.referring_data_arrays(s);
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test return only tags from block 1
+    testDataArray = s.referring_data_arrays(b1);
+    assert(size(testDataArray, 2) == 1);
+    assert(strcmp(testDataArray{1}.name, testName));
 end
 
 %% Test: referring tags

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -31,6 +31,7 @@ function funcs = TestSection
     funcs{end+1} = @test_referring_tags;
     funcs{end+1} = @test_referring_multi_tags;
     funcs{end+1} = @test_referring_sources;
+    funcs{end+1} = @test_referring_blocks;
 end
 
 %% Test: Create Section
@@ -413,4 +414,23 @@ function [] = test_referring_sources( varargin )
     b2.delete_source(s2);
     s1.set_metadata('');
     assert(isempty(s.referring_sources));
+end
+
+%% Test: referring blocks
+function [] = test_referring_blocks( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b1 = f.create_block('testBlock1', 'nixBlock');
+    b2 = f.create_block('testBlock2', 'nixBlock');
+    s = f.create_section('testSection', 'nixSection');
+    
+    assert(isempty(s.referring_blocks));
+
+    b1.set_metadata(s);
+    assert(~isempty(s.referring_blocks));
+    
+    b2.set_metadata(s);
+    assert(size(s.referring_blocks, 1) == 2);
+    
+    b2.set_metadata('')
+    assert(size(s.referring_blocks, 1) == 1);
 end


### PR DESCRIPTION
- Closes #130 

Successfully built under win32 (Matlab R2011a) and win64 (Matlab R2011a).