### PR TITLE
Add "Retrieve data" functions

### DIFF
--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -111,15 +111,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'MultiTag::openFeatureIdx', idx, @nix.Feature);
         end;
 
-        function data = retrieve_feature_data(obj, pos_index, fea_index)
-            % convert Matlab-like to C-like index
-            assert(pos_index > 0, 'Position index must be positive');
-            assert(fea_index > 0, 'Feature index must be positive');
-            tmp = nix_mx('MultiTag::featureRetrieveData', obj.nix_handle, ...
-                pos_index - 1, fea_index - 1);
+        function data = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
+            tmp = nix_mx('MultiTag::featureRetrieveDataIdx', ...
+                            obj.nix_handle, pos_idx, feat_idx);
             
-            % data must agree with file & dimensions
-            % see mkarray.cc(42)
+            % data must agree with file & dimensions; see mkarray.cc(42)
             data = permute(tmp, length(size(tmp)):-1:1);
         end;
         

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -62,6 +62,13 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'MultiTag::openReferenceIdx', idx, @nix.DataArray);
         end;
 
+        function data = retrieve_data(obj, pos_idx, id_or_name)
+            tmp = nix_mx('MultiTag::retrieveData', obj.nix_handle, pos_idx, id_or_name);
+            
+            % data must agree with file & dimensions see mkarray.cc(42)
+            data = permute(tmp, length(size(tmp)):-1:1);
+        end;
+
         function data = retrieve_data_idx(obj, pos_idx, ref_idx)
             tmp = nix_mx('MultiTag::retrieveDataIdx', obj.nix_handle, pos_idx, ref_idx);
             

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -62,15 +62,10 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'MultiTag::openReferenceIdx', idx, @nix.DataArray);
         end;
 
-        function data = retrieve_data(obj, pos_index, ref_index)
-            % convert Matlab-like to C-like index
-            assert(pos_index > 0, 'Position index must be positive');
-            assert(ref_index > 0, 'Reference index must be positive');
-            tmp = nix_mx('MultiTag::retrieveData', obj.nix_handle, ...
-                pos_index - 1, ref_index - 1);
+        function data = retrieve_data_idx(obj, pos_idx, ref_idx)
+            tmp = nix_mx('MultiTag::retrieveDataIdx', obj.nix_handle, pos_idx, ref_idx);
             
-            % data must agree with file & dimensions
-            % see mkarray.cc(42)
+            % data must agree with file & dimensions see mkarray.cc(42)
             data = permute(tmp, length(size(tmp)):-1:1);
         end;
 

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -118,6 +118,14 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'MultiTag::openFeatureIdx', idx, @nix.Feature);
         end;
 
+        function data = retrieve_feature_data(obj, pos_idx, id_or_name)
+            tmp = nix_mx('MultiTag::featureRetrieveData', ...
+                            obj.nix_handle, pos_idx, id_or_name);
+
+            % data must agree with file & dimensions; see mkarray.cc(42)
+            data = permute(tmp, length(size(tmp)):-1:1);
+        end;
+
         function data = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
             tmp = nix_mx('MultiTag::featureRetrieveDataIdx', ...
                             obj.nix_handle, pos_idx, feat_idx);

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -63,10 +63,8 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'Tag::openReferenceIdx', idx, @nix.DataArray);
         end;
 
-        function data = retrieve_data(obj, index)
-            % convert Matlab-like to C-like index
-            assert(index > 0, 'Subscript indices must be positive');
-            tmp = nix_mx('Tag::retrieveData', obj.nix_handle, index - 1);
+        function data = retrieve_data_idx(obj, idx)
+            tmp = nix_mx('Tag::retrieveDataIdx', obj.nix_handle, idx);
             
             % data must agree with file & dimensions
             % see mkarray.cc(42)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -113,10 +113,8 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'Tag::openFeatureIdx', idx, @nix.Feature);
         end;
 
-        function data = retrieve_feature_data(obj, index)
-            % convert Matlab-like to C-like index
-            assert(index > 0, 'Subscript indices must be positive');
-            tmp = nix_mx('Tag::featureRetrieveData', obj.nix_handle, index - 1);
+        function data = retrieve_feature_data_idx(obj, idx)
+            tmp = nix_mx('Tag::featureRetrieveDataIdx', obj.nix_handle, idx);
             
             % data must agree with file & dimensions
             % see mkarray.cc(42)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -63,6 +63,14 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'Tag::openReferenceIdx', idx, @nix.DataArray);
         end;
 
