### PR TITLE
Easy access to 'Section.properties' listing

### DIFF
--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -30,6 +30,7 @@ classdef Section < nix.NamedEntity
             
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
+            nix.Dynamic.add_dyn_relation(obj, 'properties', @nix.Property);
         end;
 
         function section = parent(obj)
@@ -170,7 +171,7 @@ classdef Section < nix.NamedEntity
         end;
 
         function props = get.allProperties(obj)
-            props = nix_mx('Section::properties', obj.nix_handle);
+            props = nix_mx('Section::propertiesMap', obj.nix_handle);
         end;
         
         function p_map = get.allPropertiesMap(obj)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -14,12 +14,7 @@ classdef Section < nix.NamedEntity
         % namespace reference for nix-mx functions
         alias = 'Section'
     end;
-    
-    properties(Dependent)
-        allProperties
-        allPropertiesMap
-    end;
-    
+
     methods
         function obj = Section(h)
             obj@nix.NamedEntity(h);
@@ -168,19 +163,6 @@ classdef Section < nix.NamedEntity
         function retObj = open_property_idx(obj, idx)
             retObj = nix.Utils.open_entity(obj, ...
                 'Section::openPropertyIdx', idx, @nix.Property);
-        end;
-
-        function props = get.allProperties(obj)
-            props = nix_mx('Section::propertiesMap', obj.nix_handle);
-        end;
-        
-        function p_map = get.allPropertiesMap(obj)
-            p_map = containers.Map();
-            props = obj.allProperties;
-
-            for i=1:length(props)
-                p_map(props{i}.name) = cell2mat(props{i}.values);
-            end
         end;
 
         function c = property_count(obj)

--- a/examples/Primer.m
+++ b/examples/Primer.m
@@ -73,10 +73,10 @@ cellfun(@(x) disp(strcat(x.type, ': ', x.name)), f.sections);
 sec = f.sections{2}.sections{1};
 
 % display all Section properties
-cellfun(@(x) disp(x), sec.allProperties);
+cellfun(@(x) disp(x), sec.properties);
 
 % get a certain Value by index
-value = sec.allProperties{1}.values{1};
+value = sec.properties{1}.values{1};
 
 % or by name
 value = sec.open_property('Name').values{1}.value;

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -381,6 +381,7 @@ void mexFunction(int            nlhs,
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)
             .reg("sections", &nix::Section::sections)
+            .reg("properties", &nix::Section::properties)
             .reg("openSection", GETBYSTR(nix::Section, nix::Section, getSection))
             .reg("hasProperty", GETBYSTR(bool, nix::Section, hasProperty))
             .reg("hasSection", GETBYSTR(bool, nix::Section, hasSection))
@@ -407,7 +408,7 @@ void mexFunction(int            nlhs,
             .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags))
             .reg("referringSources", GETTER(std::vector<nix::Source>, nix::Section, referringSources))
             .reg("referringBlocks", GETTER(std::vector<nix::Block>, nix::Section, referringBlocks));
-        methods->add("Section::properties", nixsection::properties);
+        methods->add("Section::propertiesMap", nixsection::propertiesMap);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);
         methods->add("Section::referringBlockSources", nixsection::referringBlockSources);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -408,7 +408,6 @@ void mexFunction(int            nlhs,
             .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags))
             .reg("referringSources", GETTER(std::vector<nix::Source>, nix::Section, referringSources))
             .reg("referringBlocks", GETTER(std::vector<nix::Block>, nix::Section, referringBlocks));
-        methods->add("Section::propertiesMap", nixsection::propertiesMap);
         methods->add("Section::createProperty", nixsection::createProperty);
         methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);
         methods->add("Section::referringBlockSources", nixsection::referringBlockSources);

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -34,37 +34,6 @@ namespace nixsection {
         return sb.array();
     }
 
