### PR TITLE
Bugfix and update Windows build batch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About NIX-MX
 -------------
 
-The *NIX-MX* project is an extension to [NIX] (https://github.com/G-Node/nix) and provides Matlab bindings for *NIX*.
+The *NIX-MX* project is an extension to [NIX](https://github.com/G-Node/nix) and provides Matlab bindings for *NIX*.
 
 
 Development Status
@@ -15,8 +15,8 @@ Getting Started (Windows 32/64)
 
 **Quick start packages, Beta-Release 1.1.0**
 
-The [quick start packages] (https://github.com/G-Node/nix-mx/releases) are compiled under Windows 32/64 and contain all dlls, binary and Matlab files required to use NIX-MX with the respective Windows OS.
-The included *NIX* dll is a [stable release 1.3.2 build] (https://github.com/G-Node/nix/releases/tag/1.3.2) . To use the packages, unzip them into a folder of your choice and run the `startup.m` script from the root folder. Do not change the file/folder structure.
+The [quick start packages](https://github.com/G-Node/nix-mx/releases) are compiled under Windows 32/64 and contain all dlls, binary and Matlab files required to use NIX-MX with the respective Windows OS.
+The included *NIX* dll is a [stable release 1.3.2 build](https://github.com/G-Node/nix/releases/tag/1.3.2) . To use the packages, unzip them into a folder of your choice and run the `startup.m` script from the root folder. Do not change the file/folder structure.
 
 The Windows 32 package contains:
 - HDF5 dlls (Release 1.8.14)

--- a/startuptests.m
+++ b/startuptests.m
@@ -1,0 +1,6 @@
+addpath(genpath(pwd));
+RunTests;
+if (stats.errorCount > 0)
+    exit(1);
+end
+exit(0);

--- a/win_build.bat
+++ b/win_build.bat
@@ -136,6 +136,11 @@ IF %ERRORLEVEL% == 1 (
 	ECHO --------------------------------------------------------------------------
 	ECHO Matlab tests failed, check details above.
 	ECHO --------------------------------------------------------------------------
+) ELSE (
+	ECHO --------------------------------------------------------------------------
+	ECHO Build complete, all tests passed!
+	ECHO Use "startup.m" to start your nix-mx experience!
+	ECHO --------------------------------------------------------------------------
 )
 
 DEL %TEST_LOG%

--- a/win_build.bat
+++ b/win_build.bat
@@ -1,15 +1,47 @@
+@ECHO off
+REM Latest dependencies at https://projects.g-node.org/nix/
 SET NIX_DEP=c:\work\nix-dep
+REM clone nix source from https://github.com/G-Node/nix
 SET NIX_ROOT=c:\work\nix
 SET NIX_MX_ROOT=c:\work\nix-mx
-REM Use only build types "Release" or "Debug"
-SET BUILD_TYPE=Release
 
-IF NOT %BUILD_TYPE% == Release (IF NOT %BUILD_TYPE% == Debug (ECHO Please use only Release or Debug as BUILD_TYPE))
+ECHO Use only build types "Release" or "Debug"
+IF "%1" == "Debug" (SET BUILD_TYPE=Debug)
+IF "%BUILD_TYPE%" == "" (SET BUILD_TYPE=Release)
+
+IF NOT %BUILD_TYPE% == Release (IF NOT %BUILD_TYPE% == Debug (ECHO Only Release or Debug are supported build types))
 IF NOT %BUILD_TYPE% == Release (IF NOT %BUILD_TYPE% == Debug (EXIT /b))
-REM Set NIX_BUILD_DIR for nix-mx FindNIX.cmake
-SET NIX_BUILD_DIR=%NIX_ROOT%\build\%BUILD_TYPE%
 
-IF %BUILD_TYPE% == Debug (CALL %NIX_DEP%\nixenv.bat Debug) ELSE (CALL %NIX_DEP%\nixenv.bat)
+ECHO --------------------------------------------------------------------------
+ECHO Setting up environment ...
+ECHO --------------------------------------------------------------------------
+
+IF "%PLATFORM%" == "" (IF %PROCESSOR_ARCHITECTURE% == x86 (SET PLATFORM=x86) ELSE (SET PLATFORM=x64))
+ECHO Platform: %PLATFORM% (%BUILD_TYPE%)
+
+SET BASE=%NIX_DEP%\%PLATFORM%\%BUILD_TYPE%
+
+SET CPPUNIT_INCLUDE_DIR=%BASE%\cppunit-1.13.2\include
+SET PATH=%PATH%;%CPPUNIT_INCLUDE_DIR%
+
+SET HDF5_BASE=%NIX_DEP%\%PLATFORM%\hdf5-1.8.14
+SET HDF5_DIR=%HDF5_BASE%\cmake\hdf5
+SET PATH=%PATH%;%HDF5_BASE%\bin
+
+SET BOOST_ROOT=%BASE%\boost-1.57.0
+SET BOOST_INCLUDEDIR=%BOOST_ROOT%\include\boost-1_57
+
+ECHO CPPUNIT_INCLUDE_DIR=%CPPUNIT_INCLUDE_DIR%
+IF EXIST %CPPUNIT_INCLUDE_DIR% (ECHO cppunit OK) ElSE (EXIT /b)
+ECHO HDF5_DIR=%HDF5_DIR%
+IF EXIST %HDF5_DIR% (ECHO hdf5 OK) ELSE (EXIT /b)
+ECHO BOOST_INCLUDEDIR=%BOOST_INCLUDEDIR%
+IF EXIST %BOOST_ROOT% (ECHO boost OK) ELSE (EXIT /b)
+
+ECHO --------------------------------------------------------------------------
+ECHO Setting up nix build ...
+ECHO --------------------------------------------------------------------------
+SET NIX_BUILD_DIR=%NIX_ROOT%\build\%BUILD_TYPE%
 
 IF NOT EXIST %NIX_ROOT%\build (MKDIR %NIX_ROOT%\build)
 CD %NIX_ROOT%\build
@@ -19,30 +51,55 @@ RD /S /Q "CMakeFiles" "Testing" "Debug" "Release" "nix-tool.dir" "x64" "TestRunn
 
 IF %PROCESSOR_ARCHITECTURE% == x86 ( cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
 
-REM Start %NIX_ROOT%\build\nix.sln
-cmake --build . --config %CONFIGURATION% --target nix
+ECHO --------------------------------------------------------------------------
+ECHO Building nix via %NIX_ROOT%\build\nix.sln ...
+ECHO --------------------------------------------------------------------------
+cmake --build . --config %BUILD_TYPE% --target nix
 
+IF %ERRORLEVEL% == 1 (EXIT /b)
+
+ECHO --------------------------------------------------------------------------
+ECHO Testing nix ...
+ECHO --------------------------------------------------------------------------
 %NIX_BUILD_DIR%\TestRunner.exe
 
+REM nix-mx requires nixversion file in ../nix/include/nix
+IF EXIST %NIX_ROOT%\build\include\nix\nixversion.hpp (
+	COPY %NIX_ROOT%\build\include\nix\nixversion.hpp %NIX_ROOT%\include\nix\
+)
+
+ECHO --------------------------------------------------------------------------
+ECHO Setting up nix-mx build ...
+ECHO --------------------------------------------------------------------------
 IF NOT EXIST %NIX_MX_ROOT%\build (MKDIR %NIX_MX_ROOT%\build)
 CD %NIX_MX_ROOT%\build
 REM Clean up build folder to ensure clean build.
 DEL * /S /Q
 RD /S /Q "CMakeFiles" "Debug" "nix_mx.dir" "Release" "Win32" "x64"
 
-COPY %NIX_BUILD_DIR%\nix.dll %NIX_MX_ROOT%\build\ /Y
-COPY %HDF5_BASE%\bin\hdf5.dll %NIX_MX_ROOT%\build\ /Y
-COPY %HDF5_BASE%\bin\msvcp120.dll %NIX_MX_ROOT%\build\ /Y
-COPY %HDF5_BASE%\bin\msvcr120.dll %NIX_MX_ROOT%\build\ /Y
-COPY %HDF5_BASE%\bin\szip.dll %NIX_MX_ROOT%\build\ /Y
-COPY %HDF5_BASE%\bin\zlib.dll %NIX_MX_ROOT%\build\ /Y
+REM Copying required libraries to nix-mx root folder
+COPY %NIX_BUILD_DIR%\nix.dll %NIX_MX_ROOT%\ /Y
+COPY %HDF5_BASE%\bin\hdf5.dll %NIX_MX_ROOT%\ /Y
+COPY %HDF5_BASE%\bin\msvcp120.dll %NIX_MX_ROOT%\ /Y
+COPY %HDF5_BASE%\bin\msvcr120.dll %NIX_MX_ROOT%\ /Y
+COPY %HDF5_BASE%\bin\szip.dll %NIX_MX_ROOT%\ /Y
+COPY %HDF5_BASE%\bin\zlib.dll %NIX_MX_ROOT%\ /Y
 
 IF %PROCESSOR_ARCHITECTURE% == x86 (cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
 
-cmake --build . --config %CONFIGURATION%
+ECHO --------------------------------------------------------------------------
+ECHO Building nix-mx via %NIX_MX_ROOT%\build\nix-mx.sln ...
+ECHO --------------------------------------------------------------------------
+cmake --build . --config %BUILD_TYPE%
 
-COPY %NIX_MX_ROOT%\build\%BUILD_TYPE%\nix_mx.mexw* %NIX_MX_ROOT%\build\ /Y
+IF %ERRORLEVEL% == 1 (EXIT /b)
+
+REM Copying required nix-mx.mex file to nix-mx root folder
+COPY %NIX_MX_ROOT%\build\%BUILD_TYPE%\nix_mx.mexw* %NIX_MX_ROOT%\ /Y
 
 CD %NIX_MX_ROOT%
 
+ECHO --------------------------------------------------------------------------
+ECHO Starting matlab ...
+ECHO --------------------------------------------------------------------------
 Start %NIX_MX_ROOT%\startup.m

--- a/win_build.bat
+++ b/win_build.bat
@@ -1,4 +1,5 @@
 @ECHO off
+SET MATLAB_BINARY=c:\work\MATLAB_R2011a\bin
 REM Latest dependencies at https://projects.g-node.org/nix/
 SET NIX_DEP=c:\work\nix-dep
 REM clone nix source from https://github.com/G-Node/nix
@@ -82,8 +83,8 @@ COPY %NIX_BUILD_DIR%\nix.dll %NIX_MX_ROOT%\ /Y
 COPY %HDF5_BASE%\bin\hdf5.dll %NIX_MX_ROOT%\ /Y
 COPY %HDF5_BASE%\bin\msvcp120.dll %NIX_MX_ROOT%\ /Y
 COPY %HDF5_BASE%\bin\msvcr120.dll %NIX_MX_ROOT%\ /Y
-COPY %HDF5_BASE%\bin\szip.dll %NIX_MX_ROOT%\ /Y
 COPY %HDF5_BASE%\bin\zlib.dll %NIX_MX_ROOT%\ /Y
+COPY %HDF5_BASE%\bin\szip.dll %NIX_MX_ROOT%\ /Y
 
 IF %PROCESSOR_ARCHITECTURE% == x86 (cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
 
@@ -100,6 +101,17 @@ COPY %NIX_MX_ROOT%\build\%BUILD_TYPE%\nix_mx.mexw* %NIX_MX_ROOT%\ /Y
 CD %NIX_MX_ROOT%
 
 ECHO --------------------------------------------------------------------------
-ECHO Starting matlab ...
+ECHO Running nix-mx tests ...
 ECHO --------------------------------------------------------------------------
-Start %NIX_MX_ROOT%\startup.m
+SET PATH=%PATH%;%MATLAB_BINARY%
+SET TEST_LOG=nix-mx-build.log~
+matlab -wait -nodesktop -nosplash -logfile %TEST_LOG% -r startuptests
+
+IF %ERRORLEVEL% == 1 (
+	TYPE %TEST_LOG%
+	ECHO --------------------------------------------------------------------------
+	ECHO Matlab tests failed, check details above.
+	ECHO --------------------------------------------------------------------------
+)
+
+DEL %TEST_LOG%

--- a/win_build.bat
+++ b/win_build.bat
@@ -75,9 +75,18 @@ cmake --build . --config %BUILD_TYPE% --target nix
 IF %ERRORLEVEL% == 1 (EXIT /b)
 
 ECHO --------------------------------------------------------------------------
+ECHO Building nix testrunner ...
+ECHO --------------------------------------------------------------------------
+cmake --build . --config %BUILD_TYPE% --target testrunner
+
+IF %ERRORLEVEL% == 1 (EXIT /b)
+
+ECHO --------------------------------------------------------------------------
 ECHO Testing nix ...
 ECHO --------------------------------------------------------------------------
 %NIX_BUILD_DIR%\TestRunner.exe
+
+IF %ERRORLEVEL% == 1 (EXIT /b)
 
 REM nix-mx requires nixversion file in ../nix/include/nix
 IF EXIST %NIX_ROOT%\build\include\nix\nixversion.hpp (

--- a/win_build.bat
+++ b/win_build.bat
@@ -6,6 +6,21 @@ REM clone nix source from https://github.com/G-Node/nix
 SET NIX_ROOT=c:\work\nix
 SET NIX_MX_ROOT=c:\work\nix-mx
 
+IF NOT EXIST %NIX_DEP% (
+	ECHO Please provide valid nix dependencies.
+	EXIT /b
+)
+
+IF NOT EXIST %NIX_ROOT% (
+	ECHO Please provide valid nix root directory.
+	EXIT /b
+)
+
+IF NOT EXIST %NIX_MX_ROOT% (
+	ECHO Please provide valid nix-mx root directory.
+	EXIT /b
+)
+
 ECHO Use only build types "Release" or "Debug"
 IF "%1" == "Debug" (SET BUILD_TYPE=Debug)
 IF "%BUILD_TYPE%" == "" (SET BUILD_TYPE=Release)


### PR DESCRIPTION
Refactors the windows `nix-mx` build batch file
- copies the auto-generated `nixversion.hpp` file to the required folder (fixes #120).
- runs c++ tests after building the c++ nix library; exists if these tests fail.
- reduces dependencies on secondary batch files.
- automatically runs Matlab tests after successful build.
- adds comments.
- in addition fixes broken links in the `README.md` file.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).