+        function data = retrieve_data(obj, id_or_name)
+            tmp = nix_mx('Tag::retrieveData', obj.nix_handle, id_or_name);
+
+            % data must agree with file & dimensions
+            % see mkarray.cc(42)
+            data = permute(tmp, length(size(tmp)):-1:1);
+        end;
+
         function data = retrieve_data_idx(obj, idx)
             tmp = nix_mx('Tag::retrieveDataIdx', obj.nix_handle, idx);
             

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -121,6 +121,14 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 'Tag::openFeatureIdx', idx, @nix.Feature);
         end;
 
+        function data = retrieve_feature_data(obj, id_or_name)
+            tmp = nix_mx('Tag::featureRetrieveData', obj.nix_handle, id_or_name);
+
+            % data must agree with file & dimensions
+            % see mkarray.cc(42)
+            data = permute(tmp, length(size(tmp)):-1:1);
+        end
+
         function data = retrieve_feature_data_idx(obj, idx)
             tmp = nix_mx('Tag::featureRetrieveDataIdx', obj.nix_handle, idx);
             

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -364,7 +364,6 @@ void mexFunction(int            nlhs,
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::MultiTag, sourceCount))
             .reg("referenceCount", GETTER(nix::ndsize_t, nix::MultiTag, referenceCount))
             .reg("featureCount", GETTER(nix::ndsize_t, nix::MultiTag, featureCount));
-        methods->add("MultiTag::retrieveData", nixmultitag::retrieveData);
         methods->add("MultiTag::featureRetrieveData", nixmultitag::retrieveFeatureData);
         methods->add("MultiTag::addReference", nixmultitag::addReference);
         methods->add("MultiTag::addReferences", nixmultitag::addReferences);
@@ -379,6 +378,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::sourcesFiltered", nixmultitag::sourcesFiltered);
         methods->add("MultiTag::referencesFiltered", nixmultitag::referencesFiltered);
         methods->add("MultiTag::featuresFiltered", nixmultitag::featuresFiltered);
+        methods->add("MultiTag::retrieveDataIdx", nixmultitag::retrieveDataIdx);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -329,6 +329,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::sourcesFiltered", nixtag::sourcesFiltered);
         methods->add("Tag::referencesFiltered", nixtag::referencesFiltered);
         methods->add("Tag::featuresFiltered", nixtag::featuresFiltered);
+        methods->add("Tag::retrieveData", nixtag::retrieveData);
         methods->add("Tag::retrieveDataIdx", nixtag::retrieveDataIdx);
         methods->add("Tag::featureRetrieveDataIdx", nixtag::retrieveFeatureDataIdx);
 

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -377,6 +377,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::sourcesFiltered", nixmultitag::sourcesFiltered);
         methods->add("MultiTag::referencesFiltered", nixmultitag::referencesFiltered);
         methods->add("MultiTag::featuresFiltered", nixmultitag::featuresFiltered);
+        methods->add("MultiTag::retrieveData", nixmultitag::retrieveData);
         methods->add("MultiTag::retrieveDataIdx", nixmultitag::retrieveDataIdx);
         methods->add("MultiTag::featureRetrieveDataIdx", nixmultitag::retrieveFeatureDataIdx);
 

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -317,7 +317,6 @@ void mexFunction(int            nlhs,
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::Tag, sourceCount))
             .reg("referenceCount", GETTER(nix::ndsize_t, nix::Tag, referenceCount))
             .reg("featureCount", GETTER(nix::ndsize_t, nix::Tag, featureCount));
-        methods->add("Tag::retrieveData", nixtag::retrieveData);
         methods->add("Tag::featureRetrieveData", nixtag::retrieveFeatureData);
         methods->add("Tag::addReference", nixtag::addReference);
         methods->add("Tag::addReferences", nixtag::addReferences);
@@ -331,6 +330,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::sourcesFiltered", nixtag::sourcesFiltered);
         methods->add("Tag::referencesFiltered", nixtag::referencesFiltered);
         methods->add("Tag::featuresFiltered", nixtag::featuresFiltered);