-    void propertiesMap(const extractor &input, infusor &output) {
-        nix::Section section = input.entity<nix::Section>(1);
-        std::vector<nix::Property> properties = section.properties();
-
-        const mwSize size = static_cast<mwSize>(properties.size());
-        mxArray *lst = mxCreateCellArray(1, &size);
-
-        for (size_t i = 0; i < properties.size(); i++) {
-
-            nix::Property pr = properties[i];
-            std::vector<nix::Value> values = pr.values();
-
-            mxArray *mx_values = make_mx_array(values);
-
-            struct_builder sb({ 1 }, {
-                "name", "id", "definition", "mapping", "unit", "values"
-            });
-
-            sb.set(pr.name());
-            sb.set(pr.id());
-            sb.set(pr.definition());
-            sb.set(pr.mapping());
-            sb.set(pr.unit());
-            sb.set(mx_values);
-
-            mxSetCell(lst, i, sb.array());
-        }
-
-        output.set(0, lst);
-    }
-
     void createProperty(const extractor &input, infusor &output) {
         nix::Section currObj = input.entity<nix::Section>(1);
 

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -34,7 +34,7 @@ namespace nixsection {
         return sb.array();
     }
 
-    void properties(const extractor &input, infusor &output) {
+    void propertiesMap(const extractor &input, infusor &output) {
         nix::Section section = input.entity<nix::Section>(1);
         std::vector<nix::Property> properties = section.properties();
 

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -15,8 +15,6 @@ namespace nixsection {
 
     mxArray *describe(const nix::Section &section);
 
-    void propertiesMap(const extractor &input, infusor &output);
-
     void createProperty(const extractor &input, infusor &output);
 
     void createPropertyWithValue(const extractor &input, infusor &output);

--- a/src/nixsection.h
+++ b/src/nixsection.h
@@ -15,7 +15,7 @@ namespace nixsection {
 
     mxArray *describe(const nix::Section &section);
 
-    void properties(const extractor &input, infusor &output);
+    void propertiesMap(const extractor &input, infusor &output);
 
     void createProperty(const extractor &input, infusor &output);
 

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -91,14 +91,14 @@ function [] = test_update_values( varargin )
     assert(updateDouble.values{1}.value == 2.2);
     
     %-- test remove values from property
-    delValues = s.open_property(s.allProperties{3}.id);
+    delValues = s.properties{3};
     assert(size(delValues.values, 1) == 4);
     delValues.values = {};
     assert(size(delValues.values, 1) == 0);
     clear delValues;
     
     %-- test add new values to empty value property
-    newValues = s.open_property(s.allProperties{3}.id);
+    newValues = s.properties{3};
     newValues.values = [1,2,3,4,5];
     assert(newValues.values{5}.value == 5);
     newValues.values = {};
@@ -110,7 +110,7 @@ function [] = test_update_values( varargin )
     val2 = newValues.values{2};
     updateNewDouble = s.create_property('doubleProperty2', nix.DataType.Double);
     updateNewDouble.values = {val1, val2};
-    assert(s.open_property(s.allProperties{end}.id).values{2}.value == val2.value);
+    assert(s.properties{end}.values{2}.value == val2.value);
 end
 
 %% Test: Value count
@@ -127,7 +127,7 @@ function [] = test_value_count( varargin )
 
     clear p s f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    pid = f.sections{1}.allProperties{1}.id;
+    pid = f.sections{1}.properties{1}.id;
     assert(f.sections{1}.open_property(pid).value_count() == 1);
 end
 
@@ -144,7 +144,7 @@ function [] = test_values_delete( varargin )
 
     clear p s f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(isempty(f.sections{1}.allProperties{1}.values));
+    assert(isempty(f.sections{1}.properties{1}.values));
 end
 
 %% Test: Compare properties

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -184,19 +184,8 @@ function [] = test_properties( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     trial = f.sections{2}.sections{2}.sections{1};
 
-    assert(~isempty(trial.allProperties));
     assert(~isempty(trial.properties));
-    
-    p1 = trial.allProperties{1};
-    assert(strcmp(p1.name, 'ExperimentalCondition'));
-
-    p1 = trial.properties{1};
-    assert(strcmp(p1.name, 'ExperimentalCondition'));
-
-    disp(f.sections{3}.allProperties);
-    disp(f.sections{3}.properties);
-    
-    assert(isempty(f.sections{3}.allProperties));
+    assert(strcmp(trial.properties{1}.name, 'ExperimentalCondition'));
     assert(isempty(f.sections{3}.properties));
 end
 
@@ -205,11 +194,11 @@ function [] = test_create_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.create_section('mainSection', 'nixSection');
 
-    tmp = s.create_property('newProperty1', nix.DataType.Double);
-    tmp = s.create_property('newProperty2', nix.DataType.Bool);
-    tmp = s.create_property('newProperty3', nix.DataType.String);
-    assert(size(s.allProperties, 1) == 3);
-    assert(strcmp(s.allProperties{1}.name, 'newProperty1'));
+    s.create_property('newProperty1', nix.DataType.Double);
+    s.create_property('newProperty2', nix.DataType.Bool);
+    s.create_property('newProperty3', nix.DataType.String);
+    assert(size(s.properties, 1) == 3);
+    assert(strcmp(s.properties{1}.name, 'newProperty1'));
 end
 
 %% Test: Create property with value
@@ -217,82 +206,77 @@ function [] = test_create_property_with_value( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.create_section('mainSection', 'nixSection');
 
-    tmp = s.create_property_with_value('doubleProperty1', [5, 6, 7, 8]);
-    assert(strcmp(s.allProperties{end}.name, 'doubleProperty1'));
-    assert(s.allProperties{end}.values{1} == 5);
-    assert(size(s.allProperties{end}.values, 2) == 4);
-    assert(s.open_property(s.allProperties{end}.id).values{1}.value == 5);
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 4);
-    assert(strcmpi(tmp.datatype,'double'));
-    
-    tmp = s.create_property_with_value('doubleProperty2', {5, 6, 7, 8});
-    assert(strcmp(s.allProperties{end}.name, 'doubleProperty2'));
-    assert(s.open_property(s.allProperties{end}.id).values{1}.value == 5);
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 4);
-    assert(strcmpi(tmp.datatype,'double'));
+    % test create by array
+    s.create_property_with_value('doubleProperty1', [5, 6, 7, 8]);
+    assert(strcmp(s.properties{end}.name, 'doubleProperty1'));
+    assert(s.properties{end}.values{1}.value == 5);
+    assert(size(s.properties{end}.values, 1) == 4);
+    assert(strcmpi(s.properties{end}.datatype, 'double'));
 
-    tmp = s.create_property_with_value('stringProperty1', ['a', 'string']);
-    assert(strcmp(s.allProperties{end}.name, 'stringProperty1'));
-    assert(strcmp(s.open_property(s.allProperties{end}.id).values{1}.value, 'a'));
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 7);
-    assert(strcmpi(tmp.datatype, 'char'));
-    
-    tmp = s.create_property_with_value('stringProperty2', {'this', 'has', 'strings'});
-    assert(strcmp(s.allProperties{end}.name, 'stringProperty2'));
-    assert(strcmp(s.allProperties{end}.values{1}, 'this'));
-    assert(size(s.allProperties{end}.values, 2) == 3);
-    assert(strcmp(s.open_property(s.allProperties{end}.id).values{1}.value, 'this'));
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
-    assert(strcmpi(tmp.datatype, 'char'));
+    % test create by cell array
+    s.create_property_with_value('doubleProperty2', {5, 6, 7, 8});
+    assert(strcmp(s.properties{end}.name, 'doubleProperty2'));
+    assert(s.properties{end}.values{2}.value == 6);
+    assert(size(s.properties{end}.values, 1) == 4);
+    assert(strcmpi(s.properties{end}.datatype, 'double'));
 
-    tmp = s.create_property_with_value('booleanProperty1', [true, false, true]);
-    assert(strcmp(s.allProperties{end}.name, 'booleanProperty1'));
-    assert(s.allProperties{end}.values{1});
-    assert(~s.allProperties{end}.values{2});
-    assert(size(s.allProperties{end}.values, 2) == 3);
-    assert(s.open_property(s.allProperties{end}.id).values{1}.value);
-    assert(~s.open_property(s.allProperties{end}.id).values{2}.value);
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
-    assert(strcmpi(tmp.datatype, 'logical'));
+    s.create_property_with_value('stringProperty1', ['a', 'string']);
+    assert(strcmp(s.properties{end}.name, 'stringProperty1'));
+    assert(strcmp(s.properties{end}.values{1}.value, 'a'));
+    assert(size(s.properties{end}.values, 1) == 7);
+    assert(strcmpi(s.properties{end}.datatype, 'char'));
 
-    tmp = s.create_property_with_value('booleanProperty2', {true, false, true});
-    assert(strcmp(s.allProperties{end}.name, 'booleanProperty2'));
-    assert(s.open_property(s.allProperties{end}.id).values{1}.value);
-    assert(~s.open_property(s.allProperties{end}.id).values{2}.value);
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
-    assert(strcmpi(tmp.datatype, 'logical'));
+    s.create_property_with_value('stringProperty2', {'this', 'has', 'strings'});
+    assert(strcmp(s.properties{end}.name, 'stringProperty2'));
+    assert(strcmp(s.properties{end}.values{1}.value, 'this'));
+    assert(size(s.properties{end}.values, 1) == 3);
+    assert(strcmpi(s.properties{end}.datatype, 'char'));
+
+    s.create_property_with_value('booleanProperty1', [true, false, true]);
+    assert(strcmp(s.properties{end}.name, 'booleanProperty1'));
+    assert(s.properties{end}.values{1}.value);
+    assert(~s.properties{end}.values{2}.value);
+    assert(size(s.properties{end}.values, 1) == 3);
+    assert(strcmpi(s.properties{end}.datatype, 'logical'));
+
+    s.create_property_with_value('booleanProperty2', {true, false, true});
+    assert(strcmp(s.properties{end}.name, 'booleanProperty2'));
+    assert(s.properties{end}.values{1}.value);
+    assert(~s.properties{end}.values{2}.value);
+    assert(size(s.properties{end}.values, 1) == 3);
+    assert(strcmpi(s.properties{end}.datatype, 'logical'));
+
+    val1 = s.properties{1}.values{1};
+    val2 = s.properties{1}.values{2};
+    s.create_property_with_value('doubleByStrunct1', [val1, val2]);
+    assert(strcmp(s.properties{end}.name, 'doubleByStrunct1'));
+    assert(s.properties{end}.values{1}.value == 5);
+    assert(size(s.properties{end}.values, 1) == 2);
+    assert(strcmpi(s.properties{end}.datatype, 'double'));
     
-    val1 = s.open_property(s.allProperties{1}.id).values{1};
-    val2 = s.open_property(s.allProperties{1}.id).values{2};
-    tmp = s.create_property_with_value('doubleByStrunct1', [val1, val2]);
-    assert(strcmp(s.allProperties{end}.name, 'doubleByStrunct1'));
-    assert(s.open_property(s.allProperties{end}.id).values{1}.value == 5);
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 2);
-    assert(strcmpi(tmp.datatype,'double'));
-    
-    val3 = s.open_property(s.allProperties{1}.id).values{3};
-    tmp = s.create_property_with_value('doubleByStrunct2', {val1, val2, val3});
-    assert(strcmp(s.allProperties{end}.name, 'doubleByStrunct2'));
-    assert(s.open_property(s.allProperties{end}.id).values{3}.value == 7);
-    assert(size(s.open_property(s.allProperties{end}.id).values, 1) == 3);
-    assert(strcmpi(tmp.datatype,'double'));
+    val3 = s.properties{1}.values{3};
+    s.create_property_with_value('doubleByStrunct2', {val1, val2, val3});
+    assert(strcmp(s.properties{end}.name, 'doubleByStrunct2'));
+    assert(s.properties{end}.values{3}.value == 7);
+    assert(size(s.properties{end}.values, 1) == 3);
+    assert(strcmpi(s.properties{end}.datatype, 'double'));
 end
 
 %% Test: Delete property by entity, propertyStruct, ID and name
 function [] = test_delete_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.create_section('mainSection', 'nixSection');
-    tmp = s.create_property('newProperty1', nix.DataType.Double);
-    tmp = s.create_property('newProperty2', nix.DataType.Bool);
-    tmp = s.create_property('newProperty3', nix.DataType.String);
-    tmp = s.create_property('newProperty4', nix.DataType.Double);
+    s.create_property('newProperty1', nix.DataType.Double);
+    s.create_property('newProperty2', nix.DataType.Bool);
+    s.create_property('newProperty3', nix.DataType.String);
+    s.create_property('newProperty4', nix.DataType.Double);
 
     assert(s.delete_property('newProperty4'));
-    assert(s.delete_property(s.allProperties{3}.id));
-    delProp = s.open_property(s.allProperties{2}.id);
+    assert(s.delete_property(s.properties{3}.id));
+    delProp = s.properties{2};
     assert(s.delete_property(delProp));
-    assert(s.delete_property(s.allProperties{1}));
-    
+    assert(s.delete_property(s.properties{1}));
+
     assert(~s.delete_property('I do not exist'));
 end
 
@@ -301,8 +285,8 @@ function [] = test_open_property( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     trial = f.sections{2}.sections{2}.sections{1};
 
-    assert(~isempty(trial.open_property(trial.allProperties{1}.id)));
-    assert(~isempty(trial.open_property(trial.allProperties{1}.name)));
+    assert(~isempty(trial.open_property(trial.properties{1}.id)));
+    assert(~isempty(trial.open_property(trial.properties{1}.name)));
 end
 
 function [] = test_open_property_idx( varargin )

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -183,15 +183,21 @@ function [] = test_properties( varargin )
 %% Test: Properties
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     trial = f.sections{2}.sections{2}.sections{1};
-    
+
     assert(~isempty(trial.allProperties));
+    assert(~isempty(trial.properties));
     
     p1 = trial.allProperties{1};
     assert(strcmp(p1.name, 'ExperimentalCondition'));
-    
+
+    p1 = trial.properties{1};
+    assert(strcmp(p1.name, 'ExperimentalCondition'));
+
     disp(f.sections{3}.allProperties);
+    disp(f.sections{3}.properties);
     
     assert(isempty(f.sections{3}.allProperties));
+    assert(isempty(f.sections{3}.properties));
 end
 
 %% Test: Create property by data type


### PR DESCRIPTION
This PR
- Closes #143.
- Adjusts tests and the `primer.m` script to the changes.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).