### PR TITLE
Add missing 'DataArray' functions

### DIFF
--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -126,5 +126,9 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             end;
         end;
 
+        function s = datatype(obj)
+            s = nix_mx('DataArray::dataType', obj.nix_handle);
+        end
+
     end;
 end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -28,7 +28,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             nix.Dynamic.add_dyn_attr(obj, 'label', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'expansionOrigin', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'polynom_coefficients', 'rw');
+            nix.Dynamic.add_dyn_attr(obj, 'polynomCoefficients', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'shape', 'rw');
         end;
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -29,7 +29,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'expansionOrigin', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'polynomCoefficients', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'shape', 'rw');
+            nix.Dynamic.add_dyn_attr(obj, 'dataExtent', 'rw');
         end;
 
         % -----------------
@@ -129,6 +129,20 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function s = datatype(obj)
             s = nix_mx('DataArray::dataType', obj.nix_handle);
         end
-
+        
+        % set data extent enabels to increase the original size 
+        % of a data array within the same dimensions.
+        % e.g. increase the size of a 2D array [5 10] to another
+        % 2D array [5 11]. Changing the dimensions is not possible
+        % e.g. changing from a 2D array to a 3D array.
+        % Furthermore if the extent shrinks the size of an array
+        % or remodels the size of an array to a completely different
+        % shape, existing data that does not fit into the new shape
+        % will be lost!
+        function [] = set_data_extent(obj, extent)
+            nix_mx('DataArray::setDataExtent', obj.nix_handle, extent);
+            % update changed dataExtent in obj.info
+            obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
+        end
     end;
 end

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -211,6 +211,7 @@ void mexFunction(int            nlhs,
             .reg("setNoneUnit", SETTER(const boost::none_t, nix::DataArray, unit))
             .reg("setExpansionOrigin", SETTER(double, nix::DataArray, expansionOrigin))
             .reg("setNoneExpansionOrigin", SETTER(boost::none_t, nix::DataArray, expansionOrigin))
+            .reg("setNonePolynomCoefficients", SETTER(boost::none_t, nix::DataArray, polynomCoefficients))
             .reg("dimensions", FILTER(std::vector<nix::Dimension>, nix::DataArray, , dimensions))
             .reg("appendSetDimension", &nix::DataArray::appendSetDimension)
             .reg("appendRangeDimension", &nix::DataArray::appendRangeDimension)
@@ -231,6 +232,7 @@ void mexFunction(int            nlhs,
         methods->add("DataArray::hasSource", nixdataarray::hasSource);
         methods->add("DataArray::sourceCount", nixdataarray::sourceCount);
         methods->add("DataArray::dimensionCount", nixdataarray::dimensionCount);
+        methods->add("DataArray::setPolynomCoefficients", nixdataarray::polynomCoefficients);
 
         classdef<nix::Source>("Source", methods)
             .desc(&nixsource::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -209,6 +209,8 @@ void mexFunction(int            nlhs,
             .reg("setNoneLabel", SETTER(const boost::none_t, nix::DataArray, label))
             .reg("setUnit", SETTER(const std::string&, nix::DataArray, unit))
             .reg("setNoneUnit", SETTER(const boost::none_t, nix::DataArray, unit))
+            .reg("setExpansionOrigin", SETTER(double, nix::DataArray, expansionOrigin))
+            .reg("setNoneExpansionOrigin", SETTER(boost::none_t, nix::DataArray, expansionOrigin))
             .reg("dimensions", FILTER(std::vector<nix::Dimension>, nix::DataArray, , dimensions))
             .reg("appendSetDimension", &nix::DataArray::appendSetDimension)
             .reg("appendRangeDimension", &nix::DataArray::appendRangeDimension)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -234,6 +234,7 @@ void mexFunction(int            nlhs,
         methods->add("DataArray::dimensionCount", nixdataarray::dimensionCount);
         methods->add("DataArray::setPolynomCoefficients", nixdataarray::polynomCoefficients);
         methods->add("DataArray::dataType", nixdataarray::dataType);
+        methods->add("DataArray::setDataExtent", nixdataarray::setDataExtent);
 
         classdef<nix::Source>("Source", methods)
             .desc(&nixsource::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -233,6 +233,7 @@ void mexFunction(int            nlhs,
         methods->add("DataArray::sourceCount", nixdataarray::sourceCount);
         methods->add("DataArray::dimensionCount", nixdataarray::dimensionCount);
         methods->add("DataArray::setPolynomCoefficients", nixdataarray::polynomCoefficients);
+        methods->add("DataArray::dataType", nixdataarray::dataType);
 
         classdef<nix::Source>("Source", methods)
             .desc(&nixsource::describe)

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -21,7 +21,7 @@ namespace nixdataarray {
 
     mxArray *describe(const nix::DataArray &da) {
         struct_builder sb({ 1 }, { "id", "type", "name", "definition", "label",
-            "shape", "unit", "expansionOrigin", "polynom_coefficients" });
+            "shape", "unit", "expansionOrigin", "polynomCoefficients" });
 
         sb.set(da.id());
         sb.set(da.type());
@@ -117,6 +117,12 @@ namespace nixdataarray {
     void dimensionCount(const extractor &input, infusor &output) {
         nix::DataArray da = input.entity<nix::DataArray>(1);
         output.set(0, da.dimensionCount());
+    }
+
+    void polynomCoefficients(const extractor &input, infusor &output) {
+        nix::DataArray da = input.entity<nix::DataArray>(1);
+        std::vector<double> pc = input.vec<double>(2);
+        da.polynomCoefficients(pc);
     }
 
 } // namespace nixdataarray

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -21,7 +21,7 @@ namespace nixdataarray {
 
     mxArray *describe(const nix::DataArray &da) {
         struct_builder sb({ 1 }, { "id", "type", "name", "definition", "label",
-            "shape", "unit", "polynom_coefficients" });
+            "shape", "unit", "expansionOrigin", "polynom_coefficients" });
 
         sb.set(da.id());
         sb.set(da.type());
@@ -30,6 +30,7 @@ namespace nixdataarray {
         sb.set(da.label());
         sb.set(da.dataExtent());
         sb.set(da.unit());
+        sb.set(da.expansionOrigin());
         sb.set(da.polynomCoefficients());
 
         return sb.array();

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -125,4 +125,9 @@ namespace nixdataarray {
         da.polynomCoefficients(pc);
     }
 
+    void dataType(const extractor &input, infusor &output) {
+        nix::DataArray da = input.entity<nix::DataArray>(1);
+        output.set(0, string_nix2mex(da.dataType()));
+    }
+
 } // namespace nixdataarray

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -21,7 +21,7 @@ namespace nixdataarray {
 
     mxArray *describe(const nix::DataArray &da) {
         struct_builder sb({ 1 }, { "id", "type", "name", "definition", "label",
-            "shape", "unit", "expansionOrigin", "polynomCoefficients" });
+            "dataExtent", "unit", "expansionOrigin", "polynomCoefficients" });
 
         sb.set(da.id());
         sb.set(da.type());
@@ -128,6 +128,12 @@ namespace nixdataarray {
     void dataType(const extractor &input, infusor &output) {
         nix::DataArray da = input.entity<nix::DataArray>(1);
         output.set(0, string_nix2mex(da.dataType()));
+    }
+
+    void setDataExtent(const extractor &input, infusor &output) {
+        nix::DataArray da = input.entity<nix::DataArray>(1);
+        nix::NDSize size = input.ndsize(2);
+        da.dataExtent(size);
     }
 
 } // namespace nixdataarray

--- a/src/nixdataarray.h
+++ b/src/nixdataarray.h
@@ -35,6 +35,8 @@ namespace nixdataarray {
 
     void dimensionCount(const extractor &input, infusor &output);
 
+    void polynomCoefficients(const extractor &input, infusor &output);
+
 } // namespace nixdataarray
 
 #endif

--- a/src/nixdataarray.h
+++ b/src/nixdataarray.h
@@ -39,6 +39,8 @@ namespace nixdataarray {
 
     void dataType(const extractor &input, infusor &output);
 
+    void setDataExtent(const extractor &input, infusor &output);
+
 } // namespace nixdataarray
 
 #endif

--- a/src/nixdataarray.h
+++ b/src/nixdataarray.h
@@ -37,6 +37,8 @@ namespace nixdataarray {
 
     void polynomCoefficients(const extractor &input, infusor &output);
 
+    void dataType(const extractor &input, infusor &output);
+
 } // namespace nixdataarray
 
 #endif

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -70,6 +70,14 @@ function [] = test_attrs( varargin )
     
     da.expansionOrigin = '';
     assert(isempty(da.expansionOrigin));
+    
+    assert(isempty(da.polynomCoefficients));
+    c = [1.1 1.2];
+    da.polynomCoefficients = c;
+    assert(da.polynomCoefficients(1) == c(1))
+    
+    da.polynomCoefficients = '';
+    assert(isempty(da.polynomCoefficients));
 end
 
 %% Test: Read all data from DataArray

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -63,6 +63,13 @@ function [] = test_attrs( varargin )
 
     da.label = '';
     assert(isempty(da.label));
+
+    assert(isempty(da.expansionOrigin));
+    da.expansionOrigin = 2.5;
+    assert(da.expansionOrigin == 2.5)
+    
+    da.expansionOrigin = '';
+    assert(isempty(da.expansionOrigin));
 end
 
 %% Test: Read all data from DataArray

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -28,6 +28,7 @@ function funcs = TestDataArray
     funcs{end+1} = @test_source_count;
     funcs{end+1} = @test_dimensions;
     funcs{end+1} = @test_dimension_count;
+    funcs{end+1} = @test_datatype;
 end
 
 function [] = test_attrs( varargin )
@@ -513,4 +514,19 @@ function [] = test_dimension_count( varargin )
     clear da b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
     assert(f.blocks{1}.dataArrays{1}.dimension_count() == 1);
+end
+
+%% Test: Datatype
+function [] = test_datatype( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    typeDA = 'nix.DataArray';
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixblock');
+
+    da = b.create_data_array_from_data('testDataArray1', typeDA, [1 2 3]);
+    assert(strcmp(da.datatype, 'double'));
+    
+    da = b.create_data_array('testDataArray2', typeDA, nix.DataType.Bool, 5);
+    da.write_all(logical([1 0 1 1 1]));
+    assert(strcmp(da.datatype, 'logical'));
 end

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -29,6 +29,7 @@ function funcs = TestDataArray
     funcs{end+1} = @test_dimensions;
     funcs{end+1} = @test_dimension_count;
     funcs{end+1} = @test_datatype;
+    funcs{end+1} = @test_set_data_extent;
 end
 
 function [] = test_attrs( varargin )
@@ -484,11 +485,11 @@ function [] = test_dimensions( varargin )
     
     daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWATest2', ...
         'nix.DataArray', [1; 2; 3]);
-    assert(isequal(daAliasWa.shape, [3 1]));
+    assert(isequal(daAliasWa.dataExtent, [3 1]));
     
     daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWATest3', ...
         'nix.DataArray', [1 2 3; 2 4 5; 3 6 7]);
-    assert(isequal(daAliasWa.shape, [3 3]));
+    assert(isequal(daAliasWa.dataExtent, [3 3]));
 end
 
 %% Test: Dimension count
@@ -529,4 +530,16 @@ function [] = test_datatype( varargin )
     da = b.create_data_array('testDataArray2', typeDA, nix.DataType.Bool, 5);
     da.write_all(logical([1 0 1 1 1]));
     assert(strcmp(da.datatype, 'logical'));
+end
+
+%% Test: Set extent
+function [] = test_set_data_extent( varargin )
+    fileName = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(fileName, nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixblock');
+
+    da = b.create_data_array_from_data('testDataArray1', 'nix.DataArray', [1 2 3; 4 5 6]);
+    extent = [4 6];
+    da.set_data_extent(extent);
+    assert(da.dataExtent(1) == extent(1) && size(da.read_all, 2) == extent(2));
 end


### PR DESCRIPTION
- Closes #128 
- Changes Matlab dynamic attribute `shape` to the original designation `dataExtent` (API change...).
- The dynamic attribute `polynom_coefficients` was not properly set until now due to how dynamic attributes are handled on the Matlab side. By changing it to `polynomCoefficients` it will currently be set properly. When changing the Matlab function naming scheme, this will change again to `polynom_coefficients`, but will also require a general change of how dynamic attributes are handled on the Matlab side and this should be done as its own issue.

Successfully built under win32 (Matlab R2011a) and win64 (Matlab R2011a).