### PR TITLE
Implement findSources and findSections

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -191,21 +191,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         % maxdepth is an index
         function sec = find_filtered_sources(obj, max_depth, filter, val)
-            if (~isnumeric(max_depth))
-                error('Provide a valid search depth');
-            end
-
-            valid = nix.Utils.valid_filter(filter, val);
-            if(~isempty(valid))
-                error(valid);
-            end
-
-            ret = nix_mx('Block::findSources', obj.nix_handle, ...
-                                            max_depth, uint8(filter), val);
-            sec = cell(length(ret), 1);
-            for i = 1:length(ret)
-                sec{i} = nix.Source(ret{i});
-            end;
+            sec = nix.Utils.find(obj, ...
+                max_depth, filter, val, 'Block::findSources', @nix.Source);
         end
 
         % -----------------
@@ -289,6 +276,6 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             filtered = nix.Utils.filter(obj, filter, val, ...
                 'Block::multiTagsFiltered', @nix.MultiTag);
         end
+    end
 
-    end;
 end

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -184,6 +184,30 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 'Block::sourcesFiltered', @nix.Source);
         end
 
+        % maxdepth is an index
+        function sec = find_sources(obj, max_depth)
+            sec = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
+        end
+
+        % maxdepth is an index
+        function sec = find_filtered_sources(obj, max_depth, filter, val)
+            if (~isnumeric(max_depth))
+                error('Provide a valid search depth');
+            end
+
+            valid = nix.Utils.valid_filter(filter, val);
+            if(~isempty(valid))
+                error(valid);
+            end
+
+            ret = nix_mx('Block::findSources', obj.nix_handle, ...
+                                            max_depth, uint8(filter), val);
+            sec = cell(length(ret), 1);
+            for i = 1:length(ret)
+                sec{i} = nix.Source(ret{i});
+            end;
+        end
+
         % -----------------
         % Tags methods
         % -----------------

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -120,21 +120,8 @@ classdef File < nix.Entity
         
         % maxdepth is an index
         function sec = find_filtered_sections(obj, max_depth, filter, val)
-            if (~isnumeric(max_depth))
-                error('Provide a valid search depth');
-            end
-
-            valid = nix.Utils.valid_filter(filter, val);
-            if(~isempty(valid))
-                error(valid);
-            end
-
-            ret = nix_mx('File::findSections', obj.nix_handle, ...
-                                            max_depth, uint8(filter), val);
-            sec = cell(length(ret), 1);
-            for i = 1:length(ret)
-                sec{i} = nix.Section(ret{i});
-            end;
+            sec = nix.Utils.find(obj, ...
+                max_depth, filter, val, 'File::findSections', @nix.Section);
         end
     end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -112,6 +112,30 @@ classdef File < nix.Entity
             filtered = nix.Utils.filter(obj, filter, val, ...
                 'File::sectionsFiltered', @nix.Section);
         end
+        
+        % maxdepth is an index
+        function sec = find_sections(obj, max_depth)
+            sec = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
+        end
+        
+        % maxdepth is an index
+        function sec = find_filtered_sections(obj, max_depth, filter, val)
+            if (~isnumeric(max_depth))
+                error('Provide a valid search depth');
+            end
+
+            valid = nix.Utils.valid_filter(filter, val);
+            if(~isempty(valid))
+                error(valid);
+            end
+
+            ret = nix_mx('File::findSections', obj.nix_handle, ...
+                                            max_depth, uint8(filter), val);
+            sec = cell(length(ret), 1);
+            for i = 1:length(ret)
+                sec{i} = nix.Section(ret{i});
+            end;
+        end
     end
 
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -123,21 +123,8 @@ classdef Section < nix.NamedEntity
 
         % maxdepth is an index
         function sec = find_filtered_sections(obj, max_depth, filter, val)
-            if (~isnumeric(max_depth))
-                error('Provide a valid search depth');
-            end
-
-            valid = nix.Utils.valid_filter(filter, val);
-            if(~isempty(valid))
-                error(valid);
-            end
-
-            ret = nix_mx('Section::findSections', obj.nix_handle, ...
-                                            max_depth, uint8(filter), val);
-            sec = cell(length(ret), 1);
-            for i = 1:length(ret)
-                sec{i} = nix.Section(ret{i});
-            end;
+            sec = nix.Utils.find(obj, ...
+                max_depth, filter, val, 'Section::findSections', @nix.Section);
         end
 
         % ----------------

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -106,6 +106,15 @@ classdef Section < nix.NamedEntity
             filtered = nix.Utils.filter(obj, filter, val, ...
                 'Section::sectionsFiltered', @nix.Section);
         end