+        methods->add("Tag::retrieveDataIdx", nixtag::retrieveDataIdx);
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .desc(&nixmultitag::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -379,6 +379,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::featuresFiltered", nixmultitag::featuresFiltered);
         methods->add("MultiTag::retrieveData", nixmultitag::retrieveData);
         methods->add("MultiTag::retrieveDataIdx", nixmultitag::retrieveDataIdx);
+        methods->add("MultiTag::featureRetrieveData", nixmultitag::retrieveFeatureData);
         methods->add("MultiTag::featureRetrieveDataIdx", nixmultitag::retrieveFeatureDataIdx);
 
         classdef<nix::Section>("Section", methods)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -364,7 +364,6 @@ void mexFunction(int            nlhs,
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::MultiTag, sourceCount))
             .reg("referenceCount", GETTER(nix::ndsize_t, nix::MultiTag, referenceCount))
             .reg("featureCount", GETTER(nix::ndsize_t, nix::MultiTag, featureCount));
-        methods->add("MultiTag::featureRetrieveData", nixmultitag::retrieveFeatureData);
         methods->add("MultiTag::addReference", nixmultitag::addReference);
         methods->add("MultiTag::addReferences", nixmultitag::addReferences);
         methods->add("MultiTag::addSource", nixmultitag::addSource);
@@ -379,6 +378,7 @@ void mexFunction(int            nlhs,
         methods->add("MultiTag::referencesFiltered", nixmultitag::referencesFiltered);
         methods->add("MultiTag::featuresFiltered", nixmultitag::featuresFiltered);
         methods->add("MultiTag::retrieveDataIdx", nixmultitag::retrieveDataIdx);
+        methods->add("MultiTag::featureRetrieveDataIdx", nixmultitag::retrieveFeatureDataIdx);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -331,6 +331,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::featuresFiltered", nixtag::featuresFiltered);
         methods->add("Tag::retrieveData", nixtag::retrieveData);
         methods->add("Tag::retrieveDataIdx", nixtag::retrieveDataIdx);
+        methods->add("Tag::featureRetrieveData", nixtag::retrieveFeatureData);
         methods->add("Tag::featureRetrieveDataIdx", nixtag::retrieveFeatureDataIdx);
 
         classdef<nix::MultiTag>("MultiTag", methods)

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -317,7 +317,6 @@ void mexFunction(int            nlhs,
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::Tag, sourceCount))
             .reg("referenceCount", GETTER(nix::ndsize_t, nix::Tag, referenceCount))
             .reg("featureCount", GETTER(nix::ndsize_t, nix::Tag, featureCount));
-        methods->add("Tag::featureRetrieveData", nixtag::retrieveFeatureData);
         methods->add("Tag::addReference", nixtag::addReference);
         methods->add("Tag::addReferences", nixtag::addReferences);
         methods->add("Tag::addSource", nixtag::addSource);
@@ -331,6 +330,7 @@ void mexFunction(int            nlhs,
         methods->add("Tag::referencesFiltered", nixtag::referencesFiltered);
         methods->add("Tag::featuresFiltered", nixtag::featuresFiltered);
         methods->add("Tag::retrieveDataIdx", nixtag::retrieveDataIdx);
+        methods->add("Tag::featureRetrieveDataIdx", nixtag::retrieveFeatureDataIdx);
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .desc(&nixmultitag::describe)

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -61,15 +61,6 @@ namespace nixmultitag {
         output.set(0, handle(newFeat));
     }
 
-    void retrieveData(const extractor &input, infusor &output) {
-        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        double p_index = input.num<double>(2);
-        double f_index = input.num<double>(3);
-
-        mxArray *data = make_mx_array_from_ds(currObj.retrieveData(p_index, f_index));
-        output.set(0, data);
-    }
-
     void retrieveFeatureData(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
         double p_index = input.num<double>(2);
@@ -133,6 +124,15 @@ namespace nixmultitag {
             return currObj.features(filter);
         });
         output.set(0, res);
+    }
+
+    void retrieveDataIdx(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        size_t pos_idx = (size_t)input.num<double>(2);
+        size_t ref_idx = (size_t)input.num<double>(3);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveData(pos_idx, ref_idx));
+        output.set(0, data);
     }
 
 } // namespace nixmultitag

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -135,6 +135,15 @@ namespace nixmultitag {
         output.set(0, data);
     }
 
