### PR TITLE
Support for filter functions

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -256,5 +256,10 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 del, 'nix.MultiTag', 'Block::deleteMultiTag');
         end;
 
+        function filtered = filter_multi_tags(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Block::multiTagsFiltered', @nix.MultiTag);
+        end
+
     end;
 end

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -59,6 +59,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             delCheck = nix.Utils.delete_entity(obj, ...
                 del, 'nix.Group', 'Block::deleteGroup');
         end;
+
+        function filtered = filter_groups(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Block::groupsFiltered', @nix.Group);
+        end
         
         % -----------------
         % DataArray methods

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -169,6 +169,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 'Block::openSourceIdx', idx, @nix.Source);
         end
 
+        function filtered = filter_sources(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Block::sourcesFiltered', @nix.Source);
+        end
+
         % -----------------
         % Tags methods
         % -----------------

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -207,6 +207,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 del, 'nix.Tag', 'Block::deleteTag');
         end;
 
+        function filtered = filter_tags(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Block::tagsFiltered', @nix.Tag);
+        end
+
         % -----------------
         % MultiTag methods
         % -----------------

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -142,6 +142,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 del, 'nix.DataArray', 'Block::deleteDataArray');
         end;
 
+        function filtered = filter_data_arrays(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Block::dataArraysFiltered', @nix.DataArray);
+        end
+
         % -----------------
         % Sources methods
         % -----------------

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -73,6 +73,11 @@ classdef File < nix.Entity
                 del, 'nix.Block', 'File::deleteBlock');
         end;
 
+        function filtered = filter_blocks(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'File::blocksFiltered', @nix.Block);
+        end
+
         % ----------------
         % Section methods
         % ----------------

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -101,7 +101,12 @@ classdef File < nix.Entity
 
         function delCheck = delete_section(obj, del)
             delCheck = nix.Utils.delete_entity(obj, del, 'nix.Section', 'File::deleteSection');
-        end;
+        end
+
+        function filtered = filter_sections(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'File::sectionsFiltered', @nix.Section);
+        end
     end
 
 end

--- a/+nix/Filter.m
+++ b/+nix/Filter.m
@@ -7,8 +7,8 @@ classdef Filter < uint8
         ids (2); % requires a cell array
         type (3);
         name (4);
-        metadata (5);
-        source (6);
+        metadata (5); % filters by id
+        source (6); % filters by name or id
     end
     
 end

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -143,6 +143,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function c = multi_tag_count(obj)
             c = nix_mx('Group::multiTagCount', obj.nix_handle);
         end
+
+        function filtered = filter_multi_tags(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Group::multiTagsFiltered', @nix.MultiTag);
+        end
     end;
 
 end

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -64,6 +64,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'nix.DataArray', 'Group::removeDataArray');
         end;
 
+        function filtered = filter_data_arrays(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Group::dataArraysFiltered', @nix.DataArray);
+        end
+
         % -----------------
         % Tags methods
         % -----------------

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -101,6 +101,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             c = nix_mx('Group::tagCount', obj.nix_handle);
         end
 
+        function filtered = filter_tags(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Group::tagsFiltered', @nix.Tag);
+        end
+
         % -----------------
         % MultiTag methods
         % -----------------

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -78,6 +78,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             c = nix_mx('MultiTag::referenceCount', obj.nix_handle);
         end
 
+        function filtered = filter_references(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'MultiTag::referencesFiltered', @nix.DataArray);
+        end
+
         % ------------------
         % Features methods
         % ------------------

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -132,6 +132,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             c = nix_mx('MultiTag::featureCount', obj.nix_handle);
         end
 
+        function filtered = filter_features(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'MultiTag::featuresFiltered', @nix.Feature);
+        end
+
         % ------------------
         % Positions methods
         % ------------------

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -166,6 +166,11 @@ classdef Section < nix.NamedEntity
             c = nix_mx('Section::propertyCount', obj.nix_handle);
         end
 
+        function filtered = filter_properties(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Section::propertiesFiltered', @nix.Property);
+        end
+
         % ----------------
         % Referring entity methods
         % ----------------

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -102,6 +102,11 @@ classdef Section < nix.NamedEntity
             c = nix_mx('Section::sectionCount', obj.nix_handle);
         end
 
+        function filtered = filter_sections(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Section::sectionsFiltered', @nix.Section);
+        end
+
         % ----------------
         % Property methods
         % ----------------

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -73,5 +73,10 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             retObj = nix.Utils.fetchObjList('Source::referringMultiTags', ...
                 obj.nix_handle, @nix.MultiTag);
         end
+
+        function filtered = filter_sources(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Source::sourcesFiltered', @nix.Source);
+        end
     end;
 end

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -59,6 +59,10 @@ classdef SourcesMixIn < handle
                 strcat(obj.alias, '::openSourceIdx'), idx, @nix.Source);
         end
 
+        function filtered = filter_sources(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                strcat(obj.alias, '::sourcesFiltered'), @nix.Source);
+        end
     end
 
 end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -128,5 +128,10 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function c = feature_count(obj)
             c = nix_mx('Tag::featureCount', obj.nix_handle);
         end
+
+        function filtered = filter_features(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Tag::featuresFiltered', @nix.Feature);
+        end
     end;
 end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -77,6 +77,11 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             c = nix_mx('Tag::referenceCount', obj.nix_handle);
         end
 
+        function filtered = filter_references(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Tag::referencesFiltered', @nix.DataArray);
+        end
+
         % ------------------
         % Features methods
         % ------------------

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -121,6 +121,7 @@ void mexFunction(int            nlhs,
         methods->add("File::validate", nixfile::validate);
         methods->add("File::openBlockIdx", nixfile::openBlockIdx);
         methods->add("File::openSectionIdx", nixfile::openSectionIdx);
+        methods->add("File::sectionsFiltered", nixfile::sectionsFiltered);
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -169,6 +169,7 @@ void mexFunction(int            nlhs,
         methods->add("Block::openSourceIdx", nixblock::openSourceIdx);
         methods->add("Block::compare", nixblock::compare);
         methods->add("Block::sourcesFiltered", nixblock::sourcesFiltered);
+        methods->add("Block::groupsFiltered", nixblock::groupsFiltered);
         methods->add("Block::tagsFiltered", nixblock::tagsFiltered);
 
         classdef<nix::Group>("Group", methods)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -325,6 +325,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::compare", nixtag::compare);
         methods->add("Tag::sourcesFiltered", nixtag::sourcesFiltered);
         methods->add("Tag::referencesFiltered", nixtag::referencesFiltered);
+        methods->add("Tag::featuresFiltered", nixtag::featuresFiltered);
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .desc(&nixmultitag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -414,6 +414,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::openSectionIdx", nixsection::openSectionIdx);
         methods->add("Section::openPropertyIdx", nixsection::openPropertyIdx);
         methods->add("Section::compare", nixsection::compare);
+        methods->add("Section::sectionsFiltered", nixsection::sectionsFiltered);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -171,6 +171,7 @@ void mexFunction(int            nlhs,
         methods->add("Block::sourcesFiltered", nixblock::sourcesFiltered);
         methods->add("Block::groupsFiltered", nixblock::groupsFiltered);
         methods->add("Block::tagsFiltered", nixblock::tagsFiltered);
+        methods->add("Block::multiTagsFiltered", nixblock::multiTagsFiltered);
 
         classdef<nix::Group>("Group", methods)
             .desc(&nixgroup::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -262,6 +262,7 @@ void mexFunction(int            nlhs,
         methods->add("DataArray::openSourceIdx", nixdataarray::openSourceIdx);
         methods->add("DataArray::openDimensionIdx", nixdataarray::openDimensionIdx);
         methods->add("DataArray::compare", nixdataarray::compare);
+        methods->add("DataArray::sourcesFiltered", nixdataarray::sourcesFiltered);
 
         classdef<nix::Source>("Source", methods)
             .desc(&nixsource::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -169,6 +169,7 @@ void mexFunction(int            nlhs,
         methods->add("Block::openSourceIdx", nixblock::openSourceIdx);
         methods->add("Block::compare", nixblock::compare);
         methods->add("Block::sourcesFiltered", nixblock::sourcesFiltered);
+        methods->add("Block::tagsFiltered", nixblock::tagsFiltered);
 
         classdef<nix::Group>("Group", methods)
             .desc(&nixgroup::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -216,6 +216,7 @@ void mexFunction(int            nlhs,
         methods->add("Group::openSourceIdx", nixgroup::openSourceIdx);
         methods->add("Group::compare", nixgroup::compare);
         methods->add("Group::sourcesFiltered", nixgroup::sourcesFiltered);
+        methods->add("Group::tagsFiltered", nixgroup::tagsFiltered);
 
         classdef<nix::DataArray>("DataArray", methods)
             .desc(&nixdataarray::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -215,6 +215,7 @@ void mexFunction(int            nlhs,
         methods->add("Group::openMultiTagIdx", nixgroup::openMultiTagIdx);
         methods->add("Group::openSourceIdx", nixgroup::openSourceIdx);
         methods->add("Group::compare", nixgroup::compare);
+        methods->add("Group::sourcesFiltered", nixgroup::sourcesFiltered);
 
         classdef<nix::DataArray>("DataArray", methods)
             .desc(&nixdataarray::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -324,6 +324,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::openSourceIdx", nixtag::openSourceIdx);
         methods->add("Tag::compare", nixtag::compare);
         methods->add("Tag::sourcesFiltered", nixtag::sourcesFiltered);
+        methods->add("Tag::referencesFiltered", nixtag::referencesFiltered);
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .desc(&nixmultitag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -218,6 +218,7 @@ void mexFunction(int            nlhs,
         methods->add("Group::sourcesFiltered", nixgroup::sourcesFiltered);
         methods->add("Group::tagsFiltered", nixgroup::tagsFiltered);
         methods->add("Group::multiTagsFiltered", nixgroup::multiTagsFiltered);
+        methods->add("Group::dataArraysFiltered", nixgroup::dataArraysFiltered);
 
         classdef<nix::DataArray>("DataArray", methods)
             .desc(&nixdataarray::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -283,6 +283,7 @@ void mexFunction(int            nlhs,
             .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Source, referringMultiTags));
         methods->add("Source::openSourceIdx", nixsource::openSourceIdx);
         methods->add("Source::compare", nixsource::compare);
+        methods->add("Source::sourcesFiltered", nixsource::sourcesFiltered);
 
         classdef<nix::Tag>("Tag", methods)
             .desc(&nixtag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -217,6 +217,7 @@ void mexFunction(int            nlhs,
         methods->add("Group::compare", nixgroup::compare);
         methods->add("Group::sourcesFiltered", nixgroup::sourcesFiltered);
         methods->add("Group::tagsFiltered", nixgroup::tagsFiltered);
+        methods->add("Group::multiTagsFiltered", nixgroup::multiTagsFiltered);
 
         classdef<nix::DataArray>("DataArray", methods)
             .desc(&nixdataarray::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -372,6 +372,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::openSourceIdx", nixmultitag::openSourceIdx);
         methods->add("MultiTag::compare", nixmultitag::compare);
         methods->add("MultiTag::sourcesFiltered", nixmultitag::sourcesFiltered);
+        methods->add("MultiTag::referencesFiltered", nixmultitag::referencesFiltered);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -415,6 +415,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::openPropertyIdx", nixsection::openPropertyIdx);
         methods->add("Section::compare", nixsection::compare);
         methods->add("Section::sectionsFiltered", nixsection::sectionsFiltered);
+        methods->add("Section::propertiesFiltered", nixsection::propertiesFiltered);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -168,6 +168,7 @@ void mexFunction(int            nlhs,
         methods->add("Block::openMultiTagIdx", nixblock::openMultiTagIdx);
         methods->add("Block::openSourceIdx", nixblock::openSourceIdx);
         methods->add("Block::compare", nixblock::compare);
+        methods->add("Block::sourcesFiltered", nixblock::sourcesFiltered);
 
         classdef<nix::Group>("Group", methods)
             .desc(&nixgroup::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -323,6 +323,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::openFeatureIdx", nixtag::openFeatureIdx);
         methods->add("Tag::openSourceIdx", nixtag::openSourceIdx);
         methods->add("Tag::compare", nixtag::compare);
+        methods->add("Tag::sourcesFiltered", nixtag::sourcesFiltered);
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .desc(&nixmultitag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -122,6 +122,7 @@ void mexFunction(int            nlhs,
         methods->add("File::openBlockIdx", nixfile::openBlockIdx);
         methods->add("File::openSectionIdx", nixfile::openSectionIdx);
         methods->add("File::sectionsFiltered", nixfile::sectionsFiltered);
+        methods->add("File::blocksFiltered", nixfile::blocksFiltered);
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -373,6 +373,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::compare", nixmultitag::compare);
         methods->add("MultiTag::sourcesFiltered", nixmultitag::sourcesFiltered);
         methods->add("MultiTag::referencesFiltered", nixmultitag::referencesFiltered);
+        methods->add("MultiTag::featuresFiltered", nixmultitag::featuresFiltered);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -172,6 +172,7 @@ void mexFunction(int            nlhs,
         methods->add("Block::groupsFiltered", nixblock::groupsFiltered);
         methods->add("Block::tagsFiltered", nixblock::tagsFiltered);
         methods->add("Block::multiTagsFiltered", nixblock::multiTagsFiltered);
+        methods->add("Block::dataArraysFiltered", nixblock::dataArraysFiltered);
 
         classdef<nix::Group>("Group", methods)
             .desc(&nixgroup::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -371,6 +371,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::openFeatureIdx", nixmultitag::openFeatureIdx);
         methods->add("MultiTag::openSourceIdx", nixmultitag::openSourceIdx);
         methods->add("MultiTag::compare", nixmultitag::compare);
+        methods->add("MultiTag::sourcesFiltered", nixmultitag::sourcesFiltered);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)

--- a/src/filters.h
+++ b/src/filters.h
@@ -95,4 +95,28 @@ std::vector<T> filterFeature(const extractor &input, FN ff) {
     return res;
 }
 
+template<typename T, typename FN>
+std::vector<T> filterProperty(const extractor &input, FN ff) {
+    std::vector<T> res;
+
+    switch (input.num<uint8_t>(2)) {
+    case switchFilter::AcceptAll:
+        res = ff(nix::util::AcceptAll<T>());
+        break;
+    case switchFilter::Id:
+        res = ff(nix::util::IdFilter<T>(input.str(3)));
+        break;
+    case switchFilter::Ids:
+        // this will crash matlab, if its not a vector of strings...
+        res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(3)));
+        break;
+    case switchFilter::Name:
+        res = ff(nix::util::NameFilter<T>(input.str(3)));
+        break;
+    default: throw std::invalid_argument("unknown or unsupported filter");
+    }
+
+    return res;
+}
+
 #endif

--- a/src/filters.h
+++ b/src/filters.h
@@ -13,36 +13,8 @@
 #include "mex.h"
 #include "datatypes.h"
 
-// filter template
 template<typename T, typename FN>
-std::vector<T> filterFileEntity(const extractor &input, FN ff) {
-    std::vector<T> res;
-
-    switch (input.num<uint8_t>(2)) {
-    case switchFilter::AcceptAll:
-        res = ff(nix::util::AcceptAll<T>());
-        break;
-    case switchFilter::Id:
-        res = ff(nix::util::IdFilter<T>(input.str(3)));
-        break;
-    case switchFilter::Ids:
-        // this will crash matlab, if its not a vector of strings...
-        res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(3)));
-        break;
-    case switchFilter::Type:
-        res = ff(nix::util::TypeFilter<T>(input.str(3)));
-        break;
-    case switchFilter::Name:
-        res = ff(nix::util::NameFilter<T>(input.str(3)));
-        break;
-    default: throw std::invalid_argument("unknown or unsupported filter");
-    }
-
-    return res;
-}
-
-template<typename T, typename FN>
-std::vector<T> filterEntity(const extractor &input, FN ff) {
+std::vector<T> filterFullEntity(const extractor &input, FN ff) {
     std::vector<T> res;
 
     switch (input.num<uint8_t>(2)) {
@@ -75,7 +47,7 @@ std::vector<T> filterEntity(const extractor &input, FN ff) {
 }
 
 template<typename T, typename FN>
-std::vector<T> filterFeature(const extractor &input, FN ff) {
+std::vector<T> filterNameTypeEntity(const extractor &input, FN ff) {
     std::vector<T> res;
 
     switch (input.num<uint8_t>(2)) {
@@ -89,6 +61,12 @@ std::vector<T> filterFeature(const extractor &input, FN ff) {
         // this will crash matlab, if its not a vector of strings...
         res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(3)));
         break;
+    case switchFilter::Type:
+        res = ff(nix::util::TypeFilter<T>(input.str(3)));
+        break;
+    case switchFilter::Name:
+        res = ff(nix::util::NameFilter<T>(input.str(3)));
+        break;
     default: throw std::invalid_argument("unknown or unsupported filter");
     }
 
@@ -96,7 +74,7 @@ std::vector<T> filterFeature(const extractor &input, FN ff) {
 }
 
 template<typename T, typename FN>
-std::vector<T> filterProperty(const extractor &input, FN ff) {
+std::vector<T> filterNamedEntity(const extractor &input, FN ff) {
     std::vector<T> res;
 
     switch (input.num<uint8_t>(2)) {
@@ -112,6 +90,27 @@ std::vector<T> filterProperty(const extractor &input, FN ff) {
         break;
     case switchFilter::Name:
         res = ff(nix::util::NameFilter<T>(input.str(3)));
+        break;
+    default: throw std::invalid_argument("unknown or unsupported filter");
+    }
+
+    return res;
+}
+
+template<typename T, typename FN>
+std::vector<T> filterEntity(const extractor &input, FN ff) {
+    std::vector<T> res;
+
+    switch (input.num<uint8_t>(2)) {
+    case switchFilter::AcceptAll:
+        res = ff(nix::util::AcceptAll<T>());
+        break;
+    case switchFilter::Id:
+        res = ff(nix::util::IdFilter<T>(input.str(3)));
+        break;
+    case switchFilter::Ids:
+        // this will crash matlab, if its not a vector of strings...
+        res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(3)));
         break;
     default: throw std::invalid_argument("unknown or unsupported filter");
     }

--- a/src/filters.h
+++ b/src/filters.h
@@ -74,4 +74,25 @@ std::vector<T> filterEntity(const extractor &input, FN ff) {
     return res;
 }
 
+template<typename T, typename FN>
+std::vector<T> filterFeature(const extractor &input, FN ff) {
+    std::vector<T> res;
+
+    switch (input.num<uint8_t>(2)) {
+    case switchFilter::AcceptAll:
+        res = ff(nix::util::AcceptAll<T>());
+        break;
+    case switchFilter::Id:
+        res = ff(nix::util::IdFilter<T>(input.str(3)));
+        break;
+    case switchFilter::Ids:
+        // this will crash matlab, if its not a vector of strings...
+        res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(3)));
+        break;
+    default: throw std::invalid_argument("unknown or unsupported filter");
+    }
+
+    return res;
+}
+
 #endif

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -124,4 +124,13 @@ namespace nixblock {
         output.set(0, res);
     }
 
+    void multiTagsFiltered(const extractor &input, infusor &output) {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        std::vector<nix::MultiTag> res = filterEntity<nix::MultiTag>(input,
+                                        [currObj](const nix::util::Filter<nix::MultiTag>::type &filter) {
+            return currObj.multiTags(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixblock

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -99,7 +99,7 @@ namespace nixblock {
 
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
-        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input,
                                             [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
         });
@@ -108,7 +108,7 @@ namespace nixblock {
 
     void groupsFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
-        std::vector<nix::Group> res = filterEntity<nix::Group>(input,
+        std::vector<nix::Group> res = filterFullEntity<nix::Group>(input,
                                             [currObj](const nix::util::Filter<nix::Group>::type &filter) {
             return currObj.groups(filter);
         });
@@ -117,7 +117,7 @@ namespace nixblock {
 
     void tagsFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
-        std::vector<nix::Tag> res = filterEntity<nix::Tag>(input,
+        std::vector<nix::Tag> res = filterFullEntity<nix::Tag>(input,
                                         [currObj](const nix::util::Filter<nix::Tag>::type &filter) {
             return currObj.tags(filter);
         });
@@ -126,7 +126,7 @@ namespace nixblock {
 
     void multiTagsFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
-        std::vector<nix::MultiTag> res = filterEntity<nix::MultiTag>(input,
+        std::vector<nix::MultiTag> res = filterFullEntity<nix::MultiTag>(input,
                                         [currObj](const nix::util::Filter<nix::MultiTag>::type &filter) {
             return currObj.multiTags(filter);
         });
@@ -135,7 +135,7 @@ namespace nixblock {
 
     void dataArraysFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
-        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+        std::vector<nix::DataArray> res = filterFullEntity<nix::DataArray>(input,
                                             [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
             return currObj.dataArrays(filter);
         });

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -106,6 +106,15 @@ namespace nixblock {
         output.set(0, res);
     }
 
+    void groupsFiltered(const extractor &input, infusor &output) {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        std::vector<nix::Group> res = filterEntity<nix::Group>(input,
+                                            [currObj](const nix::util::Filter<nix::Group>::type &filter) {
+            return currObj.groups(filter);
+        });
+        output.set(0, res);
+    }
+
     void tagsFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
         std::vector<nix::Tag> res = filterEntity<nix::Tag>(input,

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -12,8 +12,9 @@
 
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
+#include "filters.h"
+#include "handle.h"
 #include "struct.h"
 
 namespace nixblock {
@@ -94,6 +95,15 @@ namespace nixblock {
         nix::Block currObj = input.entity<nix::Block>(1);
         nix::Block other = input.entity<nix::Block>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sourcesFiltered(const extractor &input, infusor &output) {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+            return currObj.sources(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixblock

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -100,8 +100,17 @@ namespace nixblock {
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::Block currObj = input.entity<nix::Block>(1);
         std::vector<nix::Source> res = filterEntity<nix::Source>(input,
-            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+                                            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
+        });
+        output.set(0, res);
+    }
+
+    void tagsFiltered(const extractor &input, infusor &output) {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        std::vector<nix::Tag> res = filterEntity<nix::Tag>(input,
+                                        [currObj](const nix::util::Filter<nix::Tag>::type &filter) {
+            return currObj.tags(filter);
         });
         output.set(0, res);
     }

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -133,4 +133,13 @@ namespace nixblock {
         output.set(0, res);
     }
 
+    void dataArraysFiltered(const extractor &input, infusor &output) {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+                                            [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
+            return currObj.dataArrays(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixblock

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -41,6 +41,8 @@ namespace nixblock {
 
     void multiTagsFiltered(const extractor &input, infusor &output);
 
+    void dataArraysFiltered(const extractor &input, infusor &output);
+
 } // namespace nixblock
 
 #endif

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -35,6 +35,8 @@ namespace nixblock {
 
     void sourcesFiltered(const extractor &input, infusor &output);
 
+    void tagsFiltered(const extractor &input, infusor &output);
+
 } // namespace nixblock
 
 #endif

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -35,6 +35,8 @@ namespace nixblock {
 
     void sourcesFiltered(const extractor &input, infusor &output);
 
+    void groupsFiltered(const extractor &input, infusor &output);
+
     void tagsFiltered(const extractor &input, infusor &output);
 
 } // namespace nixblock

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -33,6 +33,8 @@ namespace nixblock {
 
     void compare(const extractor &input, infusor &output);
 
+    void sourcesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixblock
 
 #endif

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -39,6 +39,8 @@ namespace nixblock {
 
     void tagsFiltered(const extractor &input, infusor &output);
 
+    void multiTagsFiltered(const extractor &input, infusor &output);
+
 } // namespace nixblock
 
 #endif

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -180,7 +180,7 @@ namespace nixdataarray {
 
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::DataArray currObj = input.entity<nix::DataArray>(1);
-        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input,
                                             [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
         });

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -8,15 +8,17 @@
 
 #include "nixdataarray.h"
 #include "nixdimensions.h"
-#include "mkarray.h"
+
 #include "mex.h"
 
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
-#include "struct.h"
+#include "filters.h"
+#include "handle.h"
+#include "mkarray.h"
 #include "mknix.h"
+#include "struct.h"
 
 namespace nixdataarray {
 
@@ -174,6 +176,15 @@ namespace nixdataarray {
         nix::DataArray currObj = input.entity<nix::DataArray>(1);
         nix::DataArray other = input.entity<nix::DataArray>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sourcesFiltered(const extractor &input, infusor &output) {
+        nix::DataArray currObj = input.entity<nix::DataArray>(1);
+        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+                                            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+            return currObj.sources(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixdataarray

--- a/src/nixdataarray.h
+++ b/src/nixdataarray.h
@@ -47,6 +47,8 @@ namespace nixdataarray {
 
     void compare(const extractor &input, infusor &output);
 
+    void sourcesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixdataarray
 
 #endif

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -16,6 +16,8 @@
 #include "handle.h"
 #include "arguments.h"
 #include "struct.h"
+#include "datatypes.h"
+#include "filters.h"
 
 // helper function
 mxArray *message(std::vector<nix::valid::Message> mes) {
@@ -111,6 +113,15 @@ namespace nixfile {
         nix::File currObj = input.entity<nix::File>(1);
         nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);
         output.set(0, currObj.getSection(idx));
+    }
+
+    void sectionsFiltered(const extractor &input, infusor &output) {
+        nix::File currObj = input.entity<nix::File>(1);
+        std::vector<nix::Section> res = filterFileEntity<nix::Section>(input, 
+                                            [currObj](const nix::util::Filter<nix::Section>::type &filter) {
+            return currObj.sections(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixfile

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -117,7 +117,7 @@ namespace nixfile {
 
     void sectionsFiltered(const extractor &input, infusor &output) {
         nix::File currObj = input.entity<nix::File>(1);
-        std::vector<nix::Section> res = filterFileEntity<nix::Section>(input, 
+        std::vector<nix::Section> res = filterNameTypeEntity<nix::Section>(input, 
                                             [currObj](const nix::util::Filter<nix::Section>::type &filter) {
             return currObj.sections(filter);
         });
@@ -126,7 +126,7 @@ namespace nixfile {
 
     void blocksFiltered(const extractor &input, infusor &output) {
         nix::File currObj = input.entity<nix::File>(1);
-        std::vector<nix::Block> res = filterFileEntity<nix::Block>(input,
+        std::vector<nix::Block> res = filterNameTypeEntity<nix::Block>(input,
                                         [currObj](const nix::util::Filter<nix::Block>::type &filter) {
             return currObj.blocks(filter);
         });

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -124,4 +124,13 @@ namespace nixfile {
         output.set(0, res);
     }
 
+    void blocksFiltered(const extractor &input, infusor &output) {
+        nix::File currObj = input.entity<nix::File>(1);
+        std::vector<nix::Block> res = filterFileEntity<nix::Block>(input,
+                                        [currObj](const nix::util::Filter<nix::Block>::type &filter) {
+            return currObj.blocks(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixfile

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -27,6 +27,8 @@ namespace nixfile {
 
     void sectionsFiltered(const extractor &input, infusor &output);
 
+    void blocksFiltered(const extractor &input, infusor &output);
+
 } // namespace nixfile
 
 #endif

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -25,6 +25,8 @@ namespace nixfile {
 
     void openSectionIdx(const extractor &input, infusor &output);
 
+    void sectionsFiltered(const extractor &input, infusor &output);
+
 } // namespace nixfile
 
 #endif

--- a/src/nixgroup.cc
+++ b/src/nixgroup.cc
@@ -113,4 +113,13 @@ namespace nixgroup {
         output.set(0, res);
     }
 
+    void tagsFiltered(const extractor &input, infusor &output) {
+        nix::Group currObj = input.entity<nix::Group>(1);
+        std::vector<nix::Tag> res = filterEntity<nix::Tag>(input,
+                                        [currObj](const nix::util::Filter<nix::Tag>::type &filter) {
+            return currObj.tags(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixgroup

--- a/src/nixgroup.cc
+++ b/src/nixgroup.cc
@@ -125,8 +125,17 @@ namespace nixgroup {
     void multiTagsFiltered(const extractor &input, infusor &output) {
         nix::Group currObj = input.entity<nix::Group>(1);
         std::vector<nix::MultiTag> res = filterEntity<nix::MultiTag>(input,
-            [currObj](const nix::util::Filter<nix::MultiTag>::type &filter) {
+                                            [currObj](const nix::util::Filter<nix::MultiTag>::type &filter) {
             return currObj.multiTags(filter);
+        });
+        output.set(0, res);
+    }
+
+    void dataArraysFiltered(const extractor &input, infusor &output) {
+        nix::Group currObj = input.entity<nix::Group>(1);
+        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+                                            [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
+            return currObj.dataArrays(filter);
         });
         output.set(0, res);
     }

--- a/src/nixgroup.cc
+++ b/src/nixgroup.cc
@@ -106,7 +106,7 @@ namespace nixgroup {
 
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::Group currObj = input.entity<nix::Group>(1);
-        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input,
                                             [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
         });
@@ -115,7 +115,7 @@ namespace nixgroup {
 
     void tagsFiltered(const extractor &input, infusor &output) {
         nix::Group currObj = input.entity<nix::Group>(1);
-        std::vector<nix::Tag> res = filterEntity<nix::Tag>(input,
+        std::vector<nix::Tag> res = filterFullEntity<nix::Tag>(input,
                                         [currObj](const nix::util::Filter<nix::Tag>::type &filter) {
             return currObj.tags(filter);
         });
@@ -124,7 +124,7 @@ namespace nixgroup {
 
     void multiTagsFiltered(const extractor &input, infusor &output) {
         nix::Group currObj = input.entity<nix::Group>(1);
-        std::vector<nix::MultiTag> res = filterEntity<nix::MultiTag>(input,
+        std::vector<nix::MultiTag> res = filterFullEntity<nix::MultiTag>(input,
                                             [currObj](const nix::util::Filter<nix::MultiTag>::type &filter) {
             return currObj.multiTags(filter);
         });
@@ -133,7 +133,7 @@ namespace nixgroup {
 
     void dataArraysFiltered(const extractor &input, infusor &output) {
         nix::Group currObj = input.entity<nix::Group>(1);
-        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+        std::vector<nix::DataArray> res = filterFullEntity<nix::DataArray>(input,
                                             [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
             return currObj.dataArrays(filter);
         });

--- a/src/nixgroup.cc
+++ b/src/nixgroup.cc
@@ -122,4 +122,13 @@ namespace nixgroup {
         output.set(0, res);
     }
 
+    void multiTagsFiltered(const extractor &input, infusor &output) {
+        nix::Group currObj = input.entity<nix::Group>(1);
+        std::vector<nix::MultiTag> res = filterEntity<nix::MultiTag>(input,
+            [currObj](const nix::util::Filter<nix::MultiTag>::type &filter) {
+            return currObj.multiTags(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixgroup

--- a/src/nixgroup.cc
+++ b/src/nixgroup.cc
@@ -12,8 +12,9 @@
 
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
+#include "filters.h"
+#include "handle.h"
 #include "struct.h"
 
 namespace nixgroup {
@@ -101,6 +102,15 @@ namespace nixgroup {
         nix::Group currObj = input.entity<nix::Group>(1);
         nix::Group other = input.entity<nix::Group>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sourcesFiltered(const extractor &input, infusor &output) {
+        nix::Group currObj = input.entity<nix::Group>(1);
+        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+                                            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+            return currObj.sources(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixgroup

--- a/src/nixgroup.h
+++ b/src/nixgroup.h
@@ -43,6 +43,8 @@ namespace nixgroup {
 
     void sourcesFiltered(const extractor &input, infusor &output);
 
+    void tagsFiltered(const extractor &input, infusor &output);
+
 } // namespace nixgroup
 
 #endif

--- a/src/nixgroup.h
+++ b/src/nixgroup.h
@@ -45,6 +45,8 @@ namespace nixgroup {
 
     void tagsFiltered(const extractor &input, infusor &output);
 
+    void multiTagsFiltered(const extractor &input, infusor &output);
+
 } // namespace nixgroup
 
 #endif

--- a/src/nixgroup.h
+++ b/src/nixgroup.h
@@ -47,6 +47,8 @@ namespace nixgroup {
 
     void multiTagsFiltered(const extractor &input, infusor &output);
 
+    void dataArraysFiltered(const extractor &input, infusor &output);
+
 } // namespace nixgroup
 
 #endif

--- a/src/nixgroup.h
+++ b/src/nixgroup.h
@@ -41,6 +41,8 @@ namespace nixgroup {
 
     void compare(const extractor &input, infusor &output);
 
+    void sourcesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixgroup
 
 #endif

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -117,4 +117,13 @@ namespace nixmultitag {
         output.set(0, res);
     }
 
+    void referencesFiltered(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+                                                [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
+            return currObj.references(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixmultitag

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -7,14 +7,15 @@
 // LICENSE file in the root of the Project.
 
 #include "nixmultitag.h"
-#include "mkarray.h"
 
 #include "mex.h"
 
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
+#include "filters.h"
+#include "handle.h"
+#include "mkarray.h"
 #include "struct.h"
 
 namespace nixmultitag {
@@ -105,6 +106,15 @@ namespace nixmultitag {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
         nix::MultiTag other = input.entity<nix::MultiTag>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sourcesFiltered(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+                                            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+            return currObj.sources(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixmultitag

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -126,4 +126,13 @@ namespace nixmultitag {
         output.set(0, res);
     }
 
+    void featuresFiltered(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        std::vector<nix::Feature> res = filterFeature<nix::Feature>(input,
+                                            [currObj](const nix::util::Filter<nix::Feature>::type &filter) {
+            return currObj.features(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixmultitag

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -110,7 +110,7 @@ namespace nixmultitag {
 
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input,
                                             [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
         });
@@ -119,7 +119,7 @@ namespace nixmultitag {
 
     void referencesFiltered(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+        std::vector<nix::DataArray> res = filterFullEntity<nix::DataArray>(input,
                                                 [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
             return currObj.references(filter);
         });
@@ -128,7 +128,7 @@ namespace nixmultitag {
 
     void featuresFiltered(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        std::vector<nix::Feature> res = filterFeature<nix::Feature>(input,
+        std::vector<nix::Feature> res = filterEntity<nix::Feature>(input,
                                             [currObj](const nix::util::Filter<nix::Feature>::type &filter) {
             return currObj.features(filter);
         });

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -39,6 +39,8 @@ namespace nixmultitag {
 
     void compare(const extractor &input, infusor &output);
 
+    void sourcesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixmultitag
 
 #endif

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -43,6 +43,8 @@ namespace nixmultitag {
 
     void referencesFiltered(const extractor &input, infusor &output);
 
+    void featuresFiltered(const extractor &input, infusor &output);
+
 } // namespace nixmultitag
 
 #endif

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -41,6 +41,8 @@ namespace nixmultitag {
 
     void sourcesFiltered(const extractor &input, infusor &output);
 
+    void referencesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixmultitag
 
 #endif

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -7,14 +7,15 @@
 // LICENSE file in the root of the Project.
 
 #include "nixsection.h"
+
 #include "mex.h"
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
-#include "struct.h"
+#include "filters.h"
+#include "handle.h"
 #include "mknix.h"
-
+#include "struct.h"
 
 namespace nixsection {
 
@@ -121,6 +122,15 @@ namespace nixsection {
         nix::Section currObj = input.entity<nix::Section>(1);
         nix::Section other = input.entity<nix::Section>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sectionsFiltered(const extractor &input, infusor &output) {
+        nix::Section currObj = input.entity<nix::Section>(1);
+        std::vector<nix::Section> res = filterFileEntity<nix::Section>(input,
+                                            [currObj](const nix::util::Filter<nix::Section>::type &filter) {
+            return currObj.sections(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixsection

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -126,7 +126,7 @@ namespace nixsection {
 
     void sectionsFiltered(const extractor &input, infusor &output) {
         nix::Section currObj = input.entity<nix::Section>(1);
-        std::vector<nix::Section> res = filterFileEntity<nix::Section>(input,
+        std::vector<nix::Section> res = filterNameTypeEntity<nix::Section>(input,
                                             [currObj](const nix::util::Filter<nix::Section>::type &filter) {
             return currObj.sections(filter);
         });
@@ -135,7 +135,7 @@ namespace nixsection {
 
     void propertiesFiltered(const extractor &input, infusor &output) {
         nix::Section currObj = input.entity<nix::Section>(1);
-        std::vector<nix::Property> res = filterProperty<nix::Property>(input,
+        std::vector<nix::Property> res = filterNamedEntity<nix::Property>(input,
                                             [currObj](const nix::util::Filter<nix::Property>::type &filter) {
             return currObj.properties(filter);
         });

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -133,4 +133,13 @@ namespace nixsection {
         output.set(0, res);
     }
 
+    void propertiesFiltered(const extractor &input, infusor &output) {
+        nix::Section currObj = input.entity<nix::Section>(1);
+        std::vector<nix::Property> res = filterProperty<nix::Property>(input,
+                                            [currObj](const nix::util::Filter<nix::Property>::type &filter) {
+            return currObj.properties(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixsection

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -37,6 +37,8 @@ namespace nixsection {
 
     void sectionsFiltered(const extractor &input, infusor &output);
 
+    void propertiesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -35,6 +35,8 @@ namespace nixsection {
 
     void compare(const extractor &input, infusor &output);
 
+    void sectionsFiltered(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -42,7 +42,7 @@ namespace nixsource {
 
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::Source currObj = input.entity<nix::Source>(1);
-        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input,
                                             [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
         });

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -12,8 +12,9 @@
 
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
+#include "filters.h"
+#include "handle.h"
 #include "struct.h"
 
 namespace nixsource {
@@ -37,6 +38,15 @@ namespace nixsource {
         nix::Source currObj = input.entity<nix::Source>(1);
         nix::Source other = input.entity<nix::Source>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sourcesFiltered(const extractor &input, infusor &output) {
+        nix::Source currObj = input.entity<nix::Source>(1);
+        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+                                            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+            return currObj.sources(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixsource

--- a/src/nixsource.h
+++ b/src/nixsource.h
@@ -19,6 +19,8 @@ namespace nixsource {
 
     void compare(const extractor &input, infusor &output);
 
+    void sourcesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixsource
 
 #endif

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -112,4 +112,13 @@ namespace nixtag {
         output.set(0, res);
     }
 
+    void referencesFiltered(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+                                            [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
+            return currObj.references(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixtag

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -121,4 +121,13 @@ namespace nixtag {
         output.set(0, res);
     }
 
+    void featuresFiltered(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::vector<nix::Feature> res = filterFeature<nix::Feature>(input,
+                                            [currObj](const nix::util::Filter<nix::Feature>::type &filter) {
+            return currObj.features(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixtag

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -7,14 +7,15 @@
 // LICENSE file in the root of the Project.
 
 #include "nixtag.h"
-#include "mkarray.h"
 
 #include "mex.h"
 
 #include <nix.hpp>
 
-#include "handle.h"
 #include "arguments.h"
+#include "filters.h"
+#include "handle.h"
+#include "mkarray.h"
 #include "struct.h"
 
 namespace nixtag {
@@ -100,6 +101,15 @@ namespace nixtag {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         nix::Tag other = input.entity<nix::Tag>(2);
         output.set(0, currObj.compare(other));
+    }
+
+    void sourcesFiltered(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+                                            [currObj](const nix::util::Filter<nix::Source>::type &filter) {
+            return currObj.sources(filter);
+        });
+        output.set(0, res);
     }
 
 } // namespace nixtag

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -105,7 +105,7 @@ namespace nixtag {
 
     void sourcesFiltered(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
-        std::vector<nix::Source> res = filterEntity<nix::Source>(input,
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input,
                                             [currObj](const nix::util::Filter<nix::Source>::type &filter) {
             return currObj.sources(filter);
         });
@@ -114,7 +114,7 @@ namespace nixtag {
 
     void referencesFiltered(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
-        std::vector<nix::DataArray> res = filterEntity<nix::DataArray>(input,
+        std::vector<nix::DataArray> res = filterFullEntity<nix::DataArray>(input,
                                             [currObj](const nix::util::Filter<nix::DataArray>::type &filter) {
             return currObj.references(filter);
         });
@@ -123,7 +123,7 @@ namespace nixtag {
 
     void featuresFiltered(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
-        std::vector<nix::Feature> res = filterFeature<nix::Feature>(input,
+        std::vector<nix::Feature> res = filterEntity<nix::Feature>(input,
                                             [currObj](const nix::util::Filter<nix::Feature>::type &filter) {
             return currObj.features(filter);
         });

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -41,6 +41,8 @@ namespace nixtag {
 
     void referencesFiltered(const extractor &input, infusor &output);
 
+    void featuresFiltered(const extractor &input, infusor &output);
+
 } // namespace nixtag
 
 #endif

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -37,6 +37,8 @@ namespace nixtag {
 
     void compare(const extractor &input, infusor &output);
 
+    void sourcesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixtag
 
 #endif

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -39,6 +39,8 @@ namespace nixtag {
 
     void sourcesFiltered(const extractor &input, infusor &output);
 
+    void referencesFiltered(const extractor &input, infusor &output);
+
 } // namespace nixtag
 
 #endif

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -51,6 +51,7 @@ function funcs = TestBlock
     funcs{end+1} = @test_source_count;
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_source;
+    funcs{end+1} = @test_filter_tag;
 end
 
 function [] = test_attrs( varargin )
@@ -820,6 +821,71 @@ function [] = test_filter_source( varargin )
     assert(strcmp(filtered{1}.id, mainID));
 
     filtered = f.blocks{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+end
+
+%% Test: filter tags
+function [] = test_filter_tag( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    t = b.create_tag(filterName, 'nixTag', [1 2 3]);
+    filterID = t.id;
+	t = b.create_tag('testTag1', filterType, [1 2 3 4]);
+    filterIDs = {filterID, t.id};
+    t = b.create_tag('testTag2', filterType, [1 2]);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.filter_tags(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.filter_tags(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.blocks{1}.filter_tags(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.filter_tags(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.filter_tags(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.filter_tags(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    mainEntity = b.create_tag(mainName, 'nixTag', [1 8]);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    mainEntity.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.filter_tags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filter_tags(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    mainEntity = b.create_tag(mainName, 'nixTag', [12 3]);
+    subName = 'testSubSource1';
+    s = b.create_source(subName, 'nixSource');
+    mainEntity.add_source(s);
+    subID = s.id;
+
+    % filter works only for ID, not for name
+    filtered = f.blocks{1}.filter_tags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -51,6 +51,7 @@ function funcs = TestBlock
     funcs{end+1} = @test_source_count;
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_source;
+    funcs{end+1} = @test_filter_group;
     funcs{end+1} = @test_filter_tag;
 end
 
@@ -821,6 +822,72 @@ function [] = test_filter_source( varargin )
     assert(strcmp(filtered{1}.id, mainID));
 
     filtered = f.blocks{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+end
+
+
+%% Test: filter groups
+function [] = test_filter_group( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    g = b.create_group(filterName, 'nixGroup');
+    filterID = g.id;
+	g = b.create_group('testGroup1', filterType);
+    filterIDs = {filterID, g.id};
+    g = b.create_group('testGroup2', filterType);
+    
+    % test empty id filter
+    assert(isempty(f.blocks{1}.filter_groups(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.filter_groups(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.blocks{1}.filter_groups(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.filter_groups(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.filter_groups(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.filter_groups(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    mainEntity = b.create_group(mainName, 'nixGroup');
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    mainEntity.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.filter_groups(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filter_groups(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    mainEntity = b.create_group(mainName, 'nixGroup');
+    subName = 'testSubSource1';
+    s = b.create_source(subName, 'nixSource');
+    mainEntity.add_source(s);
+    subID = s.id;
+
+    % filter works only for ID, not for name
+    filtered = f.blocks{1}.filter_groups(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -33,6 +33,7 @@ function funcs = TestDataArray
     funcs{end+1} = @test_datatype;
     funcs{end+1} = @test_set_data_extent;
     funcs{end+1} = @test_compare;
+    funcs{end+1} = @test_filter_source;
 end
 
 function [] = test_attrs( varargin )
@@ -595,4 +596,79 @@ function [] = test_compare( varargin )
     assert(d1.compare(d1) == 0);
     assert(d2.compare(d1) > 0);
     assert(d1.compare(d3) ~= 0);
+end
+
+%% Test: filter sources
+function [] = test_filter_source( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [3 2 3]);
+    s = b.create_source(filterName, 'nixSource');
+    d.add_source(s);
+    filterID = s.id;
+	s = b.create_source('testSource1', filterType);
+    d.add_source(s);
+    filterIDs = {filterID, s.id};
+    s = b.create_source('testSource2', filterType);
+    d.add_source(s);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+
+    % test nix.Filter.id
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    mainSource = b.create_source(mainName, 'nixSource');
+    d.add_source(mainSource);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    mainSource.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    main = b.create_source(mainName, 'nixSource');
+    d.add_source(main);
+    mainID = main.id;
+    subName = 'testSubSource1';
+    s = main.create_source(subName, 'nixSource');
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, subName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, mainID));
+
+    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -32,6 +32,7 @@ function funcs = TestFile
     funcs{end+1} = @test_has_block;
     funcs{end+1} = @test_has_section;
     funcs{end+1} = @test_filter_section;
+    funcs{end+1} = @test_filter_block;
 end
 
 %% Test: Open HDF5 file in ReadOnly mode
@@ -348,6 +349,63 @@ function [] = test_filter_section( varargin )
     % test fail on nix.Filter.source
     try
         f.filter_sections(nix.Filter.source, 'someSource');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+end
+
+function [] = test_filter_block( varargin )
+%% Test: filter Blocks
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+
+    b = f.create_block(filterName, 'nixBlock');
+    filterID = b.id;
+	b = f.create_block('testBlock1', filterType);
+    filterIDs = {filterID, b.id};
+    b = f.create_block('testBlock2', filterType);
+
+    % ToDO add basic filter crash tests
+    
+    % test empty id filter
+    assert(isempty(f.filter_blocks(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.filter_blocks(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.filter_blocks(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.filter_blocks(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.filter_blocks(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.filter_blocks(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+    
+    % test fail on nix.Filter.metadata
+    err = 'unknown or unsupported filter';
+    try
+        f.filter_blocks(nix.Filter.metadata, 'someMetadata');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+    
+    % test fail on nix.Filter.source
+    try
+        f.filter_blocks(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -31,6 +31,7 @@ function funcs = TestFile
     funcs{end+1} = @test_delete_section;
     funcs{end+1} = @test_has_block;
     funcs{end+1} = @test_has_section;
+    funcs{end+1} = @test_filter_section;
 end
 
 %% Test: Open HDF5 file in ReadOnly mode
@@ -294,4 +295,61 @@ function [] = test_has_section( varargin )
     clear s f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
     assert(f.has_section(sID));
+end
+
+function [] = test_filter_section( varargin )
+%% Test: filter Sections
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+
+    s = f.create_section(filterName, 'nixSection');
+    filterID = s.id;
+	s = f.create_section('testSection1', filterType);
+    filterIDs = {filterID, s.id};
+    s = f.create_section('testSection2', filterType);
+
+    % ToDO add basic filter crash tests
+    
+    % test empty id filter
+    assert(isempty(f.filter_sections(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.filter_sections(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.filter_sections(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.filter_sections(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.filter_sections(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.filter_sections(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+    
+    % test fail on nix.Filter.metadata
+    err = 'unknown or unsupported filter';
+    try
+        f.filter_sections(nix.Filter.metadata, 'someMetadata');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+    
+    % test fail on nix.Filter.source
+    try
+        f.filter_sections(nix.Filter.source, 'someSource');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
 end

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -44,6 +44,7 @@ function funcs = TestGroup
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_source;
     funcs{end+1} = @test_filter_tag;
+    funcs{end+1} = @test_filter_multi_tag;
 end
 
 %% Test: Access nix.Group attributes
@@ -1017,6 +1018,81 @@ function [] = test_filter_tag( varargin )
 
     % filter works only for ID, not for name
     filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+end
+
+%% Test: filter multi tags
+function [] = test_filter_multi_tag( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    g = b.create_group('testGroup', 'nixGroup');
+    t = b.create_multi_tag(filterName, 'nixMultiTag', d);
+    g.add_multi_tag(t);
+    filterID = t.id;
+	t = b.create_multi_tag('testMultiTag1', filterType, d);
+    g.add_multi_tag(t);
+    filterIDs = {filterID, t.id};
+    t = b.create_multi_tag('testMultiTag2', filterType, d);
+    g.add_multi_tag(t);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    main = b.create_multi_tag(mainName, 'nixMultiTag', d);
+    g.add_multi_tag(main);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    main.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    main = b.create_multi_tag(mainName, 'nixMultiTag', d);
+    g.add_multi_tag(main);
+    mainID = main.id;
+    subName = 'testSubSource1';
+    s = b.create_source(subName, 'nixSource');
+    main.add_source(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.source, 'Do not exist')));
+
+    % filter works only for ID, not for name
+    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -42,6 +42,7 @@ function funcs = TestGroup
     funcs{end+1} = @test_open_multi_tag_idx;
     funcs{end+1} = @test_open_source_idx;
     funcs{end+1} = @test_compare;
+    funcs{end+1} = @test_filter_source;
 end
 
 %% Test: Access nix.Group attributes
@@ -868,4 +869,79 @@ function [] = test_compare( varargin )
     assert(g1.compare(g1) == 0);
     assert(g2.compare(g1) > 0);
     assert(g1.compare(g3) ~= 0);
+end
+
+%% Test: filter sources
+function [] = test_filter_source( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    g = b.create_group('testGroup', 'nixGroup');
+    s = b.create_source(filterName, 'nixSource');
+    g.add_source(s);
+    filterID = s.id;
+	s = b.create_source('testSource1', filterType);
+    g.add_source(s);
+    filterIDs = {filterID, s.id};
+    s = b.create_source('testSource2', filterType);
+    g.add_source(s);
+    
+    % test empty id filter
+    assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.groups{1}.filter_sources(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    mainSource = b.create_source(mainName, 'nixSource');
+    g.add_source(mainSource);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    mainSource.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    mainSource = b.create_source(mainName, 'nixSource');
+    g.add_source(mainSource);
+    mainID = mainSource.id;
+    subName = 'testSubSource1';
+    s = mainSource.create_source(subName, 'nixSource');
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, subName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, mainID));
+
+    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -43,6 +43,7 @@ function funcs = TestGroup
     funcs{end+1} = @test_open_source_idx;
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_source;
+    funcs{end+1} = @test_filter_tag;
 end
 
 %% Test: Access nix.Group attributes
@@ -942,6 +943,80 @@ function [] = test_filter_source( varargin )
     assert(strcmp(filtered{1}.id, mainID));
 
     filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+end
+
+%% Test: filter tags
+function [] = test_filter_tag( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    g = b.create_group('testGroup', 'nixGroup');
+    t = b.create_tag(filterName, 'nixTag', [1 2 3]);
+    g.add_tag(t);
+    filterID = t.id;
+	t = b.create_tag('testTag1', filterType, [1 2 3]);
+    g.add_tag(t);
+    filterIDs = {filterID, t.id};
+    t = b.create_tag('testTag2', filterType, [1 2 3]);
+    g.add_tag(t);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.groups{1}.filter_tags(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.groups{1}.filter_tags(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    main = b.create_tag(mainName, 'nixTag', [1 2 3]);
+    g.add_tag(main);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    main.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.groups{1}.filter_tags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    main = b.create_tag(mainName, 'nixTag', [1 2 3]);
+    g.add_tag(main);
+    mainID = main.id;
+    subName = 'testSubSource1';
+    s = b.create_source(subName, 'nixSource');
+    main.add_source(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.groups{1}.filter_tags(nix.Filter.source, 'Do not exist')));
+
+    % filter works only for ID, not for name
+    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -45,6 +45,7 @@ function funcs = TestMultiTag
     funcs{end+1} = @test_set_units;
     funcs{end+1} = @test_attrs;
     funcs{end+1} = @test_compare;
+    funcs{end+1} = @test_filter_source;
 end
 
 %% Test: Add sources by entity and id
@@ -778,4 +779,80 @@ function [] = test_compare( varargin )
     assert(t1.compare(t1) == 0);
     assert(t2.compare(t1) > 0);
     assert(t1.compare(t3) ~= 0);
+end
+
+%% Test: filter sources
+function [] = test_filter_source( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 3]);
+    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
+    s = b.create_source(filterName, 'nixSource');
+    t.add_source(s);
+    filterID = s.id;
+	s = b.create_source('testSource1', filterType);
+    t.add_source(s);
+    filterIDs = {filterID, s.id};
+    s = b.create_source('testSource2', filterType);
+    t.add_source(s);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+
+    % test nix.Filter.id
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    mainSource = b.create_source(mainName, 'nixSource');
+    t.add_source(mainSource);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    mainSource.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    main = b.create_source(mainName, 'nixSource');
+    t.add_source(main);
+    mainID = main.id;
+    subName = 'testSubSource1';
+    s = main.create_source(subName, 'nixSource');
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, subName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, mainID));
+
+    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -47,6 +47,7 @@ function funcs = TestMultiTag
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_source;
     funcs{end+1} = @test_filter_reference;
+    funcs{end+1} = @test_filter_feature;
 end
 
 %% Test: Add sources by entity and id
@@ -931,4 +932,66 @@ function [] = test_filter_reference( varargin )
     filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
+end
+
+%% Test: filter features
+function [] = test_filter_feature( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
+    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
+    d = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    feat = t.add_feature(d, nix.LinkType.Tagged);
+    filterID = feat.id;
+	d = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    feat = t.add_feature(d, nix.LinkType.Tagged);
+    filterIDs = {filterID, feat.id};
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.multiTags{1}.filter_features(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.multiTags{1}.filter_features(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.id
+    filtered = f.blocks{1}.multiTags{1}.filter_features(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.multiTags{1}.filter_features(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+
+    % test fail on nix.Filter.name
+    err = 'unknown or unsupported filter';
+    try
+        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.name, 'someName');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test fail on nix.Filter.type
+    err = 'unknown or unsupported filter';
+    try
+        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.type, 'someType');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test fail on nix.Filter.metadata
+    err = 'unknown or unsupported filter';
+    try
+        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.metadata, 'someMetadata');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test fail on nix.Filter.source
+    try
+        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.source, 'someSource');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -40,6 +40,7 @@ function funcs = TestSection
     funcs{end+1} = @test_referring_blocks;
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_section;
+    funcs{end+1} = @test_filter_property;
 end
 
 %% Test: Create Section
@@ -673,6 +674,62 @@ function [] = test_filter_section( varargin )
     % test fail on nix.Filter.source
     try
         f.sections{1}.filter_sections(nix.Filter.source, 'someSource');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+end
+
+%% Test: filter properties
+function [] = test_filter_property( varargin )
+    filterName = 'filterMe';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    ms = f.create_section('testSection', 'nixSection');
+    p = ms.create_property(filterName, nix.DataType.Double);
+    filterID = p.id;
+	s = ms.create_property('testProperty', nix.DataType.Bool);
+    filterIDs = {filterID, s.id};
+    
+    % test empty id filter
+    assert(isempty(f.sections{1}.filter_properties(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.sections{1}.filter_properties(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 2);
+    
+    % test nix.Filter.id
+    filtered = f.sections{1}.filter_properties(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.sections{1}.filter_properties(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+
+    % test nix.Filter.name
+    filtered  = f.sections{1}.filter_properties(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+
+    % test fail on nix.Filter.type
+    err = 'unknown or unsupported filter';
+    try
+        f.sections{1}.filter_properties(nix.Filter.type, 'someType');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test fail on nix.Filter.metadata
+    err = 'unknown or unsupported filter';
+    try
+        f.sections{1}.filter_properties(nix.Filter.metadata, 'someMetadata');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test fail on nix.Filter.source
+    try
+        f.sections{1}.filter_properties(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -39,6 +39,7 @@ function funcs = TestSection
     funcs{end+1} = @test_referring_block_sources;
     funcs{end+1} = @test_referring_blocks;
     funcs{end+1} = @test_compare;
+    funcs{end+1} = @test_filter_section;
 end
 
 %% Test: Create Section
@@ -619,4 +620,60 @@ function [] = test_compare( varargin )
     assert(s1.compare(s2) < 0);
     assert(s1.compare(s1) == 0);
     assert(s2.compare(s1) > 0);
+end
+
+%% Test: filter Sections
+function [] = test_filter_section( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    ms = f.create_section('testSection', 'nixSection');
+    s = ms.create_section(filterName, 'nixSection');
+    filterID = s.id;
+	s = ms.create_section('testSection1', filterType);
+    filterIDs = {filterID, s.id};
+    s = ms.create_section('testSection2', filterType);
+
+    % ToDO add basic filter crash tests
+    
+    % test empty id filter
+    assert(isempty(f.sections{1}.filter_sections(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.sections{1}.filter_sections(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+    
+    % test nix.Filter.id
+    filtered = f.sections{1}.filter_sections(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.sections{1}.filter_sections(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.sections{1}.filter_sections(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.sections{1}.filter_sections(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+    
+    % test fail on nix.Filter.metadata
+    err = 'unknown or unsupported filter';
+    try
+        f.sections{1}.filter_sections(nix.Filter.metadata, 'someMetadata');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+    
+    % test fail on nix.Filter.source
+    try
+        f.sections{1}.filter_sections(nix.Filter.source, 'someSource');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
 end

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -40,6 +40,7 @@ function funcs = TestTag
     funcs{end+1} = @test_has_feature;
     funcs{end+1} = @test_has_reference;
     funcs{end+1} = @test_compare;
+    funcs{end+1} = @test_filter_source;
 end
 
 %% Test: Add sources by entity and id
@@ -651,4 +652,79 @@ function [] = test_compare( varargin )
     assert(t1.compare(t1) == 0);
     assert(t2.compare(t1) > 0);
     assert(t1.compare(t3) ~= 0);
+end
+
+%% Test: filter sources
+function [] = test_filter_source( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    t = b.create_tag('testTag', 'nixTag', [1 2 3]);
+    s = b.create_source(filterName, 'nixSource');
+    t.add_source(s);
+    filterID = s.id;
+	s = b.create_source('testSource1', filterType);
+    t.add_source(s);
+    filterIDs = {filterID, s.id};
+    s = b.create_source('testSource2', filterType);
+    t.add_source(s);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+
+    % test nix.Filter.id
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.tags{1}.filter_sources(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    mainSource = b.create_source(mainName, 'nixSource');
+    t.add_source(mainSource);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    mainSource.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    main = b.create_source(mainName, 'nixSource');
+    t.add_source(main);
+    mainID = main.id;
+    subName = 'testSubSource1';
+    s = main.create_source(subName, 'nixSource');
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, subName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, mainID));
+
+    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -41,6 +41,7 @@ function funcs = TestTag
     funcs{end+1} = @test_has_reference;
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_source;
+    funcs{end+1} = @test_filter_reference;
 end
 
 %% Test: Add sources by entity and id
@@ -725,6 +726,80 @@ function [] = test_filter_source( varargin )
     assert(strcmp(filtered{1}.id, mainID));
 
     filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+end
+
+%% Test: filter references
+function [] = test_filter_reference( varargin )
+    filterName = 'filterMe';
+    filterType = 'filterType';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    t = b.create_tag('testTag', 'nixTag', [1 2 3]);
+    d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    t.add_reference(d);
+    filterID = d.id;
+	d = b.create_data_array('testDataArray1', filterType, nix.DataType.Double, [1 2]);
+    t.add_reference(d);
+    filterIDs = {filterID, d.id};
+    d = b.create_data_array('testDataArray2', filterType, nix.DataType.Double, [1 2]);
+    t.add_reference(d);
+
+    % test empty id filter
+    assert(isempty(f.blocks{1}.tags{1}.filter_references(nix.Filter.id, 'IdoNotExist')));
+
+    % test nix.Filter.accept_all
+    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.accept_all, '');
+    assert(size(filtered, 1) == 3);
+
+    % test nix.Filter.id
+    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.id, filterID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, filterID));
+
+    % test nix.Filter.ids
+    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.ids, filterIDs);
+    assert(size(filtered, 1) == 2);
+    assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
+    
+    % test nix.Filter.name
+    filtered  = f.blocks{1}.tags{1}.filter_references(nix.Filter.name, filterName);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, filterName));
+    
+    % test nix.Filter.type
+    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.type, filterType);
+    assert(size(filtered, 1) == 2);
+
+    % test nix.Filter.metadata
+    mainName = 'testSubSection';
+    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    t.add_reference(main);
+    subName = 'testSubSection1';
+    s = f.create_section(subName, 'nixSection');
+    main.set_metadata(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.tags{1}.filter_references(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.metadata, subID);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, mainName));
+
+    % test nix.Filter.source
+    mainName = 'testSubSource';
+    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    t.add_reference(main);
+    mainID = main.id;
+    subName = 'testSubSource1';
+    s = b.create_source(subName, 'nixSource');
+    main.add_source(s);
+    subID = s.id;
+
+    assert(isempty(f.blocks{1}.tags{1}.filter_references(nix.Filter.source, 'Do not exist')));
+
+    % filter works only for ID, not for name
+    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end


### PR DESCRIPTION
- This PR introduces the filters implemented with PR #147 to the C++ and Matlab side.
- It refactors the filter implementation on the C++ side to reduce boilerplate code.
- Adds tests for all added functions on the Matlab side.
- Closes #122.

Successfully built under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).