+        
+        % find_related returns the nearest occurrence downstream of a
+        % nix.Section matching the filter.
+        % If no section can be found downstream, it will look for the
+        % nearest occurrence upstream of a nix.Section matching the filter.
+        function filtered = find_related(obj, filter, val)
+            filtered = nix.Utils.filter(obj, filter, val, ...
+                'Section::findRelated', @nix.Section);
+        end
 
         % maxdepth is an index
         function sec = find_sections(obj, max_depth)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -107,6 +107,30 @@ classdef Section < nix.NamedEntity
                 'Section::sectionsFiltered', @nix.Section);
         end
 
+        % maxdepth is an index
+        function sec = find_sections(obj, max_depth)
+            sec = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
+        end
+
+        % maxdepth is an index
+        function sec = find_filtered_sections(obj, max_depth, filter, val)
+            if (~isnumeric(max_depth))
+                error('Provide a valid search depth');
+            end
+
+            valid = nix.Utils.valid_filter(filter, val);
+            if(~isempty(valid))
+                error(valid);
+            end
+
+            ret = nix_mx('Section::findSections', obj.nix_handle, ...
+                                            max_depth, uint8(filter), val);
+            sec = cell(length(ret), 1);
+            for i = 1:length(ret)
+                sec{i} = nix.Section(ret{i});
+            end;
+        end
+
         % ----------------
         % Property methods
         % ----------------

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -88,21 +88,8 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         % maxdepth is an index where idx = 0 corresponds to the calling
         % source
         function sec = find_filtered_sources(obj, max_depth, filter, val)
-            if (~isnumeric(max_depth))
-                error('Provide a valid search depth');
-            end
-
-            valid = nix.Utils.valid_filter(filter, val);
-            if(~isempty(valid))
-                error(valid);
-            end
-
-            ret = nix_mx('Source::findSources', obj.nix_handle, ...
-                                            max_depth, uint8(filter), val);
-            sec = cell(length(ret), 1);
-            for i = 1:length(ret)
-                sec{i} = nix.Source(ret{i});
-            end;
+            sec = nix.Utils.find(obj, ...
+                max_depth, filter, val, 'Source::findSources', @nix.Source);
         end
     end;
 end

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -78,5 +78,31 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             filtered = nix.Utils.filter(obj, filter, val, ...
                 'Source::sourcesFiltered', @nix.Source);
         end
+
+        % maxdepth is an index where idx = 0 corresponds to the calling
+        % source
+        function sec = find_sources(obj, max_depth)
+            sec = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
+        end
+
+        % maxdepth is an index where idx = 0 corresponds to the calling
+        % source
+        function sec = find_filtered_sources(obj, max_depth, filter, val)
+            if (~isnumeric(max_depth))
+                error('Provide a valid search depth');
+            end
+
+            valid = nix.Utils.valid_filter(filter, val);
+            if(~isempty(valid))
+                error(valid);
+            end
+
+            ret = nix_mx('Source::findSources', obj.nix_handle, ...
+                                            max_depth, uint8(filter), val);
+            sec = cell(length(ret), 1);
+            for i = 1:length(ret)
+                sec{i} = nix.Source(ret{i});
+            end;
+        end
     end;
 end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -114,5 +114,29 @@ classdef Utils
             end;
         end
 
+        % -----------------------------------------------------------
+        % findXXX helper functions
+        % -----------------------------------------------------------
+
+        function currData = find(obj, max_depth, filter, val, ...
+                                                mxMethod, objConstructor)
+            if (~isnumeric(max_depth))
+                error('Provide a valid search depth');
+            end
+
+            valid = nix.Utils.valid_filter(filter, val);
+            if(~isempty(valid))
+                error(valid);
+            end
+
+            currList = nix_mx(mxMethod, ...
+                            obj.nix_handle, max_depth, uint8(filter), val);
+
+            currData = cell(length(currList), 1);
+            for i = 1:length(currList)
+                currData{i} = objConstructor(currList{i});
+            end;
+        end
+
     end;
 end

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -418,6 +418,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::sectionsFiltered", nixsection::sectionsFiltered);
         methods->add("Section::propertiesFiltered", nixsection::propertiesFiltered);
         methods->add("Section::findSections", nixsection::findSections);