+    void retrieveFeatureData(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        size_t pos_idx = (size_t)input.num<double>(2);
+        std::string name_id = input.str(3);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveFeatureData(pos_idx, name_id));
+        output.set(0, data);
+    }
+
     void retrieveFeatureDataIdx(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
         size_t pos_idx = (size_t)input.num<double>(2);

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -117,6 +117,15 @@ namespace nixmultitag {
         output.set(0, res);
     }
 
+    void retrieveData(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        size_t pos_idx = (size_t)input.num<double>(2);
+        std::string name_id = input.str(3);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveData(pos_idx, name_id));
+        output.set(0, data);
+    }
+
     void retrieveDataIdx(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
         size_t pos_idx = (size_t)input.num<double>(2);

--- a/src/nixmultitag.cc
+++ b/src/nixmultitag.cc
@@ -61,15 +61,6 @@ namespace nixmultitag {
         output.set(0, handle(newFeat));
     }
 
-    void retrieveFeatureData(const extractor &input, infusor &output) {
-        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
-        double p_index = input.num<double>(2);
-        double f_index = input.num<double>(3);
-
-        mxArray *data = make_mx_array_from_ds(currObj.retrieveFeatureData(p_index, f_index));
-        output.set(0, data);
-    }
-
     void addPositions(const extractor &input, infusor &output) {
         nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
         currObj.positions(input.str(2));
@@ -132,6 +123,15 @@ namespace nixmultitag {
         size_t ref_idx = (size_t)input.num<double>(3);
 
         mxArray *data = make_mx_array_from_ds(currObj.retrieveData(pos_idx, ref_idx));
+        output.set(0, data);
+    }
+
+    void retrieveFeatureDataIdx(const extractor &input, infusor &output) {
+        nix::MultiTag currObj = input.entity<nix::MultiTag>(1);
+        size_t pos_idx = (size_t)input.num<double>(2);
+        size_t ref_idx = (size_t)input.num<double>(3);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveFeatureData(pos_idx, ref_idx));
         output.set(0, data);
     }
 

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -45,6 +45,8 @@ namespace nixmultitag {
 
     void retrieveDataIdx(const extractor &input, infusor &output);
 
+    void retrieveFeatureData(const extractor &input, infusor &output);
+
     void retrieveFeatureDataIdx(const extractor &input, infusor &output);
 
 } // namespace nixmultitag

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -41,6 +41,8 @@ namespace nixmultitag {
 
     void featuresFiltered(const extractor &input, infusor &output);
 
+    void retrieveData(const extractor &input, infusor &output);
+
     void retrieveDataIdx(const extractor &input, infusor &output);
 
     void retrieveFeatureDataIdx(const extractor &input, infusor &output);

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -25,8 +25,6 @@ namespace nixmultitag {
 
     void createFeature(const extractor &input, infusor &output);
 
-    void retrieveFeatureData(const extractor &input, infusor &output);
-
     void addPositions(const extractor &input, infusor &output);
 
     void openReferenceIdx(const extractor &input, infusor &output);
@@ -44,6 +42,8 @@ namespace nixmultitag {
     void featuresFiltered(const extractor &input, infusor &output);
 
     void retrieveDataIdx(const extractor &input, infusor &output);
+
+    void retrieveFeatureDataIdx(const extractor &input, infusor &output);
 
 } // namespace nixmultitag
 

--- a/src/nixmultitag.h
+++ b/src/nixmultitag.h
@@ -25,8 +25,6 @@ namespace nixmultitag {
 
     void createFeature(const extractor &input, infusor &output);
 
-    void retrieveData(const extractor &input, infusor &output);
-
     void retrieveFeatureData(const extractor &input, infusor &output);
 
     void addPositions(const extractor &input, infusor &output);
@@ -44,6 +42,8 @@ namespace nixmultitag {
     void referencesFiltered(const extractor &input, infusor &output);
 
     void featuresFiltered(const extractor &input, infusor &output);
+
+    void retrieveDataIdx(const extractor &input, infusor &output);
 
 } // namespace nixmultitag
 

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -130,6 +130,14 @@ namespace nixtag {
         output.set(0, data);
     }
 
+    void retrieveFeatureData(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::string name_id = input.str(2);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveFeatureData(name_id));
+        output.set(0, data);
+    }
+
     void retrieveFeatureDataIdx(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -114,6 +114,14 @@ namespace nixtag {
         output.set(0, res);
     }
 
+    void retrieveData(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        std::string name_id = input.str(2);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveData(name_id));
+        output.set(0, data);
+    }
+
     void retrieveDataIdx(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -63,14 +63,6 @@ namespace nixtag {
         output.set(0, handle(newFeat));
     }
 
-    void retrieveFeatureData(const extractor &input, infusor &output) {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        double index = input.num<double>(2);
-
-        mxArray *data = make_mx_array_from_ds(currObj.retrieveFeatureData(index));
-        output.set(0, data);
-    }
-
     void openReferenceIdx(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);
@@ -127,6 +119,14 @@ namespace nixtag {
         nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);
 
         mxArray *data = make_mx_array_from_ds(currObj.retrieveData(idx));
+        output.set(0, data);
+    }
+
+    void retrieveFeatureDataIdx(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveFeatureData(idx));
         output.set(0, data);
     }
 

--- a/src/nixtag.cc
+++ b/src/nixtag.cc
@@ -63,14 +63,6 @@ namespace nixtag {
         output.set(0, handle(newFeat));
     }
 
-    void retrieveData(const extractor &input, infusor &output) {
-        nix::Tag currObj = input.entity<nix::Tag>(1);
-        double index = input.num<double>(2);
-
-        mxArray *data = make_mx_array_from_ds(currObj.retrieveData(index));
-        output.set(0, data);
-    }
-
     void retrieveFeatureData(const extractor &input, infusor &output) {
         nix::Tag currObj = input.entity<nix::Tag>(1);
         double index = input.num<double>(2);
@@ -128,6 +120,14 @@ namespace nixtag {
             return currObj.features(filter);
         });
         output.set(0, res);
+    }
+
+    void retrieveDataIdx(const extractor &input, infusor &output) {
+        nix::Tag currObj = input.entity<nix::Tag>(1);
+        nix::ndsize_t idx = (nix::ndsize_t)input.num<double>(2);
+
+        mxArray *data = make_mx_array_from_ds(currObj.retrieveData(idx));
+        output.set(0, data);
     }
 
 } // namespace nixtag

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -25,8 +25,6 @@ namespace nixtag {
 
     void createFeature(const extractor &input, infusor &output);
 
-    void retrieveFeatureData(const extractor &input, infusor &output);
-
     void openReferenceIdx(const extractor &input, infusor &output);
 
     void openFeatureIdx(const extractor &input, infusor &output);
@@ -42,6 +40,8 @@ namespace nixtag {
     void featuresFiltered(const extractor &input, infusor &output);
 
     void retrieveDataIdx(const extractor &input, infusor &output);
+
+    void retrieveFeatureDataIdx(const extractor &input, infusor &output);
 
 } // namespace nixtag
 

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -39,6 +39,8 @@ namespace nixtag {
 
     void featuresFiltered(const extractor &input, infusor &output);
 
+    void retrieveData(const extractor &input, infusor &output);
+
     void retrieveDataIdx(const extractor &input, infusor &output);
 
     void retrieveFeatureDataIdx(const extractor &input, infusor &output);

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -43,6 +43,8 @@ namespace nixtag {
 
     void retrieveDataIdx(const extractor &input, infusor &output);
 
+    void retrieveFeatureData(const extractor &input, infusor &output);
+
     void retrieveFeatureDataIdx(const extractor &input, infusor &output);
 
 } // namespace nixtag

--- a/src/nixtag.h
+++ b/src/nixtag.h
@@ -25,8 +25,6 @@ namespace nixtag {
 
     void createFeature(const extractor &input, infusor &output);
 
-    void retrieveData(const extractor &input, infusor &output);
-
     void retrieveFeatureData(const extractor &input, infusor &output);
 
     void openReferenceIdx(const extractor &input, infusor &output);
@@ -42,6 +40,8 @@ namespace nixtag {
     void referencesFiltered(const extractor &input, infusor &output);
 
     void featuresFiltered(const extractor &input, infusor &output);
+
+    void retrieveDataIdx(const extractor &input, infusor &output);
 
 } // namespace nixtag
 

--- a/src/utils/handle.h
+++ b/src/utils/handle.h
@@ -50,31 +50,31 @@ struct entity_to_id<nix::Source> {
 template<>
 struct entity_to_id<nix::Feature> {
     static const bool is_valid = true;
-    static const int value = 5;
+    static const int value = 6;
 };
 
 template<>
 struct entity_to_id<nix::MultiTag> {
     static const bool is_valid = true;
-    static const int value = 6;
+    static const int value = 7;
 };
 
 template<>
 struct entity_to_id<nix::Section> {
     static const bool is_valid = true;
-    static const int value = 7;
+    static const int value = 8;
 };
 
 template<>
 struct entity_to_id<nix::Property> {
     static const bool is_valid = true;
-    static const int value = 8;
+    static const int value = 9;
 };
 
 template<>
 struct entity_to_id<nix::Group> {
     static const bool is_valid = true;
-    static const int value = 9;
+    static const int value = 10;
 };
 
 /*

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -41,7 +41,7 @@ function funcs = TestMultiTag
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
     funcs{end+1} = @test_retrieve_data_idx;
-    funcs{end+1} = @test_retrieve_feature_data;
+    funcs{end+1} = @test_retrieve_feature_data_idx;
     funcs{end+1} = @test_set_units;
     funcs{end+1} = @test_attrs;
     funcs{end+1} = @test_compare;
@@ -704,9 +704,92 @@ function [] = test_retrieve_data_idx( varargin )
 end
 
 %% Test: Retrieve feature data
-function [] = test_retrieve_feature_data( varargin )
-    % TODO
-    disp('Test MultiTag: retrieve feature ... TODO (proper testfile)');
+function [] = test_retrieve_feature_data_idx( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+
+    % create feature data arrays
+    raw_feat1 = [11 12 13 14 15 16 17 18];
+    da_feat1 = b.create_data_array_from_data('feature1', 'nixDataArray', raw_feat1);
+    da_feat1.append_sampled_dimension(1);
+
+    raw_feat2 = [21 22 23 24 25 26 27 28];
+    da_feat2 = b.create_data_array_from_data('feature2', 'nixDataArray', raw_feat2);
+    da_feat2.append_sampled_dimension(1);
+
+    % create referenced data array
+    raw_feat3 = [31 32 33 34 35 36 37 38];
+    da_feat3 = b.create_data_array_from_data('reference', 'nixDataArray', raw_feat3);
+    da_feat3.append_sampled_dimension(1);
+
+    % create position, extents DA and multi tag
+    pos = [0; 3; 5];
+    ext = [1; 1; 3];
+
+    da_pos = b.create_data_array_from_data('positions', 'nixDataArray', pos);
+    da_ext = b.create_data_array_from_data('extents', 'nixDataArray', ext);
+
+    da_pos.append_sampled_dimension(0);
+    da_ext.append_sampled_dimension(0);
+
+    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da_pos);
+    t.set_extents(da_ext);
+
+    % add feature data_arrays
+    t.add_feature(da_feat1, nix.LinkType.Untagged);
+    t.add_feature(da_feat2, nix.LinkType.Tagged);
+    t.add_feature(da_feat3, nix.LinkType.Indexed);
+
+    % test invalid position idx
+    try
+        t.retrieve_feature_data_idx(100, 1);
+    catch ME
+        assert(isempty(strfind(ME.message, 'ounds of positions or extents')), ...
+            'Invalid position index failed');
+    end
+    assert(exist('ME') == 1, 'Invalid position index fail, error not raised');
+    clear ME;
+
+    % test invalid feature idx
+    try
+        t.retrieve_feature_data_idx(0, 100);
+    catch ME
+        assert(~isempty(strfind(ME.message, 'out of bounds')), ...
+            'Invalid reference index failed');
+    end
+    assert(exist('ME') == 1, 'Invalid reference index fail, error not raised');
+    clear ME;
+
+    % test untagged ignores position and returns full data
+    retData = t.retrieve_feature_data_idx(100, 0);
+    assert(isequal(raw_feat1, retData), 'Untagged fail');
+
+    % test tagged properly applies position and extents
+    retData = t.retrieve_feature_data_idx(0, 1);
+    assert(isequal(retData, [21]), 'Tagged pos 1 fail');
+
+    retData = t.retrieve_feature_data_idx(1, 1);
+    assert(isequal(retData, [24]), 'Tagged pos 2 fail');
+
+    retData = t.retrieve_feature_data_idx(2, 1);
+    assert(isequal(retData, [26, 27, 28]), 'Tagged pos 3 fail');
+
+    % test indexed returns first and last index value
+    retData = t.retrieve_feature_data_idx(0, 2);
+    assert(isequal(retData, raw_feat3(1)), 'Indexed first pos fail');
+    
+    retData = t.retrieve_feature_data_idx(7, 2);
+    assert(isequal(retData, raw_feat3(end)), 'Indexed last pos fail');
+    
+    % test indexed fail when accessing position > length of referenced array
+    try
+        t.retrieve_feature_data_idx(size(raw_feat3, 2) + 1, 2);
+    catch ME
+        assert(~isempty(strfind(ME.message, 'than the data stored in the feature')), ...
+            'Indexed out of length fail');
+    end
+    assert(exist('ME') == 1, 'Indexed out of length fail, error not raised');
+    clear ME;
 end
 
 %% Test: nix.MultiTag has feature by ID

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -35,7 +35,7 @@ function funcs = TestTag
     funcs{end+1} = @test_set_metadata;
     funcs{end+1} = @test_open_metadata;
     funcs{end+1} = @test_retrieve_data_idx;
-    funcs{end+1} = @test_retrieve_feature_data;
+    funcs{end+1} = @test_retrieve_feature_data_idx;
     funcs{end+1} = @test_attrs;
     funcs{end+1} = @test_has_feature;
     funcs{end+1} = @test_has_reference;
@@ -548,10 +548,47 @@ function [] = test_retrieve_data_idx( varargin )
     assert(retData(1) == raw(t.position + 1), 'Position check failed');
 end
 
-%% Test: Retrieve feature data
-function [] = test_retrieve_feature_data( varargin )
-    % TODO
-    disp('Test Tag: retrieve feature ... TODO (proper testfile)');
+%% Test: Retrieve feature data by index
+function [] = test_retrieve_feature_data_idx( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.create_block('testBlock', 'nixBlock');
+    raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
+    d.append_sampled_dimension(1);
+    tagStartPos = [3];
+    t = b.create_tag('testTag', 'nixTag', tagStartPos);
+    t.extent = [3];
+    t.add_reference(d);
+
+    rawFeature = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+
+    % test retrieve untagged feature data 
+    df = b.create_data_array_from_data('testUntagged', 'nixDataArray', rawFeature);
+    df.append_sampled_dimension(1);
+    t.add_feature(df, nix.LinkType.Untagged);
+    retData = t.retrieve_feature_data_idx(0);
+    assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
+
+    % test retrieve tagged feature data 
+    df = b.create_data_array_from_data('testTagged', 'nixDataArray', rawFeature);
+    df.append_sampled_dimension(1);
+    t.add_feature(df, nix.LinkType.Tagged);
+    retData = t.retrieve_feature_data_idx(1);
+    assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
+    assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
+
+    % test retrieve indexed feature data
+    df = b.create_data_array_from_data('testIndexed', 'nixDataArray', rawFeature);
+    df.append_sampled_dimension(1);
+    t.add_feature(df, nix.LinkType.Indexed);
+    retData = t.retrieve_feature_data_idx(2);
+    assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
+
+    try
+        t.retrieve_feature_data_idx(12);
+    catch ME
+        assert(~isempty(strfind(ME.message, 'out of bounds')), 'Invalid index check fail');
+    end
 end
 
 %% Test: Read and write nix.Tag attributes


### PR DESCRIPTION
This PR 
- Refactors existing `retrieveData` and `retrieveFeatureData` by index functions for `Tag` and `MultiTag`.
- Adds `retrieveData` and `retrieveFeatureData` by name or id functions for `Tag` and `MultiTag`.
- Refactors all existing tests and adds tests for newly added functions.
- Closes #132.
- Additionally fixes the c++ `entity_to_id` enumeration hickup.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).