+        methods->add("Section::findRelated", nixsection::findRelated);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -417,6 +417,7 @@ void mexFunction(int            nlhs,
         methods->add("Section::compare", nixsection::compare);
         methods->add("Section::sectionsFiltered", nixsection::sectionsFiltered);
         methods->add("Section::propertiesFiltered", nixsection::propertiesFiltered);
+        methods->add("Section::findSections", nixsection::findSections);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -287,6 +287,7 @@ void mexFunction(int            nlhs,
         methods->add("Source::openSourceIdx", nixsource::openSourceIdx);
         methods->add("Source::compare", nixsource::compare);
         methods->add("Source::sourcesFiltered", nixsource::sourcesFiltered);
+        methods->add("Source::findSources", nixsource::findSources);
 
         classdef<nix::Tag>("Tag", methods)
             .desc(&nixtag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -123,6 +123,7 @@ void mexFunction(int            nlhs,
         methods->add("File::openSectionIdx", nixfile::openSectionIdx);
         methods->add("File::sectionsFiltered", nixfile::sectionsFiltered);
         methods->add("File::blocksFiltered", nixfile::blocksFiltered);
+        methods->add("File::findSections", nixfile::findSections);
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -174,6 +174,7 @@ void mexFunction(int            nlhs,
         methods->add("Block::tagsFiltered", nixblock::tagsFiltered);
         methods->add("Block::multiTagsFiltered", nixblock::multiTagsFiltered);
         methods->add("Block::dataArraysFiltered", nixblock::dataArraysFiltered);
+        methods->add("Block::findSources", nixblock::findSources);
 
         classdef<nix::Group>("Group", methods)
             .desc(&nixgroup::describe)

--- a/src/filters.h
+++ b/src/filters.h
@@ -13,6 +13,7 @@
 #include "mex.h"
 #include "datatypes.h"
 
+// filter function templates
 template<typename T, typename FN>
 std::vector<T> filterFullEntity(const extractor &input, FN ff) {
     std::vector<T> res;
@@ -111,6 +112,69 @@ std::vector<T> filterEntity(const extractor &input, FN ff) {
     case switchFilter::Ids:
         // this will crash matlab, if its not a vector of strings...
         res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(3)));
+        break;
+    default: throw std::invalid_argument("unknown or unsupported filter");
+    }
+
+    return res;
+}
+
+// find filter function templates
+template<typename T, typename FN>
+std::vector<T> filterFullEntity(const extractor &input, 
+                    uint8_t filter_id, size_t val_pos, size_t max_depth, FN ff) {
+    std::vector<T> res;
+
+    switch (filter_id) {
+    case switchFilter::AcceptAll:
+        res = ff(nix::util::AcceptAll<T>(), max_depth);
+        break;
+    case switchFilter::Id:
+        res = ff(nix::util::IdFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    case switchFilter::Ids:
+        // this will crash matlab, if its not a vector of strings...
+        res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(val_pos)), max_depth);
+        break;
+    case switchFilter::Type:
+        res = ff(nix::util::TypeFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    case switchFilter::Name:
+        res = ff(nix::util::NameFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    case switchFilter::Metadata:
+        res = ff(nix::util::MetadataFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    case switchFilter::Source:
+        res = ff(nix::util::SourceFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    default: throw std::invalid_argument("unknown or unsupported filter");
+    }
+
+    return res;
+}
+
+template<typename T, typename FN>
+std::vector<T> filterNameTypeEntity(const extractor &input,
+                        uint8_t filter_id, size_t val_pos, size_t max_depth, FN ff) {
+    std::vector<T> res;
+
+    switch (filter_id) {
+    case switchFilter::AcceptAll:
+        res = ff(nix::util::AcceptAll<T>(), max_depth);
+        break;
+    case switchFilter::Id:
+        res = ff(nix::util::IdFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    case switchFilter::Ids:
+        // this will crash matlab, if its not a vector of strings...
+        res = ff(nix::util::IdsFilter<T>(input.vec<std::string>(val_pos)), max_depth);
+        break;
+    case switchFilter::Type:
+        res = ff(nix::util::TypeFilter<T>(input.str(val_pos)), max_depth);
+        break;
+    case switchFilter::Name:
+        res = ff(nix::util::NameFilter<T>(input.str(val_pos)), max_depth);
         break;
     default: throw std::invalid_argument("unknown or unsupported filter");
     }

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -142,4 +142,17 @@ namespace nixblock {
         output.set(0, res);
     }
 
+    void findSources(const extractor &input, infusor &output) {
+        nix::Block currObj = input.entity<nix::Block>(1);
+        size_t max_depth = (size_t)input.num<double>(2);
+        uint8_t filter_id = input.num<uint8_t>(3);
+
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input, filter_id, 4, max_depth,
+            [currObj](const nix::util::Filter<nix::Source>::type &filter, size_t &md) {
+                return currObj.findSources(filter, md);
+        });
+
+        output.set(0, res);
+    }
+
 } // namespace nixblock

--- a/src/nixblock.h
+++ b/src/nixblock.h
@@ -43,6 +43,8 @@ namespace nixblock {
 
     void dataArraysFiltered(const extractor &input, infusor &output);
 
+    void findSources(const extractor &input, infusor &output);
+
 } // namespace nixblock
 
 #endif

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -133,4 +133,17 @@ namespace nixfile {
         output.set(0, res);
     }
 
+    void findSections(const extractor &input, infusor &output) {
+        nix::File currObj = input.entity<nix::File>(1);
+        size_t max_depth = (size_t)input.num<double>(2);
+        uint8_t filter_id = input.num<uint8_t>(3);
+
+        std::vector<nix::Section> res = filterNameTypeEntity<nix::Section>(input, filter_id, 4, max_depth, 
+            [currObj](const nix::util::Filter<nix::Section>::type &filter, size_t &md) {
+                return currObj.findSections(filter, md);
+        });
+
+        output.set(0, res);
+    }
+
 } // namespace nixfile

--- a/src/nixfile.h
+++ b/src/nixfile.h
@@ -29,6 +29,8 @@ namespace nixfile {
 
     void blocksFiltered(const extractor &input, infusor &output);
 
+    void findSections(const extractor &input, infusor &output);
+
 } // namespace nixfile
 
 #endif

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -155,4 +155,13 @@ namespace nixsection {
         output.set(0, res);
     }
 
+    void findRelated(const extractor &input, infusor &output) {
+        nix::Section currObj = input.entity<nix::Section>(1);
+        std::vector<nix::Section> res = filterNameTypeEntity<nix::Section>(input,
+                                            [currObj](const nix::util::Filter<nix::Section>::type &filter) {
+            return currObj.findRelated(filter);
+        });
+        output.set(0, res);
+    }
+
 } // namespace nixsection

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -142,4 +142,17 @@ namespace nixsection {
         output.set(0, res);
     }
 
+    void findSections(const extractor &input, infusor &output) {
+        nix::Section currObj = input.entity<nix::Section>(1);
+        size_t max_depth = (size_t)input.num<double>(2);
+        uint8_t filter_id = input.num<uint8_t>(3);
+
+        std::vector<nix::Section> res = filterNameTypeEntity<nix::Section>(input, filter_id, 4, max_depth,
+            [currObj](const nix::util::Filter<nix::Section>::type &filter, size_t &md) {
+                return currObj.findSections(filter, md);
+        });
+
+        output.set(0, res);
+    }
+
 } // namespace nixsection

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -41,6 +41,8 @@ namespace nixsection {
 
     void findSections(const extractor &input, infusor &output);
 
+    void findRelated(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -39,6 +39,8 @@ namespace nixsection {
 
     void propertiesFiltered(const extractor &input, infusor &output);
 
+    void findSections(const extractor &input, infusor &output);
+
 } // namespace nixsection
 
 #endif

--- a/src/nixsource.cc
+++ b/src/nixsource.cc
@@ -49,4 +49,17 @@ namespace nixsource {
         output.set(0, res);
     }
 
+    void findSources(const extractor &input, infusor &output) {
+        nix::Source currObj = input.entity<nix::Source>(1);
+        size_t max_depth = (size_t)input.num<double>(2);
+        uint8_t filter_id = input.num<uint8_t>(3);
+
+        std::vector<nix::Source> res = filterFullEntity<nix::Source>(input, filter_id, 4, max_depth,
+            [currObj](const nix::util::Filter<nix::Source>::type &filter, size_t &md) {
+                return currObj.findSources(filter, md);
+        });
+
+        output.set(0, res);
+    }
+
 } // namespace nixsource

--- a/src/nixsource.h
+++ b/src/nixsource.h
@@ -21,6 +21,8 @@ namespace nixsource {
 
     void sourcesFiltered(const extractor &input, infusor &output);
 
+    void findSources(const extractor &input, infusor &output);
+
 } // namespace nixsource
 
 #endif

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -41,6 +41,8 @@ function funcs = TestSection
     funcs{end+1} = @test_compare;
     funcs{end+1} = @test_filter_section;
     funcs{end+1} = @test_filter_property;
+    funcs{end+1} = @test_find_section;
+    funcs{end+1} = @test_find_section_filtered;
 end
 
 %% Test: Create Section
@@ -730,6 +732,125 @@ function [] = test_filter_property( varargin )
     % test fail on nix.Filter.source
     try
         f.sections{1}.filter_properties(nix.Filter.source, 'someSource');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+end
+
+%% Test: Find sections w/o filter
+function [] = test_find_section
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    main = f.create_section('testSection', 'nixSection');
+    sl1 = main.create_section('sectionLvl1', 'nixSection');
+
+    sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
+    sl22 = sl1.create_section('sectionLvl2_2', 'nixSection');
+
+    sl31 = sl21.create_section('sectionLvl3_1', 'nixSection');
+    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.create_section('sectionLvl3_3', 'nixSection');
+
+    sl41 = sl31.create_section('sectionLvl4_1', 'nixSection');
+    sl42 = sl31.create_section('sectionLvl4_2', 'nixSection');
+    sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
+    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+
+    side = f.create_section('sideSection', 'nixSection');
+    side1 = side.create_section('sideSubSection', 'nixSection');
+
+    % Check invalid entry
+    err = 'Provide a valid search depth';
+    try
+        sl1.find_sections('hurra');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % find all
+    filtered = sl1.find_sections(4);
+    assert(size(filtered, 1) == 10);
+
+    % find until level 4
+    filtered = sl1.find_sections(3);
+    assert(size(filtered, 1) == 10);
+
+    % find until level 3
+    filtered = sl1.find_sections(2);
+    assert(size(filtered, 1) == 6);
+
+    % find until level 2
+    filtered = sl1.find_sections(1);
+    assert(size(filtered, 1) == 3);
+
+    % find until level 1
+    filtered = sl1.find_sections(0);
+    assert(size(filtered, 1) == 1);
+end
+
+%% Test: Find sections with filters
+function [] = test_find_section_filtered
+    findSection = 'nixFindSection';
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    main = f.create_section('testSection', 'nixSection');
+    sl1 = main.create_section('sectionLvl1', 'nixSection');
+
+    sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
+    sl22 = sl1.create_section('sectionLvl2_2', findSection);
+
+    sl31 = sl21.create_section('sectionLvl3_1', findSection);
+    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.create_section('sectionLvl3_3', 'nixSection');
+
+    sl41 = sl31.create_section('sectionLvl4_1', findSection);
+    sl42 = sl31.create_section('sectionLvl4_2', 'nixSection');
+    sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
+    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+
+    sideName = 'sideSubSection';
+    side = f.create_section('sideSection', 'nixSection');
+    side1 = side.create_section(sideName, 'nixSection');
+
+    % test find by id
+    filtered = sl1.find_filtered_sections(0, nix.Filter.id, sl41.id);
+    assert(isempty(filtered));
+    filtered = sl1.find_filtered_sections(3, nix.Filter.id, sl41.id);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.id, sl41.id));
+
+    % test find by ids
+    filterids = {sl1.id, sl41.id};
+    filtered = sl1.find_filtered_sections(0, nix.Filter.ids, filterids);
+    assert(size(filtered, 1) == 1);
+    filtered = sl1.find_filtered_sections(3, nix.Filter.ids, filterids);
+    assert(size(filtered, 1) == 2);
+
+    % test find by name
+    filtered = sl1.find_filtered_sections(4, nix.Filter.name, sideName);
+    assert(isempty(filtered));
+    filtered = sl1.find_filtered_sections(0, nix.Filter.name, sl41.name);
+    assert(isempty(filtered));
+    filtered = sl1.find_filtered_sections(3, nix.Filter.name, sl41.name);
+    assert(size(filtered, 1) == 1);
+    assert(strcmp(filtered{1}.name, sl41.name));
+
+    % test find by type
+    filtered = sl1.find_filtered_sections(0, nix.Filter.type, findSection);
+    assert(isempty(filtered));
+    filtered = sl1.find_filtered_sections(3, nix.Filter.type, findSection);
+    assert(size(filtered, 1) == 3);
+    assert(strcmp(filtered{1}.type, findSection));
+
+    % test fail on nix.Filter.metadata
+    err = 'unknown or unsupported filter';
+    try
+        sl1.find_filtered_sections(1, nix.Filter.metadata, 'metadata');
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
+
+    % test fail on nix.Filter.source
+    try
+        sl1.find_filtered_sections(1, nix.Filter.source, 'source');
     catch ME
         assert(strcmp(ME.message, err));
     end


### PR DESCRIPTION
This PR 

- adds find filter templates to the C++ side.
- adds `findSources`, `findSections` and `findRelated` functions to the appropriate Entitites.
- adds tests for every new function.
- closes #99.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).