### PR TITLE
Refactor and Cleanup, Part I

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -13,85 +13,80 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % namespace reference for nix-mx functions
         alias = 'Block'
     end
-    
+
     methods
         function obj = Block(h)
             obj@nix.NamedEntity(h);
             obj@nix.MetadataMixIn();
-            
+
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'groups', @nix.Group);
             nix.Dynamic.add_dyn_relation(obj, 'dataArrays', @nix.DataArray);
             nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
             nix.Dynamic.add_dyn_relation(obj, 'tags', @nix.Tag);
             nix.Dynamic.add_dyn_relation(obj, 'multiTags', @nix.MultiTag);
-        end;
-        
+        end
+
         % -----------------
         % Group methods
         % -----------------
-        
-        function c = group_count(obj)
-            c = nix_mx('Block::groupCount', obj.nix_handle);
+
+        function r = group_count(obj)
+            r = nix_mx('Block::groupCount', obj.nix_handle);
         end
 
-        function g = create_group(obj, name, nixtype)
-            handle = nix_mx('Block::createGroup', obj.nix_handle, ...
-                name, nixtype);
-            g = nix.Group(handle);
-        end;
-        
-        function hasGroup = has_group(obj, id_or_name)
-            hasGroup = nix_mx('Block::hasGroup', obj.nix_handle, id_or_name);
-        end;
-
-        function retObj = get_group(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::getGroup', id_or_name, @nix.Group);
-        end;
-
-        function retObj = open_group_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::openGroupIdx', idx, @nix.Group);
+        function r = create_group(obj, name, nixtype)
+            h = nix_mx('Block::createGroup', obj.nix_handle, name, nixtype);
+            r = nix.Group(h);
         end
 
-        function delCheck = delete_group(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, ...
-                del, 'nix.Group', 'Block::deleteGroup');
-        end;
-
-        function filtered = filter_groups(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'Block::groupsFiltered', @nix.Group);
+        function r = has_group(obj, id_or_name)
+            r = nix_mx('Block::hasGroup', obj.nix_handle, id_or_name);
         end
-        
+
+        function r = get_group(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'Block::getGroup', id_or_name, @nix.Group);
+        end
+
+        function r = open_group_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Block::openGroupIdx', idx, @nix.Group);
+        end
+
+        function r = delete_group(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Group', 'Block::deleteGroup');
+        end
+
+        function r = filter_groups(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'Block::groupsFiltered', @nix.Group);
+        end
+
         % -----------------
         % DataArray methods
         % -----------------
-        
-        function c = data_array_count(obj)
-            c = nix_mx('Block::dataArrayCount', obj.nix_handle);
+
+        function r = data_array_count(obj)
+            r = nix_mx('Block::dataArrayCount', obj.nix_handle);
         end
 
-        function retObj = data_array(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = data_array(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
                 'Block::openDataArray', id_or_name, @nix.DataArray);
-        end;
+        end
 
-        function retObj = open_data_array_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_data_array_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
                 'Block::openDataArrayIdx', idx, @nix.DataArray);
         end
 
-        function da = create_data_array(obj, name, nixtype, datatype, shape)
+        function r = create_data_array(obj, name, nixtype, datatype, shape)
             %-- Quick fix to enable alias range dimension with
             %-- 1D data arrays created with this function.
             %-- e.g. size([1 2 3]) returns shape [1 3], which would not
             %-- be accepted when trying to add an alias range dimension.
             if(shape(1) == 1)
-                shape(2:size(shape,2));
-            end;
-            
+                shape(2:size(shape, 2));
+            end
+
             errorStruct.identifier = 'Block:unsupportedDataType';
             if(~isa(datatype, 'nix.DataType'))
                 errorStruct.message = 'Please provide a valid nix.DataType';
@@ -100,13 +95,13 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
                 error(errorStruct);
             else
-                handle = nix_mx('Block::createDataArray', obj.nix_handle, ...
+                h = nix_mx('Block::createDataArray', obj.nix_handle, ...
                     name, nixtype, lower(datatype.char), shape);
-                da = nix.DataArray(handle);
-            end;
+                r = nix.DataArray(h);
+            end
         end
-        
-        function da = create_data_array_from_data(obj, name, nixtype, data)
+
+        function r = create_data_array_from_data(obj, name, nixtype, data)
             shape = size(data);
             %-- Quick fix to enable alias range dimension with
             %-- 1D data arrays created with this function.
@@ -114,7 +109,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             %-- be accepted when trying to add an alias range dimension.
             if(shape(1) == 1)
                 shape = size(data, 2);
-            end;
+            end
 
             errorStruct.identifier = 'Block:unsupportedDataType';
             if(ischar(data))
@@ -127,153 +122,142 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             else
                 errorStruct.message = 'DataType of provided data is not supported.';
                 error(errorStruct);
-            end;
+            end
 
-            da = obj.create_data_array(name, nixtype, dtype, shape);
-            da.write_all(data);
+            r = obj.create_data_array(name, nixtype, dtype, shape);
+            r.write_all(data);
         end
 
-        function hasDA = has_data_array(obj, id_or_name)
-            hasDA = nix_mx('Block::hasDataArray', obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = delete_data_array(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, ...
-                del, 'nix.DataArray', 'Block::deleteDataArray');
-        end;
+        function r = has_data_array(obj, id_or_name)
+            r = nix_mx('Block::hasDataArray', obj.nix_handle, id_or_name);
+        end
 
-        function filtered = filter_data_arrays(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = delete_data_array(obj, del)
+            r = nix.Utils.delete_entity(obj, ...
+                del, 'nix.DataArray', 'Block::deleteDataArray');
+        end
+
+        function r = filter_data_arrays(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Block::dataArraysFiltered', @nix.DataArray);
         end
 
         % -----------------
         % Sources methods
         % -----------------
-        
-        function c = source_count(obj)
-            c = nix_mx('Block::sourceCount', obj.nix_handle);
+
+        function r = source_count(obj)
+            r = nix_mx('Block::sourceCount', obj.nix_handle);
         end
 
-        function s = create_source(obj, name, type)
-            s = nix.Source(nix_mx('Block::createSource', ...
-                obj.nix_handle, name, type));
-        end;
-        
-        function hasSource = has_source(obj, id_or_name)
-            hasSource = nix_mx('Block::hasSource', obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = delete_source(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, ...
-                del, 'nix.Source', 'Block::deleteSource');
-        end;
-        
-        function retObj = open_source(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::openSource', id_or_name, @nix.Source);
-        end;
-
-        function retObj = open_source_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::openSourceIdx', idx, @nix.Source);
+        function r = create_source(obj, name, type)
+            r = nix.Source(nix_mx('Block::createSource', obj.nix_handle, name, type));
         end
 
-        function filtered = filter_sources(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'Block::sourcesFiltered', @nix.Source);
+        function r = has_source(obj, id_or_name)
+            r = nix_mx('Block::hasSource', obj.nix_handle, id_or_name);
+        end
+
+        function r = delete_source(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Source', 'Block::deleteSource');
+        end
+
+        function r = open_source(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'Block::openSource', id_or_name, @nix.Source);
+        end
+
+        function r = open_source_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Block::openSourceIdx', idx, @nix.Source);
+        end
+
+        function r = filter_sources(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'Block::sourcesFiltered', @nix.Source);
         end
 
         % maxdepth is an index
-        function sec = find_sources(obj, max_depth)
-            sec = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
+        function r = find_sources(obj, max_depth)
+            r = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
         end
 
         % maxdepth is an index
-        function sec = find_filtered_sources(obj, max_depth, filter, val)
-            sec = nix.Utils.find(obj, ...
+        function r = find_filtered_sources(obj, max_depth, filter, val)
+            r = nix.Utils.find(obj, ...
                 max_depth, filter, val, 'Block::findSources', @nix.Source);
         end
 
         % -----------------
         % Tags methods
         % -----------------
-        
-        function c = tag_count(obj)
-            c = nix_mx('Block::tagCount', obj.nix_handle);
+
+        function r = tag_count(obj)
+            r = nix_mx('Block::tagCount', obj.nix_handle);
         end
 
-        function hasTag = has_tag(obj, id_or_name)
-            hasTag = nix_mx('Block::hasTag', obj.nix_handle, id_or_name);
-        end;
-        
-        function retObj = open_tag(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::openTag', id_or_name, @nix.Tag);
-        end;
-
-        function retObj = open_tag_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::openTagIdx', idx, @nix.Tag);
+        function r = has_tag(obj, id_or_name)
+            r = nix_mx('Block::hasTag', obj.nix_handle, id_or_name);
         end
 
-        function tag = create_tag(obj, name, type, position)
-           th = nix_mx('Block::createTag', obj.nix_handle, ...
-               name, type, position);
-           tag = nix.Tag(th);
-        end;
+        function r = open_tag(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'Block::openTag', id_or_name, @nix.Tag);
+        end
 
-        function delCheck = delete_tag(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, ...
-                del, 'nix.Tag', 'Block::deleteTag');
-        end;
+        function r = open_tag_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Block::openTagIdx', idx, @nix.Tag);
+        end
 
-        function filtered = filter_tags(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'Block::tagsFiltered', @nix.Tag);
+        function r = create_tag(obj, name, type, position)
+           h = nix_mx('Block::createTag', obj.nix_handle, name, type, position);
+           r = nix.Tag(h);
+        end
+
+        function r = delete_tag(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', 'Block::deleteTag');
+        end
+
+        function r = filter_tags(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'Block::tagsFiltered', @nix.Tag);
         end
 
         % -----------------
         % MultiTag methods
         % -----------------
-        
-        function c = multi_tag_count(obj)
-            c = nix_mx('Block::multiTagCount', obj.nix_handle);
+
+        function r = multi_tag_count(obj)
+            r = nix_mx('Block::multiTagCount', obj.nix_handle);
         end
 
-        function hasMTag = has_multi_tag(obj, id_or_name)
-            hasMTag = nix_mx('Block::hasMultiTag', obj.nix_handle, id_or_name);
-        end;
+        function r = has_multi_tag(obj, id_or_name)
+            r = nix_mx('Block::hasMultiTag', obj.nix_handle, id_or_name);
+        end
 
-        function retObj = open_multi_tag(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_multi_tag(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
                 'Block::openMultiTag', id_or_name, @nix.MultiTag);
-        end;
+        end
 
-        function retObj = open_multi_tag_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Block::openMultiTagIdx', idx, @nix.MultiTag);
+        function r = open_multi_tag_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Block::openMultiTagIdx', idx, @nix.MultiTag);
         end
 
         %-- Creating a multitag requires an already existing data array
-        function multitag = create_multi_tag(obj, name, type, add_data_array)
+        function r = create_multi_tag(obj, name, type, add_data_array)
             if(strcmp(class(add_data_array), 'nix.DataArray'))
                 addID = add_data_array.id;
             else
                 addID = add_data_array;
-            end;
+            end
 
-            multitag = nix.MultiTag(nix_mx('Block::createMultiTag', ...
-                obj.nix_handle, name, type, addID));
-        end;
-        
-        function delCheck = delete_multi_tag(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, ...
+            h = nix_mx('Block::createMultiTag', obj.nix_handle, name, type, addID);
+            r = nix.MultiTag(h);
+        end
+
+        function r = delete_multi_tag(obj, del)
+            r = nix.Utils.delete_entity(obj, ...
                 del, 'nix.MultiTag', 'Block::deleteMultiTag');
-        end;
+        end
 
-        function filtered = filter_multi_tags(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = filter_multi_tags(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Block::multiTagsFiltered', @nix.MultiTag);
         end
     end

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -7,7 +7,7 @@
 % LICENSE file in the root of the Project.
 
 classdef Block < nix.NamedEntity & nix.MetadataMixIn
-    %Block nix Block object
+    % Block nix Block object
 
     properties (Hidden)
         % namespace reference for nix-mx functions
@@ -32,32 +32,39 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = group_count(obj)
-            r = nix_mx('Block::groupCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::groupCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = create_group(obj, name, nixtype)
-            h = nix_mx('Block::createGroup', obj.nix_handle, name, nixtype);
+            fname = strcat(obj.alias, '::createGroup');
+            h = nix_mx(fname, obj.nix_handle, name, nixtype);
             r = nix.Group(h);
         end
 
         function r = has_group(obj, id_or_name)
-            r = nix_mx('Block::hasGroup', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasGroup');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = get_group(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'Block::getGroup', id_or_name, @nix.Group);
+            fname = strcat(obj.alias, '::getGroup');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Group);
         end
 
         function r = open_group_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Block::openGroupIdx', idx, @nix.Group);
+            fname = strcat(obj.alias, '::openGroupIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Group);
         end
 
         function r = delete_group(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Group', 'Block::deleteGroup');
+            fname = strcat(obj.alias, '::deleteGroup');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Group', fname);
         end
 
         function r = filter_groups(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'Block::groupsFiltered', @nix.Group);
+            fname = strcat(obj.alias, '::groupsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Group);
         end
 
         % -----------------
@@ -65,17 +72,18 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = data_array_count(obj)
-            r = nix_mx('Block::dataArrayCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::dataArrayCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = data_array(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Block::openDataArray', id_or_name, @nix.DataArray);
+            fname = strcat(obj.alias, '::openDataArray');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
         end
 
         function r = open_data_array_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'Block::openDataArrayIdx', idx, @nix.DataArray);
+            fname = strcat(obj.alias, '::openDataArrayIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
         end
 
         function r = create_data_array(obj, name, nixtype, datatype, shape)
@@ -95,8 +103,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
                 error(errorStruct);
             else
-                h = nix_mx('Block::createDataArray', obj.nix_handle, ...
-                    name, nixtype, lower(datatype.char), shape);
+                fname = strcat(obj.alias, '::createDataArray');
+                h = nix_mx(fname, obj.nix_handle, name, nixtype, lower(datatype.char), shape);
                 r = nix.DataArray(h);
             end
         end
@@ -129,17 +137,18 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_data_array(obj, id_or_name)
-            r = nix_mx('Block::hasDataArray', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasDataArray');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = delete_data_array(obj, del)
-            r = nix.Utils.delete_entity(obj, ...
-                del, 'nix.DataArray', 'Block::deleteDataArray');
+            fname = strcat(obj.alias, '::deleteDataArray');
+            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
         end
 
         function r = filter_data_arrays(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Block::dataArraysFiltered', @nix.DataArray);
+            fname = strcat(obj.alias, '::dataArraysFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
         end
 
         % -----------------
@@ -147,31 +156,38 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = source_count(obj)
-            r = nix_mx('Block::sourceCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::sourceCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = create_source(obj, name, type)
-            r = nix.Source(nix_mx('Block::createSource', obj.nix_handle, name, type));
+            fname = strcat(obj.alias, '::createSource');
+            r = nix.Source(nix_mx(fname, obj.nix_handle, name, type));
         end
 
         function r = has_source(obj, id_or_name)
-            r = nix_mx('Block::hasSource', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasSource');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = delete_source(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Source', 'Block::deleteSource');
+            fname = strcat(obj.alias, '::deleteSource');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Source', fname);
         end
 
         function r = open_source(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'Block::openSource', id_or_name, @nix.Source);
+            fname = strcat(obj.alias, '::openSource');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Source);
         end
 
         function r = open_source_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Block::openSourceIdx', idx, @nix.Source);
+            fname = strcat(obj.alias, '::openSourceIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Source);
         end
 
         function r = filter_sources(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'Block::sourcesFiltered', @nix.Source);
+            fname = strcat(obj.alias, '::sourcesFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Source);
         end
 
         % maxdepth is an index
@@ -181,8 +197,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         % maxdepth is an index
         function r = find_filtered_sources(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, ...
-                max_depth, filter, val, 'Block::findSources', @nix.Source);
+            fname = strcat(obj.alias, '::findSources');
+            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Source);
         end
 
         % -----------------
@@ -190,32 +206,39 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = tag_count(obj)
-            r = nix_mx('Block::tagCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::tagCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = has_tag(obj, id_or_name)
-            r = nix_mx('Block::hasTag', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasTag');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = open_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'Block::openTag', id_or_name, @nix.Tag);
+            fname = strcat(obj.alias, '::openTag');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Tag);
         end
 
         function r = open_tag_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Block::openTagIdx', idx, @nix.Tag);
+            fname = strcat(obj.alias, '::openTagIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Tag);
         end
 
         function r = create_tag(obj, name, type, position)
-           h = nix_mx('Block::createTag', obj.nix_handle, name, type, position);
-           r = nix.Tag(h);
+            fname = strcat(obj.alias, '::createTag');
+            h = nix_mx(fname, obj.nix_handle, name, type, position);
+            r = nix.Tag(h);
         end
 
         function r = delete_tag(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', 'Block::deleteTag');
+            fname = strcat(obj.alias, '::deleteTag');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', fname);
         end
 
         function r = filter_tags(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'Block::tagsFiltered', @nix.Tag);
+            fname = strcat(obj.alias, '::tagsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Tag);
         end
 
         % -----------------
@@ -223,20 +246,23 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = multi_tag_count(obj)
-            r = nix_mx('Block::multiTagCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::multiTagCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = has_multi_tag(obj, id_or_name)
-            r = nix_mx('Block::hasMultiTag', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasMultiTag');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = open_multi_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Block::openMultiTag', id_or_name, @nix.MultiTag);
+            fname = strcat(obj.alias, '::openMultiTag');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.MultiTag);
         end
 
         function r = open_multi_tag_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Block::openMultiTagIdx', idx, @nix.MultiTag);
+            fname = strcat(obj.alias, '::openMultiTagIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.MultiTag);
         end
 
         %-- Creating a multitag requires an already existing data array
@@ -247,18 +273,19 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 addID = add_data_array;
             end
 
-            h = nix_mx('Block::createMultiTag', obj.nix_handle, name, type, addID);
+            fname = strcat(obj.alias, '::createMultiTag');
+            h = nix_mx(fname, obj.nix_handle, name, type, addID);
             r = nix.MultiTag(h);
         end
 
         function r = delete_multi_tag(obj, del)
-            r = nix.Utils.delete_entity(obj, ...
-                del, 'nix.MultiTag', 'Block::deleteMultiTag');
+            fname = strcat(obj.alias, '::deleteMultiTag');
+            r = nix.Utils.delete_entity(obj, del, 'nix.MultiTag', fname);
         end
 
         function r = filter_multi_tags(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Block::multiTagsFiltered', @nix.MultiTag);
+            fname = strcat(obj.alias, '::multiTagsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.MultiTag);
         end
     end
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -38,7 +38,8 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function dimensions = get.dimensions(obj)
             dimensions = {};
-            currList = nix_mx('DataArray::dimensions', obj.nix_handle);
+            fname = strcat(obj.alias, '::dimensions');
+            currList = nix_mx(fname, obj.nix_handle);
             for i = 1:length(currList)
                 switch currList(i).dtype
                     case 'set'
@@ -54,34 +55,34 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = append_set_dimension(obj)
-            func_name = strcat(obj.alias, '::appendSetDimension');
-            h = nix_mx(func_name, obj.nix_handle);
+            fname = strcat(obj.alias, '::appendSetDimension');
+            h = nix_mx(fname, obj.nix_handle);
             r = nix.SetDimension(h);
         end
 
         function r = append_sampled_dimension(obj, interval)
-            func_name = strcat(obj.alias, '::appendSampledDimension');
-            h = nix_mx(func_name, obj.nix_handle, interval);
+            fname = strcat(obj.alias, '::appendSampledDimension');
+            h = nix_mx(fname, obj.nix_handle, interval);
             r = nix.SampledDimension(h);
         end
 
         function r = append_range_dimension(obj, ticks)
-            func_name = strcat(obj.alias, '::appendRangeDimension');
-            h = nix_mx(func_name, obj.nix_handle, ticks);
+            fname = strcat(obj.alias, '::appendRangeDimension');
+            h = nix_mx(fname, obj.nix_handle, ticks);
             r = nix.RangeDimension(h);
         end
 
         function r = append_alias_range_dimension(obj)
-            func_name = strcat(obj.alias, '::appendAliasRangeDimension');
-            h = nix_mx(func_name, obj.nix_handle);
+            fname = strcat(obj.alias, '::appendAliasRangeDimension');
+            h = nix_mx(fname, obj.nix_handle);
             r = nix.RangeDimension(h);
         end
 
         function r = open_dimension_idx(obj, idx)
         % Getting the dimension by index starts with 1
         % instead of 0 compared to all other index functions.
-            func_name = strcat(obj.alias, '::openDimensionIdx');
-            dim = nix_mx(func_name, obj.nix_handle, idx);
+            fname = strcat(obj.alias, '::openDimensionIdx');
+            dim = nix_mx(fname, obj.nix_handle, idx);
             switch(dim.dimension_type)
                 case 'set'
                     r = nix.SetDimension(dim.handle);
@@ -93,12 +94,13 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = delete_dimensions(obj)
-            func_name = strcat(obj.alias, '::deleteDimensions');
-            r = nix_mx(func_name, obj.nix_handle);
+            fname = strcat(obj.alias, '::deleteDimensions');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = dimension_count(obj)
-            r = nix_mx('DataArray::dimensionCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::dimensionCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         % -----------------
@@ -106,10 +108,11 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function r = read_all(obj)
-           data = nix_mx('DataArray::readAll', obj.nix_handle);
+            fname = strcat(obj.alias, '::readAll');
+            data = nix_mx(fname, obj.nix_handle);
 
-           % data must agree with file & dimensions; see mkarray.cc(42)
-           r = permute(data, length(size(data)):-1:1);
+            % data must agree with file & dimensions; see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
         end
 
         %-- TODO add (optional) offset
@@ -138,14 +141,16 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 errorStruct.message = ('Writing char/string DataArrays is not supported as of yet.');
                 error(errorStruct);
             else
+                fname = strcat(obj.alias, '::writeAll');
                 % data must agree with file & dimensions; see mkarray.cc(42)
                 tmp = permute(data, length(size(data)):-1:1);
-                nix_mx('DataArray::writeAll', obj.nix_handle, tmp);
+                nix_mx(fname, obj.nix_handle, tmp);
             end
         end
 
         function r = datatype(obj)
-            r = nix_mx('DataArray::dataType', obj.nix_handle);
+            fname = strcat(obj.alias, '::dataType');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         % Set data extent enables to increase the original size 
@@ -158,7 +163,8 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % shape, existing data that does not fit into the new shape
         % will be lost!
         function [] = set_data_extent(obj, extent)
-            nix_mx('DataArray::setDataExtent', obj.nix_handle, extent);
+            fname = strcat(obj.alias, '::setDataExtent');
+            nix_mx(fname, obj.nix_handle, extent);
             % update changed dataExtent in obj.info
             obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
         end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -110,9 +110,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = read_all(obj)
             fname = strcat(obj.alias, '::readAll');
             data = nix_mx(fname, obj.nix_handle);
-
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         %-- TODO add (optional) offset
@@ -142,9 +140,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 error(errorStruct);
             else
                 fname = strcat(obj.alias, '::writeAll');
-                % data must agree with file & dimensions; see mkarray.cc(42)
-                tmp = permute(data, length(size(data)):-1:1);
-                nix_mx(fname, obj.nix_handle, tmp);
+                nix_mx(fname, obj.nix_handle, nix.Utils.transpose_array(data));
             end
         end
 

--- a/+nix/DataType.m
+++ b/+nix/DataType.m
@@ -23,5 +23,5 @@ classdef DataType
         UInt32;
         UInt64;
     end
-    
+
 end

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -32,7 +32,8 @@ classdef Dynamic
                 end
 
                 if (isempty(val))
-                    nix_mx(strcat(obj.alias, '::setNone', upper(prop(1)), prop(2:end)), obj.nix_handle, 0);
+                    fname = strcat(obj.alias, '::setNone', upper(prop(1)), prop(2:end));
+                    nix_mx(fname, obj.nix_handle, 0);
                 elseif((strcmp(prop, 'units') || strcmp(prop, 'labels')) && (~iscell(val)))
                 %-- BUGFIX: Matlab crashes, if units in Tags and MultiTags
                 %-- or labels of SetDimension are set using anything else than a cell.
@@ -40,7 +41,8 @@ classdef Dynamic
                       'This value only supports cells.'));
                     throwAsCaller(ME);
                 else
-                    nix_mx(strcat(obj.alias, '::set', upper(prop(1)), prop(2:end)), obj.nix_handle, val);
+                    fname = strcat(obj.alias, '::set', upper(prop(1)), prop(2:end));
+                    nix_mx(fname, obj.nix_handle, val);
                 end
                 obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
             end

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -7,7 +7,7 @@
 % LICENSE file in the root of the Project.
 
 classdef Dynamic
-    %Dynamic class (with static methods hehe)
+    % Dynamic class (with static methods hehe)
     % implements methods to dynamically assigns properties 
 
     methods (Static)
@@ -15,7 +15,7 @@ classdef Dynamic
             if nargin < 3
                 mode = 'r'; 
             end
-            
+
             % create dynamic property
             p = addprop(obj, prop);
 
@@ -49,7 +49,7 @@ classdef Dynamic
                 val = obj.info.(prop);
             end
         end
-        
+
         function add_dyn_relation(obj, name, constructor)
             dataAttr = strcat(name, 'Data');
             data = addprop(obj, dataAttr);
@@ -59,19 +59,19 @@ classdef Dynamic
             % adds a proxy property
             rel = addprop(obj, name);
             rel.GetMethod = @get_method;
-            
+
             % same property but returns Map 
             rel_map = addprop(obj, strcat(name, 'Map'));
             rel_map.GetMethod = @get_as_map;
             rel_map.Hidden = true;
-            
+
             function val = get_method(obj)
                 obj.(dataAttr) = nix.Utils.fetchObjList(...
                     strcat(obj.alias, '::', name), obj.nix_handle, ...
                     constructor);
                 val = obj.(dataAttr);
             end
-            
+
             function val = get_as_map(obj)
                 val = containers.Map();
                 props = obj.(name);

--- a/+nix/Entity.m
+++ b/+nix/Entity.m
@@ -7,33 +7,33 @@
 % LICENSE file in the root of the Project.
 
 classdef Entity < dynamicprops
-    %Entity base class for nix entities
+    % Entity base class for nix entities
     %   handles object lifetime
-    
+
     properties (Hidden)
         nix_handle
         info
     end
-    
+
     properties (Abstract, Hidden)
         alias
     end
-    
+
     methods
         function obj = Entity(h)
             obj.nix_handle = h;
-            
+
             % fetch all object attrs
             obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
         end
-        
-        function delete(obj)
+
+        function [] = delete(obj)
             nix_mx('Entity::destroy', obj.nix_handle);
         end
-        
-        function ua = updatedAt(obj)
-            ua = nix_mx('Entity::updatedAt', obj.nix_handle);
-        end;
+
+        function r = updatedAt(obj)
+            r = nix_mx('Entity::updatedAt', obj.nix_handle);
+        end
     end
-    
+
 end

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -7,45 +7,45 @@
 % LICENSE file in the root of the Project.
 
 classdef Feature < nix.Entity
-    %Feature nix Feature object
-    
+    % Feature nix Feature object
+
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'Feature'
     end
-    
+
     properties(Dependent)
         id
         linkType
-    end;
-    
+    end
+
     methods
         function obj = Feature(h)
            obj@nix.Entity(h);
-        end;
+        end
 
-        function id = get.id(obj)
-           id = obj.info.id; 
-        end;
+        function r = get.id(obj)
+           r = obj.info.id; 
+        end
 
-        function linkType = get.linkType(obj)
-            linkType = nix_mx('Feature::getLinkType', obj.nix_handle);
-        end;
+        function r = get.linkType(obj)
+            r = nix_mx('Feature::getLinkType', obj.nix_handle);
+        end
 
         function [] = set.linkType(obj, linkType)
             nix_mx('Feature::setLinkType', obj.nix_handle, linkType);
-        end;
+        end
 
-        function dataArray = open_data(obj)
-           dataArray = nix.DataArray(nix_mx('Feature::openData', obj.nix_handle));
-        end;
-        
+        function r = open_data(obj)
+           r = nix.DataArray(nix_mx('Feature::openData', obj.nix_handle));
+        end
+
         function [] = set_data(obj, setData)
             if(strcmp(class(setData), 'nix.DataArray'))
                 setData = setData.id;
-            end;
+            end
             nix_mx('Feature::setData', obj.nix_handle, setData);
-        end;
-    end;
+        end
+    end
 
 end

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -29,22 +29,27 @@ classdef Feature < nix.Entity
         end
 
         function r = get.linkType(obj)
-            r = nix_mx('Feature::getLinkType', obj.nix_handle);
+            fname = strcat(obj.alias, '::getLinkType');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function [] = set.linkType(obj, linkType)
-            nix_mx('Feature::setLinkType', obj.nix_handle, linkType);
+            fname = strcat(obj.alias, '::setLinkType');
+            nix_mx(fname, obj.nix_handle, linkType);
         end
 
         function r = open_data(obj)
-           r = nix.DataArray(nix_mx('Feature::openData', obj.nix_handle));
+            fname = strcat(obj.alias, '::openData');
+            h = nix_mx(fname, obj.nix_handle);
+            r = nix.DataArray(h);
         end
 
         function [] = set_data(obj, setData)
             if(strcmp(class(setData), 'nix.DataArray'))
                 setData = setData.id;
             end
-            nix_mx('Feature::setData', obj.nix_handle, setData);
+            fname = strcat(obj.alias, '::setData');
+            nix_mx(fname, obj.nix_handle, setData);
         end
     end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -31,15 +31,18 @@ classdef File < nix.Entity
 
         % braindead...
         function r = is_open(obj)
-            r = nix_mx('File::isOpen', obj.nix_handle);
+            fname = strcat(obj.alias, '::isOpen');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = file_mode(obj)
-            r = nix_mx('File::fileMode', obj.nix_handle);
+            fname = strcat(obj.alias, '::fileMode');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = validate(obj)
-            r = nix_mx('File::validate', obj.nix_handle);
+            fname = strcat(obj.alias, '::validate');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         % ----------------
@@ -47,31 +50,39 @@ classdef File < nix.Entity
         % ----------------
 
         function r = create_block(obj, name, type)
-            r = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
+            fname = strcat(obj.alias, '::createBlock');
+            h = nix_mx(fname, obj.nix_handle, name, type);
+            r = nix.Block(h);
         end
 
         function r = block_count(obj)
-            r = nix_mx('File::blockCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::blockCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = has_block(obj, id_or_name)
-            r = nix_mx('File::hasBlock', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasBlock');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = open_block(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'File::openBlock', id_or_name, @nix.Block);
+            fname = strcat(obj.alias, '::openBlock');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Block);
         end
 
         function r = open_block_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'File::openBlockIdx', idx, @nix.Block);
+            fname = strcat(obj.alias, '::openBlockIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Block);
         end
 
         function r = delete_block(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Block', 'File::deleteBlock');
+            fname = strcat(obj.alias, '::deleteBlock');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Block', fname);
         end
 
         function r = filter_blocks(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'File::blocksFiltered', @nix.Block);
+            fname = strcat(obj.alias, '::blocksFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Block);
         end
 
         % ----------------
@@ -79,32 +90,39 @@ classdef File < nix.Entity
         % ----------------
 
         function r = create_section(obj, name, type)
-            r = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
+            fname = strcat(obj.alias, '::createSection');
+            h = nix_mx(fname, obj.nix_handle, name, type);
+            r = nix.Section(h);
         end
 
         function r = section_count(obj)
-            r = nix_mx('File::sectionCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::sectionCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = has_section(obj, id_or_name)
-            r = nix_mx('File::hasSection', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasSection');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = open_section(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'File::openSection', id_or_name, @nix.Section);
+            fname = strcat(obj.alias, '::openSection');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Section);
         end
 
         function r = open_section_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'File::openSectionIdx', idx, @nix.Section);
+            fname = strcat(obj.alias, '::openSectionIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Section);
         end
 
         function r = delete_section(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Section', 'File::deleteSection');
+            fname = strcat(obj.alias, '::deleteSection');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Section', fname);
         end
 
         function r = filter_sections(obj, filter, val)
-            r = nix.Utils.filter(obj, ...
-                filter, val, 'File::sectionsFiltered', @nix.Section);
+            fname = strcat(obj.alias, '::sectionsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Section);
         end
 
         % maxdepth is an index
@@ -114,8 +132,8 @@ classdef File < nix.Entity
 
         % maxdepth is an index
         function r = find_filtered_sections(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, ...
-                max_depth, filter, val, 'File::findSections', @nix.Section);
+            fname = strcat(obj.alias, '::findSections');
+            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Section);
         end
     end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -7,13 +7,13 @@
 % LICENSE file in the root of the Project.
 
 classdef File < nix.Entity
-    %File nix File object
-    
+    % File nix File object
+
     properties(Hidden)
         % namespace reference for nix-mx functions
         alias = 'File'
-    end;
-    
+    end
+
     methods
         function obj = File(path, mode)
             if ~exist('mode', 'var')
@@ -21,7 +21,7 @@ classdef File < nix.Entity
             end
             h = nix_mx('File::open', path, mode); 
             obj@nix.Entity(h);
-            
+
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'blocks', @nix.Block);
             nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
@@ -30,97 +30,91 @@ classdef File < nix.Entity
         end
 
         % braindead...
-        function check = is_open(obj)
-            check = nix_mx('File::isOpen', obj.nix_handle);
+        function r = is_open(obj)
+            r = nix_mx('File::isOpen', obj.nix_handle);
         end
 
-        function mode = file_mode(obj)
-            mode = nix_mx('File::fileMode', obj.nix_handle);
+        function r = file_mode(obj)
+            r = nix_mx('File::fileMode', obj.nix_handle);
         end
 
-        function res = validate(obj)
-            res = nix_mx('File::validate', obj.nix_handle);
+        function r = validate(obj)
+            r = nix_mx('File::validate', obj.nix_handle);
         end
 
         % ----------------
         % Block methods
         % ----------------
 
-        function newBlock = create_block(obj, name, type)
-            newBlock = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
-        end;
-
-        function c = block_count(obj)
-            c = nix_mx('File::blockCount', obj.nix_handle);
+        function r = create_block(obj, name, type)
+            r = nix.Block(nix_mx('File::createBlock', obj.nix_handle, name, type));
         end
 
-        function hasBlock = has_block(obj, id_or_name)
-            hasBlock = nix_mx('File::hasBlock', obj.nix_handle, id_or_name);
-        end;
-
-        function retObj = open_block(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'File::openBlock', id_or_name, @nix.Block);
+        function r = block_count(obj)
+            r = nix_mx('File::blockCount', obj.nix_handle);
         end
 
-        function retObj = open_block_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'File::openBlockIdx', idx, @nix.Block);
+        function r = has_block(obj, id_or_name)
+            r = nix_mx('File::hasBlock', obj.nix_handle, id_or_name);
         end
 
-        function delCheck = delete_block(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, ...
-                del, 'nix.Block', 'File::deleteBlock');
-        end;
+        function r = open_block(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'File::openBlock', id_or_name, @nix.Block);
+        end
 
-        function filtered = filter_blocks(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'File::blocksFiltered', @nix.Block);
+        function r = open_block_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'File::openBlockIdx', idx, @nix.Block);
+        end
+
+        function r = delete_block(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Block', 'File::deleteBlock');
+        end
+
+        function r = filter_blocks(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'File::blocksFiltered', @nix.Block);
         end
 
         % ----------------
         % Section methods
         % ----------------
 
-        function newSec = create_section(obj, name, type)
-            newSec = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
-        end;
-
-        function c = section_count(obj)
-            c = nix_mx('File::sectionCount', obj.nix_handle);
+        function r = create_section(obj, name, type)
+            r = nix.Section(nix_mx('File::createSection', obj.nix_handle, name, type));
         end
 
-        function hasSec = has_section(obj, id_or_name)
-            hasSec = nix_mx('File::hasSection', obj.nix_handle, id_or_name);
-        end;
-
-        function retObj = open_section(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'File::openSection', id_or_name, @nix.Section);
+        function r = section_count(obj)
+            r = nix_mx('File::sectionCount', obj.nix_handle);
         end
 
-        function retObj = open_section_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'File::openSectionIdx', idx, @nix.Section);
+        function r = has_section(obj, id_or_name)
+            r = nix_mx('File::hasSection', obj.nix_handle, id_or_name);
         end
 
-        function delCheck = delete_section(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, 'nix.Section', 'File::deleteSection');
+        function r = open_section(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'File::openSection', id_or_name, @nix.Section);
         end
 
-        function filtered = filter_sections(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'File::sectionsFiltered', @nix.Section);
+        function r = open_section_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'File::openSectionIdx', idx, @nix.Section);
         end
-        
+
+        function r = delete_section(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Section', 'File::deleteSection');
+        end
+
+        function r = filter_sections(obj, filter, val)
+            r = nix.Utils.filter(obj, ...
+                filter, val, 'File::sectionsFiltered', @nix.Section);
+        end
+
         % maxdepth is an index
-        function sec = find_sections(obj, max_depth)
-            sec = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
+        function r = find_sections(obj, max_depth)
+            r = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
         end
-        
+
         % maxdepth is an index
-        function sec = find_filtered_sections(obj, max_depth, filter, val)
-            sec = nix.Utils.find(obj, ...
+        function r = find_filtered_sections(obj, max_depth, filter, val)
+            r = nix.Utils.find(obj, ...
                 max_depth, filter, val, 'File::findSections', @nix.Section);
         end
     end

--- a/+nix/FileMode.m
+++ b/+nix/FileMode.m
@@ -7,12 +7,12 @@
 % LICENSE file in the root of the Project.
 
 classdef FileMode
-    %FILEMODE nix file open modes
-    
+    % FILEMODE nix file open modes
+
     properties (Constant)
         ReadOnly = uint8(0)
         ReadWrite = uint8(1)
         Overwrite = uint8(2)
     end
-    
+
 end

--- a/+nix/Filter.m
+++ b/+nix/Filter.m
@@ -1,5 +1,5 @@
 classdef Filter < uint8
-    %FILTER available nix custom filters
+    % FILTER available nix custom filters
 
     enumeration
         accept_all (0); % requires an empty value
@@ -10,5 +10,5 @@ classdef Filter < uint8
         metadata (5); % filters by id
         source (6); % filters by name or id
     end
-    
+
 end

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -7,7 +7,7 @@
 % LICENSE file in the root of the Project.
 
 classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    %Group nix Group object
+    % Group nix Group object
 
     properties (Hidden)
         % namespace reference for nix-mx functions
@@ -24,48 +24,47 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             nix.Dynamic.add_dyn_relation(obj, 'dataArrays', @nix.DataArray);
             nix.Dynamic.add_dyn_relation(obj, 'tags', @nix.Tag);
             nix.Dynamic.add_dyn_relation(obj, 'multiTags', @nix.MultiTag);
-        end;
+        end
 
         % -----------------
         % DataArray methods
         % -----------------
 
-        function c = data_array_count(obj)
-            c = nix_mx('Group::dataArrayCount', obj.nix_handle);
+        function r = data_array_count(obj)
+            r = nix_mx('Group::dataArrayCount', obj.nix_handle);
         end
 
-        function hasDataArray = has_data_array(obj, id_or_name)
-            hasDataArray = nix_mx('Group::hasDataArray', ...
-                obj.nix_handle, id_or_name);
-        end;
+        function r = has_data_array(obj, id_or_name)
+            r = nix_mx('Group::hasDataArray', obj.nix_handle, id_or_name);
+        end
 
-        function retObj = get_data_array(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = get_data_array(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
                 'Group::getDataArray', id_or_name, @nix.DataArray);
-        end;
+        end
 
-        function retObj = open_data_array_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_data_array_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
                 'Group::openDataArrayIdx', idx, @nix.DataArray);
         end
 
         function [] = add_data_array(obj, add_this)
             nix.Utils.add_entity(obj, add_this, ...
                 'nix.DataArray', 'Group::addDataArray');
-        end;
+        end
 
         function [] = add_data_arrays(obj, add_cell_array)
             nix.Utils.add_entity_array(obj, add_cell_array, ...
                 'nix.DataArray', strcat(obj.alias, '::addDataArrays'));
         end
 
-        function delCheck = remove_data_array(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
+        function r = remove_data_array(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
                 'nix.DataArray', 'Group::removeDataArray');
-        end;
+        end
 
-        function filtered = filter_data_arrays(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = filter_data_arrays(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Group::dataArraysFiltered', @nix.DataArray);
         end
 
@@ -74,85 +73,78 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = add_tag(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, ...
-                'nix.Tag', 'Group::addTag');
-        end;
+            nix.Utils.add_entity(obj, add_this, 'nix.Tag', 'Group::addTag');
+        end
 
         function [] = add_tags(obj, add_cell_array)
             nix.Utils.add_entity_array(obj, add_cell_array, ...
                 'nix.Tag', strcat(obj.alias, '::addTags'));
         end
 
-        function hasTag = has_tag(obj, id_or_name)
-            hasTag = nix_mx('Group::hasTag', obj.nix_handle, id_or_name);
-        end;
-
-        function retObj = get_tag(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Group::getTag', id_or_name, @nix.Tag);
-        end;
-
-        function retObj = open_tag_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Group::openTagIdx', idx, @nix.Tag);
+        function r = has_tag(obj, id_or_name)
+            r = nix_mx('Group::hasTag', obj.nix_handle, id_or_name);
         end
 
-        function delCheck = remove_tag(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
-                'nix.Tag', 'Group::removeTag');
-        end;
-
-        function c = tag_count(obj)
-            c = nix_mx('Group::tagCount', obj.nix_handle);
+        function r = get_tag(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'Group::getTag', id_or_name, @nix.Tag);
         end
 
-        function filtered = filter_tags(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'Group::tagsFiltered', @nix.Tag);
+        function r = open_tag_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Group::openTagIdx', idx, @nix.Tag);
+        end
+
+        function r = remove_tag(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', 'Group::removeTag');
+        end
+
+        function r = tag_count(obj)
+            r = nix_mx('Group::tagCount', obj.nix_handle);
+        end
+
+        function r = filter_tags(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'Group::tagsFiltered', @nix.Tag);
         end
 
         % -----------------
         % MultiTag methods
         % -----------------
-        
+
         function [] = add_multi_tag(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, ...
-                'nix.MultiTag', 'Group::addMultiTag');
-        end;
+            nix.Utils.add_entity(obj, add_this, 'nix.MultiTag', 'Group::addMultiTag');
+        end
 
         function [] = add_multi_tags(obj, add_cell_array)
             nix.Utils.add_entity_array(obj, add_cell_array, ...
                 'nix.MultiTag', strcat(obj.alias, '::addMultiTags'));
         end
 
-        function hasMTag = has_multi_tag(obj, id_or_name)
-            hasMTag = nix_mx('Group::hasMultiTag', ...
-                obj.nix_handle, id_or_name);
-        end;
+        function r = has_multi_tag(obj, id_or_name)
+            r = nix_mx('Group::hasMultiTag', obj.nix_handle, id_or_name);
+        end
 
-        function retObj = get_multi_tag(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = get_multi_tag(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
                 'Group::getMultiTag', id_or_name, @nix.MultiTag);
-        end;
+        end
 
-        function retObj = open_multi_tag_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_multi_tag_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
                 'Group::openMultiTagIdx', idx, @nix.MultiTag);
         end
 
-        function delCheck = remove_multi_tag(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
+        function r = remove_multi_tag(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
                 'nix.MultiTag', 'Group::removeMultiTag');
         end
 
-        function c = multi_tag_count(obj)
-            c = nix_mx('Group::multiTagCount', obj.nix_handle);
+        function r = multi_tag_count(obj)
+            r = nix_mx('Group::multiTagCount', obj.nix_handle);
         end
 
-        function filtered = filter_multi_tags(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = filter_multi_tags(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Group::multiTagsFiltered', @nix.MultiTag);
         end
-    end;
+    end
 
 end

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -31,41 +31,43 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function r = data_array_count(obj)
-            r = nix_mx('Group::dataArrayCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::dataArrayCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = has_data_array(obj, id_or_name)
-            r = nix_mx('Group::hasDataArray', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasDataArray');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = get_data_array(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Group::getDataArray', id_or_name, @nix.DataArray);
+            fname = strcat(obj.alias, '::getDataArray');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
         end
 
         function r = open_data_array_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'Group::openDataArrayIdx', idx, @nix.DataArray);
+            fname = strcat(obj.alias, '::openDataArrayIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
         end
 
         function [] = add_data_array(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, ...
-                'nix.DataArray', 'Group::addDataArray');
+            fname = strcat(obj.alias, '::addDataArray');
+            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
         end
 
         function [] = add_data_arrays(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, add_cell_array, ...
-                'nix.DataArray', strcat(obj.alias, '::addDataArrays'));
+            fname = strcat(obj.alias, '::addDataArrays');
+            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.DataArray', fname);
         end
 
         function r = remove_data_array(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.DataArray', 'Group::removeDataArray');
+            fname = strcat(obj.alias, '::removeDataArray');
+            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
         end
 
         function r = filter_data_arrays(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Group::dataArraysFiltered', @nix.DataArray);
+            fname = strcat(obj.alias, '::dataArraysFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
         end
 
         % -----------------
@@ -73,36 +75,43 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = add_tag(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, 'nix.Tag', 'Group::addTag');
+            fname = strcat(obj.alias, '::addTag');
+            nix.Utils.add_entity(obj, add_this, 'nix.Tag', fname);
         end
 
         function [] = add_tags(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, add_cell_array, ...
-                'nix.Tag', strcat(obj.alias, '::addTags'));
+            fname = strcat(obj.alias, '::addTags');
+            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.Tag', fname);
         end
 
         function r = has_tag(obj, id_or_name)
-            r = nix_mx('Group::hasTag', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasTag');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = get_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'Group::getTag', id_or_name, @nix.Tag);
+            fname = strcat(obj.alias, '::getTag');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Tag);
         end
 
         function r = open_tag_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Group::openTagIdx', idx, @nix.Tag);
+            fname = strcat(obj.alias, '::openTagIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Tag);
         end
 
         function r = remove_tag(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', 'Group::removeTag');
+            fname = strcat(obj.alias, '::removeTag');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', fname);
         end
 
         function r = tag_count(obj)
-            r = nix_mx('Group::tagCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::tagCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_tags(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'Group::tagsFiltered', @nix.Tag);
+            fname = strcat(obj.alias, '::tagsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Tag);
         end
 
         % -----------------
@@ -110,40 +119,43 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = add_multi_tag(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, 'nix.MultiTag', 'Group::addMultiTag');
+            fname = strcat(obj.alias, '::addMultiTag');
+            nix.Utils.add_entity(obj, add_this, 'nix.MultiTag', fname);
         end
 
         function [] = add_multi_tags(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, add_cell_array, ...
-                'nix.MultiTag', strcat(obj.alias, '::addMultiTags'));
+            fname = strcat(obj.alias, '::addMultiTags');
+            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.MultiTag', fname);
         end
 
         function r = has_multi_tag(obj, id_or_name)
-            r = nix_mx('Group::hasMultiTag', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasMultiTag');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = get_multi_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Group::getMultiTag', id_or_name, @nix.MultiTag);
+            fname = strcat(obj.alias, '::getMultiTag');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.MultiTag);
         end
 
         function r = open_multi_tag_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'Group::openMultiTagIdx', idx, @nix.MultiTag);
+            fname = strcat(obj.alias, '::openMultiTagIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.MultiTag);
         end
 
         function r = remove_multi_tag(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.MultiTag', 'Group::removeMultiTag');
+            fname = strcat(obj.alias, '::removeMultiTag');
+            r = nix.Utils.delete_entity(obj, del, 'nix.MultiTag', fname);
         end
 
         function r = multi_tag_count(obj)
-            r = nix_mx('Group::multiTagCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::multiTagCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_multi_tags(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Group::multiTagsFiltered', @nix.MultiTag);
+            fname = strcat(obj.alias, '::multiTagsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.MultiTag);
         end
     end
 

--- a/+nix/LinkType.m
+++ b/+nix/LinkType.m
@@ -7,7 +7,7 @@
 % LICENSE file in the root of the Project.
 
 classdef LinkType
-    %LINKTYPE nix link types
+    % LINKTYPE nix link types
 
     properties (Constant)
         Tagged = uint8(0)

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -18,18 +18,17 @@ classdef MetadataMixIn < handle
 
     methods
         function r = open_metadata(obj)
-            r = nix.Utils.fetchObj(...
-                strcat(obj.alias, '::openMetadataSection'), ...
-                obj.nix_handle, @nix.Section);
+            fname = strcat(obj.alias, '::openMetadataSection');
+            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Section);
         end
 
         function [] = set_metadata(obj, val)
             if (isempty(val))
-                nix_mx(strcat(obj.alias, '::setNoneMetadata'), ...
-                    obj.nix_handle, val);
+                fname = strcat(obj.alias, '::setNoneMetadata');
+                nix_mx(fname, obj.nix_handle, val);
             else
-                nix.Utils.add_entity(obj, val, 'nix.Section', ...
-                    strcat(obj.alias, '::setMetadata'));
+                fname = strcat(obj.alias, '::setMetadata');
+                nix.Utils.add_entity(obj, val, 'nix.Section', fname);
             end
         end
     end

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -11,27 +11,27 @@ classdef MetadataMixIn < handle
     % mixin class for nix entities with metadata
     % depends on 
     % - nix.Entity
-    
+
     properties (Abstract, Hidden)
         alias
     end
-    
+
     methods
-        function metadata = open_metadata(obj)
-            metadata = nix.Utils.fetchObj(...
+        function r = open_metadata(obj)
+            r = nix.Utils.fetchObj(...
                 strcat(obj.alias, '::openMetadataSection'), ...
                 obj.nix_handle, @nix.Section);
-        end;
+        end
 
-        function set_metadata(obj, val)
+        function [] = set_metadata(obj, val)
             if (isempty(val))
                 nix_mx(strcat(obj.alias, '::setNoneMetadata'), ...
                     obj.nix_handle, val);
             else
                 nix.Utils.add_entity(obj, val, 'nix.Section', ...
                     strcat(obj.alias, '::setMetadata'));
-            end;
-        end;
-    end;
-    
+            end
+        end
+    end
+
 end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -65,17 +65,13 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = retrieve_data(obj, pos_idx, id_or_name)
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
-
-            % data must agree with file & dimensions see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = retrieve_data_idx(obj, pos_idx, ref_idx)
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, pos_idx, ref_idx);
-
-            % data must agree with file & dimensions see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = reference_count(obj)
@@ -125,17 +121,13 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = retrieve_feature_data(obj, pos_idx, id_or_name)
             fname = strcat(obj.alias, '::featureRetrieveData');
             data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
-
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, pos_idx, feat_idx);
-            
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = feature_count(obj)

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -151,11 +151,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = open_positions(obj)
             fname = strcat(obj.alias, '::openPositions');
-            h = nix_mx(fname, obj.nix_handle);
-            r = {};
-            if h ~= 0
-                r = nix.DataArray(h);
-            end
+            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.DataArray);
         end
 
         function [] = add_positions(obj, add_this)
@@ -175,11 +171,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = open_extents(obj)
             fname = strcat(obj.alias, '::openExtents');
-            h = nix_mx(fname, obj.nix_handle);
-            r = {};
-            if h ~= 0
-                r = nix.DataArray(h);
-            end
+            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.DataArray);
         end
 
         function [] = set_extents(obj, add_this)

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -7,8 +7,8 @@
 % LICENSE file in the root of the Project.
 
 classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    %MultiTag nix MultiTag object
-    
+    % MultiTag nix MultiTag object
+
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'MultiTag'
@@ -19,15 +19,15 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj@nix.NamedEntity(h);
             obj@nix.MetadataMixIn();
             obj@nix.SourcesMixIn();
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'units', 'rw');
-            
+
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'references', @nix.DataArray);
             nix.Dynamic.add_dyn_relation(obj, 'features', @nix.Feature);
-        end;
-        
+        end
+
         % ------------------
         % References methods
         % ------------------
@@ -35,53 +35,52 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function [] = add_reference(obj, add_this)
             nix.Utils.add_entity(obj, add_this, ...
                 'nix.DataArray', 'MultiTag::addReference');
-        end;
+        end
 
         function [] = add_references(obj, add_cell_array)
             nix.Utils.add_entity_array(obj, add_cell_array, ...
                 'nix.DataArray', strcat(obj.alias, '::addReferences'));
         end
 
-        function hasRef = has_reference(obj, id_or_name)
-            hasRef = nix_mx('MultiTag::hasReference', ...
-                obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = remove_reference(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
-                'nix.DataArray', 'MultiTag::removeReference');
-        end;
-
-        function retObj = open_reference(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'MultiTag::openReferences', id_or_name, @nix.DataArray);
-        end;
-
-        function retObj = open_reference_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'MultiTag::openReferenceIdx', idx, @nix.DataArray);
-        end;
-
-        function data = retrieve_data(obj, pos_idx, id_or_name)
-            tmp = nix_mx('MultiTag::retrieveData', obj.nix_handle, pos_idx, id_or_name);
-            
-            % data must agree with file & dimensions see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
-        end;
-
-        function data = retrieve_data_idx(obj, pos_idx, ref_idx)
-            tmp = nix_mx('MultiTag::retrieveDataIdx', obj.nix_handle, pos_idx, ref_idx);
-            
-            % data must agree with file & dimensions see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
-        end;
-
-        function c = reference_count(obj)
-            c = nix_mx('MultiTag::referenceCount', obj.nix_handle);
+        function r = has_reference(obj, id_or_name)
+            r = nix_mx('MultiTag::hasReference', obj.nix_handle, id_or_name);
         end
 
-        function filtered = filter_references(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = remove_reference(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
+                'nix.DataArray', 'MultiTag::removeReference');
+        end
+
+        function r = open_reference(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
+                'MultiTag::openReferences', id_or_name, @nix.DataArray);
+        end
+
+        function r = open_reference_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
+                'MultiTag::openReferenceIdx', idx, @nix.DataArray);
+        end
+
+        function r = retrieve_data(obj, pos_idx, id_or_name)
+            data = nix_mx('MultiTag::retrieveData', obj.nix_handle, pos_idx, id_or_name);
+            
+            % data must agree with file & dimensions see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
+
+        function r = retrieve_data_idx(obj, pos_idx, ref_idx)
+            data = nix_mx('MultiTag::retrieveDataIdx', obj.nix_handle, pos_idx, ref_idx);
+            
+            % data must agree with file & dimensions see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
+
+        function r = reference_count(obj)
+            r = nix_mx('MultiTag::referenceCount', obj.nix_handle);
+        end
+
+        function r = filter_references(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'MultiTag::referencesFiltered', @nix.DataArray);
         end
 
@@ -89,57 +88,57 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Features methods
         % ------------------
 
-        function retObj = add_feature(obj, add_this, link_type)
+        function r = add_feature(obj, add_this, link_type)
             if(strcmp(class(add_this), 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;
-            end;
-            retObj = nix.Feature(nix_mx('MultiTag::createFeature', ...
+            end
+            r = nix.Feature(nix_mx('MultiTag::createFeature', ...
                 obj.nix_handle, addID, link_type));
-        end;
+        end
 
-        function hasFeature = has_feature(obj, id_or_name)
-            hasFeature = nix_mx('MultiTag::hasFeature', obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = remove_feature(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
+        function r = has_feature(obj, id_or_name)
+            r = nix_mx('MultiTag::hasFeature', obj.nix_handle, id_or_name);
+        end
+
+        function r = remove_feature(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
                 'nix.Feature', 'MultiTag::deleteFeature');
-        end;
+        end
 
-        function retObj = open_feature(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_feature(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
                 'MultiTag::openFeature', id_or_name, @nix.Feature);
-        end;
+        end
 
-        function retObj = open_feature_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_feature_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
                 'MultiTag::openFeatureIdx', idx, @nix.Feature);
-        end;
+        end
 
-        function data = retrieve_feature_data(obj, pos_idx, id_or_name)
-            tmp = nix_mx('MultiTag::featureRetrieveData', ...
+        function r = retrieve_feature_data(obj, pos_idx, id_or_name)
+            data = nix_mx('MultiTag::featureRetrieveData', ...
                             obj.nix_handle, pos_idx, id_or_name);
 
             % data must agree with file & dimensions; see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
-        end;
+            r = permute(data, length(size(data)):-1:1);
+        end
 
-        function data = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
-            tmp = nix_mx('MultiTag::featureRetrieveDataIdx', ...
+        function r = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
+            data = nix_mx('MultiTag::featureRetrieveDataIdx', ...
                             obj.nix_handle, pos_idx, feat_idx);
             
             % data must agree with file & dimensions; see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
-        end;
-        
-        function c = feature_count(obj)
-            c = nix_mx('MultiTag::featureCount', obj.nix_handle);
+            r = permute(data, length(size(data)):-1:1);
         end
 
-        function filtered = filter_features(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = feature_count(obj)
+            r = nix_mx('MultiTag::featureCount', obj.nix_handle);
+        end
+
+        function r = filter_features(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'MultiTag::featuresFiltered', @nix.Feature);
         end
 
@@ -147,38 +146,39 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Positions methods
         % ------------------
 
-        function hasPositions = has_positions(obj)
-            hasPositions = nix_mx('MultiTag::hasPositions', obj.nix_handle);
-        end;
-        
-        function retObj = open_positions(obj)
-            handle = nix_mx('MultiTag::openPositions', obj.nix_handle);
-            retObj = {};
-            if handle ~= 0
-                retObj = nix.DataArray(handle);
-            end;
-        end;
+        function r = has_positions(obj)
+            r = nix_mx('MultiTag::hasPositions', obj.nix_handle);
+        end
+
+        function r = open_positions(obj)
+            h = nix_mx('MultiTag::openPositions', obj.nix_handle);
+            r = {};
+            if h ~= 0
+                r = nix.DataArray(h);
+            end
+        end
 
         function [] = add_positions(obj, add_this)
             if(strcmp(class(add_this), 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;
-            end;
-            nix_mx('MultiTag::addPositions', obj.nix_handle, addID);
-        end;
+            end
+
+            nix_mx('MultiTag::addPositions', obj.nix_handle, addID)
+        end
 
         % ------------------
         % Extents methods
         % ------------------
 
-        function retObj = open_extents(obj)
-            handle = nix_mx('MultiTag::openExtents', obj.nix_handle);
-            retObj = {};
-            if handle ~= 0
-                retObj = nix.DataArray(handle);
-            end;
-        end;
+        function r = open_extents(obj)
+            h = nix_mx('MultiTag::openExtents', obj.nix_handle);
+            r = {};
+            if h ~= 0
+                r = nix.DataArray(h);
+            end
+        end
 
         function [] = set_extents(obj, add_this)
             if(isempty(add_this))
@@ -188,10 +188,10 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                     addID = add_this.id;
                 else
                     addID = add_this;
-                end;
+                end
                 nix_mx('MultiTag::setExtents', obj.nix_handle, addID);
-            end;
-        end;
+            end
+        end
+    end
 
-    end;
 end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -94,8 +94,14 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             else
                 addID = add_this;
             end
+
             fname = strcat(obj.alias, '::createFeature');
-            r = nix.Feature(nix_mx(fname, obj.nix_handle, addID, link_type));
+            h = nix_mx(fname, obj.nix_handle, addID, link_type);
+
+            r = {};
+            if (h ~= 0)
+                r = nix.Feature(h);
+            end
         end
 
         function r = has_feature(obj, id_or_name)
@@ -155,14 +161,8 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function [] = add_positions(obj, add_this)
-            if(strcmp(class(add_this), 'nix.DataArray'))
-                addID = add_this.id;
-            else
-                addID = add_this;
-            end
-
             fname = strcat(obj.alias, '::addPositions');
-            nix_mx(fname, obj.nix_handle, addID)
+            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
         end
 
         % ------------------
@@ -179,13 +179,8 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 fname = strcat(obj.alias, '::setNoneExtents');
                 nix_mx(fname, obj.nix_handle, 0);
             else
-                if(strcmp(class(add_this), 'nix.DataArray'))
-                    addID = add_this.id;
-                else
-                    addID = add_this;
-                end
                 fname = strcat(obj.alias, '::setExtents');
-                nix_mx(fname, obj.nix_handle, addID);
+                nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
             end
         end
     end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -33,55 +33,59 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function [] = add_reference(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, ...
-                'nix.DataArray', 'MultiTag::addReference');
+            fname = strcat(obj.alias, '::addReference');
+            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
         end
 
         function [] = add_references(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, add_cell_array, ...
-                'nix.DataArray', strcat(obj.alias, '::addReferences'));
+            fname = strcat(obj.alias, '::addReferences');
+            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.DataArray', fname);
         end
 
         function r = has_reference(obj, id_or_name)
-            r = nix_mx('MultiTag::hasReference', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasReference');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = remove_reference(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.DataArray', 'MultiTag::removeReference');
+            fname = strcat(obj.alias, '::removeReference');
+            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
         end
 
         function r = open_reference(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'MultiTag::openReferences', id_or_name, @nix.DataArray);
+            fname = strcat(obj.alias, '::openReferences');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
         end
 
         function r = open_reference_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'MultiTag::openReferenceIdx', idx, @nix.DataArray);
+            fname = strcat(obj.alias, '::openReferenceIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
         end
 
         function r = retrieve_data(obj, pos_idx, id_or_name)
-            data = nix_mx('MultiTag::retrieveData', obj.nix_handle, pos_idx, id_or_name);
-            
+            fname = strcat(obj.alias, '::retrieveData');
+            data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
+
             % data must agree with file & dimensions see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = retrieve_data_idx(obj, pos_idx, ref_idx)
-            data = nix_mx('MultiTag::retrieveDataIdx', obj.nix_handle, pos_idx, ref_idx);
-            
+            fname = strcat(obj.alias, '::retrieveDataIdx');
+            data = nix_mx(fname, obj.nix_handle, pos_idx, ref_idx);
+
             % data must agree with file & dimensions see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = reference_count(obj)
-            r = nix_mx('MultiTag::referenceCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::referenceCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_references(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'MultiTag::referencesFiltered', @nix.DataArray);
+            fname = strcat(obj.alias, '::referencesFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
         end
 
         % ------------------
@@ -94,52 +98,54 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             else
                 addID = add_this;
             end
-            r = nix.Feature(nix_mx('MultiTag::createFeature', ...
-                obj.nix_handle, addID, link_type));
+            fname = strcat(obj.alias, '::createFeature');
+            r = nix.Feature(nix_mx(fname, obj.nix_handle, addID, link_type));
         end
 
         function r = has_feature(obj, id_or_name)
-            r = nix_mx('MultiTag::hasFeature', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasFeature');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = remove_feature(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.Feature', 'MultiTag::deleteFeature');
+            fname = strcat(obj.alias, '::deleteFeature');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Feature', fname);
         end
 
         function r = open_feature(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'MultiTag::openFeature', id_or_name, @nix.Feature);
+            fname = strcat(obj.alias, '::openFeature');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Feature);
         end
 
         function r = open_feature_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'MultiTag::openFeatureIdx', idx, @nix.Feature);
+            fname = strcat(obj.alias, '::openFeatureIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Feature);
         end
 
         function r = retrieve_feature_data(obj, pos_idx, id_or_name)
-            data = nix_mx('MultiTag::featureRetrieveData', ...
-                            obj.nix_handle, pos_idx, id_or_name);
+            fname = strcat(obj.alias, '::featureRetrieveData');
+            data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
 
             % data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
-            data = nix_mx('MultiTag::featureRetrieveDataIdx', ...
-                            obj.nix_handle, pos_idx, feat_idx);
+            fname = strcat(obj.alias, '::featureRetrieveDataIdx');
+            data = nix_mx(fname, obj.nix_handle, pos_idx, feat_idx);
             
             % data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = feature_count(obj)
-            r = nix_mx('MultiTag::featureCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::featureCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_features(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'MultiTag::featuresFiltered', @nix.Feature);
+            fname = strcat(obj.alias, '::featuresFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Feature);
         end
 
         % ------------------
@@ -147,11 +153,13 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = has_positions(obj)
-            r = nix_mx('MultiTag::hasPositions', obj.nix_handle);
+            fname = strcat(obj.alias, '::hasPositions');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = open_positions(obj)
-            h = nix_mx('MultiTag::openPositions', obj.nix_handle);
+            fname = strcat(obj.alias, '::openPositions');
+            h = nix_mx(fname, obj.nix_handle);
             r = {};
             if h ~= 0
                 r = nix.DataArray(h);
@@ -165,7 +173,8 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 addID = add_this;
             end
 
-            nix_mx('MultiTag::addPositions', obj.nix_handle, addID)
+            fname = strcat(obj.alias, '::addPositions');
+            nix_mx(fname, obj.nix_handle, addID)
         end
 
         % ------------------
@@ -173,7 +182,8 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = open_extents(obj)
-            h = nix_mx('MultiTag::openExtents', obj.nix_handle);
+            fname = strcat(obj.alias, '::openExtents');
+            h = nix_mx(fname, obj.nix_handle);
             r = {};
             if h ~= 0
                 r = nix.DataArray(h);
@@ -182,14 +192,16 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function [] = set_extents(obj, add_this)
             if(isempty(add_this))
-                nix_mx('MultiTag::setNoneExtents', obj.nix_handle, 0);
+                fname = strcat(obj.alias, '::setNoneExtents');
+                nix_mx(fname, obj.nix_handle, 0);
             else
                 if(strcmp(class(add_this), 'nix.DataArray'))
                     addID = add_this.id;
                 else
                     addID = add_this;
                 end
-                nix_mx('MultiTag::setExtents', obj.nix_handle, addID);
+                fname = strcat(obj.alias, '::setExtents');
+                nix_mx(fname, obj.nix_handle, addID);
             end
         end
     end

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -7,13 +7,13 @@
 % LICENSE file in the root of the Project.
 
 classdef NamedEntity < nix.Entity
-    %NamedEntity
+    % NamedEntity
     % base class for nix entities with name/type/definition
 
     methods
         function obj = NamedEntity(h)
             obj = obj@nix.Entity(h);
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'id', 'r');
             nix.Dynamic.add_dyn_attr(obj, 'name', 'r');
@@ -21,15 +21,14 @@ classdef NamedEntity < nix.Entity
             nix.Dynamic.add_dyn_attr(obj, 'definition', 'rw');
         end
 
-        function res = compare(obj, entity)
+        function r = compare(obj, entity)
         % Compares first name and second id, return > 0 if the entity 
         % is larger than the other, 0 if both are equal, and < 0 otherwise.
             if(~strcmp(class(obj), class(entity)))
                 error('Only entities of the same class can be compared.');
-            end;
-            res = nix_mx(strcat(obj.alias, '::compare'), ...
-                obj.nix_handle, entity.nix_handle);
-        end;
+            end
+            r = nix_mx(strcat(obj.alias, '::compare'), obj.nix_handle, entity.nix_handle);
+        end
     end
-    
+
 end

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -27,7 +27,8 @@ classdef NamedEntity < nix.Entity
             if(~strcmp(class(obj), class(entity)))
                 error('Only entities of the same class can be compared.');
             end
-            r = nix_mx(strcat(obj.alias, '::compare'), obj.nix_handle, entity.nix_handle);
+            fname = strcat(obj.alias, '::compare');
+            r = nix_mx(fname, obj.nix_handle, entity.nix_handle);
         end
     end
 

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -7,30 +7,30 @@
 % LICENSE file in the root of the Project.
 
 classdef Property < nix.NamedEntity
-    %PROPERTY Metadata Property class
+    % PROPERTY Metadata Property class
     %   NIX metadata property
-    
+
     properties(Hidden)
         % namespace reference for nix-mx functions
         alias = 'Property'
-    end;
-    
+    end
+
     properties(Dependent)
         values
-    end;
-    
+    end
+
     methods
         function obj = Property(h)
             obj@nix.NamedEntity(h);
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'mapping', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'datatype', 'r');
-        end;
+        end
 
-        function retVals = get.values(obj)
-            retVals = nix_mx('Property::values', obj.nix_handle);
+        function r = get.values(obj)
+            r = nix_mx('Property::values', obj.nix_handle);
         end
 
         function [] = set.values(obj, val)
@@ -38,39 +38,38 @@ classdef Property < nix.NamedEntity
             if (~iscell(values))
                 values = num2cell(val);
             end
-            
+
             for i = 1:length(values)
                 if (isstruct(values{i}))
                     curr = values{i}.value;
                 else
                     curr = values{i};
                 end
-                
+
                 if (~strcmpi(class(curr), obj.datatype))
                     error('Values do not match property data type!');
                 end
             end
-            
+
             nix_mx('Property::updateValues', obj.nix_handle, values);
         end
-        
-        function c = value_count(obj)
-            c = nix_mx('Property::valueCount', obj.nix_handle);
+
+        function r = value_count(obj)
+            r = nix_mx('Property::valueCount', obj.nix_handle);
         end
 
         function [] = values_delete(obj)
             nix_mx('Property::deleteValues', obj.nix_handle);
         end
-        
+
         % return value 0 means name and id of two properties are
         % identical, any other value means either name or id differ.
-        function cmp_val = compare(obj, property)
+        function r = compare(obj, property)
             if (~strcmp(class(property), class(obj)))
                error('Function only supports comparison of Properties.');
             end
-            cmp_val = nix_mx('Property::compare', obj.nix_handle, property.nix_handle);
+            r = nix_mx('Property::compare', obj.nix_handle, property.nix_handle);
         end
-
     end
 
 end

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -30,7 +30,8 @@ classdef Property < nix.NamedEntity
         end
 
         function r = get.values(obj)
-            r = nix_mx('Property::values', obj.nix_handle);
+            fname = strcat(obj.alias, '::values');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function [] = set.values(obj, val)
@@ -51,15 +52,18 @@ classdef Property < nix.NamedEntity
                 end
             end
 
-            nix_mx('Property::updateValues', obj.nix_handle, values);
+            fname = strcat(obj.alias, '::updateValues');
+            nix_mx(fname, obj.nix_handle, values);
         end
 
         function r = value_count(obj)
-            r = nix_mx('Property::valueCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::valueCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function [] = values_delete(obj)
-            nix_mx('Property::deleteValues', obj.nix_handle);
+            fname = strcat(obj.alias, '::deleteValues');
+            nix_mx(fname, obj.nix_handle);
         end
 
         % return value 0 means name and id of two properties are
@@ -68,7 +72,9 @@ classdef Property < nix.NamedEntity
             if (~strcmp(class(property), class(obj)))
                error('Function only supports comparison of Properties.');
             end
-            r = nix_mx('Property::compare', obj.nix_handle, property.nix_handle);
+
+            fname = strcat(obj.alias, '::compare');
+            r = nix_mx(fname, obj.nix_handle, property.nix_handle);
         end
     end
 

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -30,13 +30,13 @@ classdef RangeDimension < nix.Entity
             if index > 0
                 index = index - 1;
             end
-            func_name = strcat(obj.alias, '::tickAt');
-            r = nix_mx(func_name, obj.nix_handle, index);
+            fname = strcat(obj.alias, '::tickAt');
+            r = nix_mx(fname, obj.nix_handle, index);
         end
 
         function r = index_of(obj, position)
-            func_name = strcat(obj.alias, '::indexOf');
-            r = nix_mx(func_name, obj.nix_handle, position);
+            fname = strcat(obj.alias, '::indexOf');
+            r = nix_mx(fname, obj.nix_handle, position);
         end
 
         function r = axis(obj, count, startIndex)
@@ -48,8 +48,8 @@ classdef RangeDimension < nix.Entity
                 startIndex = startIndex - 1;
             end
 
-            func_name = strcat(obj.alias, '::axis');
-            r = nix_mx(func_name, obj.nix_handle, count, startIndex);
+            fname = strcat(obj.alias, '::axis');
+            r = nix_mx(fname, obj.nix_handle, count, startIndex);
         end
     end
 

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -7,17 +7,17 @@
 % LICENSE file in the root of the Project.
 
 classdef RangeDimension < nix.Entity
-    %RangeDimension nix RangeDimension object
-    
+    % RangeDimension nix RangeDimension object
+
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'RangeDimension'
     end
-    
+
     methods
         function obj = RangeDimension(h)
             obj@nix.Entity(h);
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
             nix.Dynamic.add_dyn_attr(obj, 'isAlias', 'r');
@@ -26,30 +26,31 @@ classdef RangeDimension < nix.Entity
             nix.Dynamic.add_dyn_attr(obj, 'ticks', 'rw');
         end
 
-        function tickAt = tick_at(obj, index)
+        function r = tick_at(obj, index)
             if index > 0
                 index = index - 1;
             end
             func_name = strcat(obj.alias, '::tickAt');
-            tickAt = nix_mx(func_name, obj.nix_handle, index);
-        end
-        
-        function indexOf = index_of(obj, position)
-            func_name = strcat(obj.alias, '::indexOf');
-            indexOf = nix_mx(func_name, obj.nix_handle, position);
+            r = nix_mx(func_name, obj.nix_handle, index);
         end
 
-        function axis = axis(obj, count, startIndex)
+        function r = index_of(obj, position)
+            func_name = strcat(obj.alias, '::indexOf');
+            r = nix_mx(func_name, obj.nix_handle, position);
+        end
+
+        function r = axis(obj, count, startIndex)
             if nargin < 3
                 startIndex = 0;
             end
+
             if(startIndex > 0)
                 startIndex = startIndex - 1;
             end
-            
-            func_name = strcat(obj.alias, '::axis');
-            axis = nix_mx(func_name, obj.nix_handle, count, startIndex);
-        end
 
+            func_name = strcat(obj.alias, '::axis');
+            r = nix_mx(func_name, obj.nix_handle, count, startIndex);
+        end
     end
+
 end

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -7,17 +7,17 @@
 % LICENSE file in the root of the Project.
 
 classdef SampledDimension < nix.Entity
-    %SampledDimension nix SampledDimension object
-    
+    % SampledDimension nix SampledDimension object
+
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'SampledDimension'
     end
-    
+
     methods
         function obj = SampledDimension(h)
             obj@nix.Entity(h);
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
             nix.Dynamic.add_dyn_attr(obj, 'label', 'rw');
@@ -26,28 +26,31 @@ classdef SampledDimension < nix.Entity
             nix.Dynamic.add_dyn_attr(obj, 'offset', 'rw');
         end
 
-        function indexOf = index_of(obj, position)
+        function r = index_of(obj, position)
             func_name = strcat(obj.alias, '::indexOf');
-            indexOf = nix_mx(func_name, obj.nix_handle, position);
+            r = nix_mx(func_name, obj.nix_handle, position);
         end
-        
-        function posAt = position_at(obj, index)
+
+        function r = position_at(obj, index)
             if index > 0
                 index = index - 1;
             end
             func_name = strcat(obj.alias, '::positionAt');
-            posAt = nix_mx(func_name, obj.nix_handle, index);
+            r = nix_mx(func_name, obj.nix_handle, index);
         end
 
-        function axis = axis(obj, count, startIndex)
+        function r = axis(obj, count, startIndex)
             if nargin < 3
                 startIndex = 0;
             end
+
             if startIndex > 0
                 startIndex = startIndex - 1;
             end
+
             func_name = strcat(obj.alias, '::axis');
-            axis = nix_mx(func_name, obj.nix_handle, count, startIndex);
+            r = nix_mx(func_name, obj.nix_handle, count, startIndex);
         end
     end
+
 end

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -27,16 +27,17 @@ classdef SampledDimension < nix.Entity
         end
 
         function r = index_of(obj, position)
-            func_name = strcat(obj.alias, '::indexOf');
-            r = nix_mx(func_name, obj.nix_handle, position);
+            fname = strcat(obj.alias, '::indexOf');
+            r = nix_mx(fname, obj.nix_handle, position);
         end
 
         function r = position_at(obj, index)
             if index > 0
                 index = index - 1;
             end
-            func_name = strcat(obj.alias, '::positionAt');
-            r = nix_mx(func_name, obj.nix_handle, index);
+
+            fname = strcat(obj.alias, '::positionAt');
+            r = nix_mx(fname, obj.nix_handle, index);
         end
 
         function r = axis(obj, count, startIndex)
@@ -48,8 +49,8 @@ classdef SampledDimension < nix.Entity
                 startIndex = startIndex - 1;
             end
 
-            func_name = strcat(obj.alias, '::axis');
-            r = nix_mx(func_name, obj.nix_handle, count, startIndex);
+            fname = strcat(obj.alias, '::axis');
+            r = nix_mx(fname, obj.nix_handle, count, startIndex);
         end
     end
 

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -29,11 +29,12 @@ classdef Section < nix.NamedEntity
         end
 
         function r = parent(obj)
-           h = nix_mx('Section::parent', obj.nix_handle);
-           r = {};
-           if h ~= 0
-               r = nix.Section(h);
-           end
+            fname = strcat(obj.alias, '::parent');
+            h = nix_mx(fname, obj.nix_handle);
+            r = {};
+            if h ~= 0
+                r = nix.Section(h);
+            end
         end
 
         % ----------------
@@ -42,28 +43,32 @@ classdef Section < nix.NamedEntity
 
         function [] = set_link(obj, val)
             if (isempty(val))
-                nix_mx('Section::setNoneLink', obj.nix_handle);
+                fname = strcat(obj.alias, '::setNoneLink');
+                nix_mx(fname, obj.nix_handle);
             else
                 if(strcmp(class(val), 'nix.Section'))
                     addID = val.id;
                 else
                     addID = val;
                 end
-                nix_mx('Section::setLink', obj.nix_handle, addID);
+
+                fname = strcat(obj.alias, '::setLink');
+                nix_mx(fname, obj.nix_handle, addID);
             end
         end
 
         function r = openLink(obj)
-           h = nix_mx('Section::openLink', obj.nix_handle);
-           r = {};
-           if h ~= 0
-               r = nix.Section(h);
-           end
+            fname = strcat(obj.alias, '::openLink');
+            h = nix_mx(fname, obj.nix_handle);
+            r = {};
+            if h ~= 0
+                r = nix.Section(h);
+            end
         end
 
         function r = inherited_properties(obj)
-            r = nix.Utils.fetchObjList('Section::inheritedProperties', ...
-                obj.nix_handle, @nix.Property);
+            fname = strcat(obj.alias, '::inheritedProperties');
+            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.Property);
         end
 
         % ----------------
@@ -71,36 +76,39 @@ classdef Section < nix.NamedEntity
         % ----------------
 
         function r = create_section(obj, name, type)
-            r = nix.Section(nix_mx('Section::createSection', ...
-                obj.nix_handle, name, type));
+            fname = strcat(obj.alias, '::createSection');
+            h = nix_mx(fname, obj.nix_handle, name, type);
+            r = nix.Section(h);
         end
 
         function r = delete_section(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.Section', 'Section::deleteSection');
+            fname = strcat(obj.alias, '::deleteSection');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Section', fname);
         end
 
         function r = open_section(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Section::openSection', id_or_name, @nix.Section);
+            fname = strcat(obj.alias, '::openSection');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Section);
         end
 
         function r = open_section_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'Section::openSectionIdx', idx, @nix.Section);
+            fname = strcat(obj.alias, '::openSectionIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Section);
         end
 
         function r = has_section(obj, id_or_name)
-            r = nix_mx('Section::hasSection', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasSection');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = section_count(obj)
-            r = nix_mx('Section::sectionCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::sectionCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_sections(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Section::sectionsFiltered', @nix.Section);
+            fname = strcat(obj.alias, '::sectionsFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Section);
         end
 
         % find_related returns the nearest occurrence downstream of a
@@ -108,7 +116,8 @@ classdef Section < nix.NamedEntity
         % If no section can be found downstream, it will look for the
         % nearest occurrence upstream of a nix.Section matching the filter.
         function r = find_related(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'Section::findRelated', @nix.Section);
+            fname = strcat(obj.alias, '::findRelated');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Section);
         end
 
         % maxdepth is an index
@@ -118,8 +127,8 @@ classdef Section < nix.NamedEntity
 
         % maxdepth is an index
         function r = find_filtered_sections(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, ...
-                max_depth, filter, val, 'Section::findSections', @nix.Section);
+            fname = strcat(obj.alias, '::findSections');
+            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Section);
         end
 
         % ----------------
@@ -127,50 +136,55 @@ classdef Section < nix.NamedEntity
         % ----------------
 
         function r = create_property(obj, name, datatype)
-            if(~isa(datatype, 'nix.DataType'))
+            if (~isa(datatype, 'nix.DataType'))
                 error('Please provide a valid nix.DataType');
             else
-                r = nix.Property(nix_mx('Section::createProperty', ...
-                    obj.nix_handle, name, lower(datatype.char)));
+                fname = strcat(obj.alias, '::createProperty');
+                h = nix_mx(fname, obj.nix_handle, name, lower(datatype.char));
+                r = nix.Property(h);
             end
         end
 
         function r = create_property_with_value(obj, name, val)
-            if(~iscell(val))
+            if (~iscell(val))
                 val = num2cell(val);
             end
-            r = nix.Property(nix_mx('Section::createPropertyWithValue', ...
-                obj.nix_handle, name, val));
+            fname = strcat(obj.alias, '::createPropertyWithValue');
+            h = nix_mx(fname, obj.nix_handle, name, val);
+            r = nix.Property(h);
         end
 
         function r = delete_property(obj, del)
-            if(isstruct(del) && isfield(del, 'id'))
+            if (isstruct(del) && isfield(del, 'id'))
                 delID = del.id;
             elseif (strcmp(class(del), 'nix.Property'))
                 delID = del.id;
             else
                 delID = del;
             end
-            r = nix_mx('Section::deleteProperty', obj.nix_handle, delID);
+
+            fname = strcat(obj.alias, '::deleteProperty');
+            r = nix_mx(fname, obj.nix_handle, delID);
         end
 
         function r = open_property(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Section::openProperty', id_or_name, @nix.Property);
+            fname = strcat(obj.alias, '::openProperty');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Property);
         end
 
         function r = open_property_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'Section::openPropertyIdx', idx, @nix.Property);
+            fname = strcat(obj.alias, '::openPropertyIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Property);
         end
 
         function r = property_count(obj)
-            r = nix_mx('Section::propertyCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::propertyCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_properties(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Section::propertiesFiltered', @nix.Property);
+            fname = strcat(obj.alias, '::propertiesFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Property);
         end
 
         % ----------------
@@ -194,8 +208,8 @@ classdef Section < nix.NamedEntity
         end
 
         function r = referring_blocks(obj)
-            r = nix.Utils.fetchObjList('Section::referringBlocks', ...
-                obj.nix_handle, @nix.Block);
+            fname = strcat(obj.alias, '::referringBlocks');
+            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.Block);
         end
     end
 
@@ -207,15 +221,16 @@ classdef Section < nix.NamedEntity
         % referring_util receives a nix entityConstructor, part of a function
         % name and varargin to provide abstract access to nix.Section
         % referringXXX and referringXXX(Block) methods.
-        function r = referring_util(obj, entityConstructor, funcName, varargin)
+        function r = referring_util(obj, entityConstructor, fsuffix, varargin)
             if (isempty(varargin))
-                r = nix.Utils.fetchObjList(strcat('Section::referring', funcName), ...
-                    obj.nix_handle, entityConstructor);
+                fname = strcat(obj.alias, '::referring', fsuffix);
+                r = nix.Utils.fetchObjList(fname, obj.nix_handle, entityConstructor);
             elseif ((size(varargin, 2) > 1) || ...
                     (~strcmp(class(varargin{1}), 'nix.Block')))
                 error('Provide either empty arguments or a single Block entity');
             else
-                r = nix.Utils.fetchObjListByEntity(strcat('Section::referringBlock', funcName), ...
+                fname = strcat(obj.alias, '::referringBlock', fsuffix);
+                r = nix.Utils.fetchObjListByEntity(fname, ...
                     obj.nix_handle, varargin{1}.nix_handle, entityConstructor);
             end
         end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -42,14 +42,8 @@ classdef Section < nix.NamedEntity
                 fname = strcat(obj.alias, '::setNoneLink');
                 nix_mx(fname, obj.nix_handle);
             else
-                if(strcmp(class(val), 'nix.Section'))
-                    addID = val.id;
-                else
-                    addID = val;
-                end
-
                 fname = strcat(obj.alias, '::setLink');
-                nix_mx(fname, obj.nix_handle, addID);
+                nix.Utils.add_entity(obj, val, 'nix.Section', fname);
             end
         end
 

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -7,34 +7,34 @@
 % LICENSE file in the root of the Project.
 
 classdef Section < nix.NamedEntity
-    %SECTION Metadata Section class
+    % SECTION Metadata Section class
     %   NIX metadata section
-    
+
     properties(Hidden)
         % namespace reference for nix-mx functions
         alias = 'Section'
-    end;
+    end
 
     methods
         function obj = Section(h)
             obj@nix.NamedEntity(h);
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'repository', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'mapping', 'rw');
-            
+
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
             nix.Dynamic.add_dyn_relation(obj, 'properties', @nix.Property);
-        end;
+        end
 
-        function section = parent(obj)
-           handle = nix_mx('Section::parent', obj.nix_handle);
-           section = {};
-           if handle ~= 0
-               section = nix.Section(handle);
-           end;
-        end;
+        function r = parent(obj)
+           h = nix_mx('Section::parent', obj.nix_handle);
+           r = {};
+           if h ~= 0
+               r = nix.Section(h);
+           end
+        end
 
         % ----------------
         % Link methods
@@ -48,78 +48,77 @@ classdef Section < nix.NamedEntity
                     addID = val.id;
                 else
                     addID = val;
-                end;
+                end
                 nix_mx('Section::setLink', obj.nix_handle, addID);
-            end;
-        end;
+            end
+        end
 
-        function section = openLink(obj)
-           handle = nix_mx('Section::openLink', obj.nix_handle);
-           section = {};
-           if handle ~= 0
-               section = nix.Section(handle);
-           end;
-        end;
+        function r = openLink(obj)
+           h = nix_mx('Section::openLink', obj.nix_handle);
+           r = {};
+           if h ~= 0
+               r = nix.Section(h);
+           end
+        end
 
-        function retList = inherited_properties(obj)
-            retList = nix.Utils.fetchObjList('Section::inheritedProperties', ...
+        function r = inherited_properties(obj)
+            r = nix.Utils.fetchObjList('Section::inheritedProperties', ...
                 obj.nix_handle, @nix.Property);
         end
 
         % ----------------
         % Section methods
         % ----------------
-        
-        function newSec = create_section(obj, name, type)
-            newSec = nix.Section(nix_mx('Section::createSection', ...
+
+        function r = create_section(obj, name, type)
+            r = nix.Section(nix_mx('Section::createSection', ...
                 obj.nix_handle, name, type));
-        end;
-
-        function delCheck = delete_section(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
-                'nix.Section', 'Section::deleteSection');
-        end;
-
-        function retObj = open_section(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Section::openSection', id_or_name, @nix.Section);
-        end;
-
-        function retObj = open_section_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Section::openSectionIdx', idx, @nix.Section);
-        end;
-        
-        function hs = has_section(obj, id_or_name)
-            hs = nix_mx('Section::hasSection', obj.nix_handle, id_or_name);
-        end;
-
-        function c = section_count(obj)
-            c = nix_mx('Section::sectionCount', obj.nix_handle);
         end
 
-        function filtered = filter_sections(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = delete_section(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
+                'nix.Section', 'Section::deleteSection');
+        end
+
+        function r = open_section(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
+                'Section::openSection', id_or_name, @nix.Section);
+        end
+
+        function r = open_section_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
+                'Section::openSectionIdx', idx, @nix.Section);
+        end
+
+        function r = has_section(obj, id_or_name)
+            r = nix_mx('Section::hasSection', obj.nix_handle, id_or_name);
+        end
+
+        function r = section_count(obj)
+            r = nix_mx('Section::sectionCount', obj.nix_handle);
+        end
+
+        function r = filter_sections(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Section::sectionsFiltered', @nix.Section);
         end
-        
+
         % find_related returns the nearest occurrence downstream of a
         % nix.Section matching the filter.
         % If no section can be found downstream, it will look for the
         % nearest occurrence upstream of a nix.Section matching the filter.
-        function filtered = find_related(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'Section::findRelated', @nix.Section);
+        function r = find_related(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'Section::findRelated', @nix.Section);
         end
 
         % maxdepth is an index
-        function sec = find_sections(obj, max_depth)
-            sec = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
+        function r = find_sections(obj, max_depth)
+            r = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
         end
 
         % maxdepth is an index
-        function sec = find_filtered_sections(obj, max_depth, filter, val)
-            sec = nix.Utils.find(obj, ...
+        function r = find_filtered_sections(obj, max_depth, filter, val)
+            r = nix.Utils.find(obj, ...
                 max_depth, filter, val, 'Section::findSections', @nix.Section);
         end
 
@@ -127,50 +126,50 @@ classdef Section < nix.NamedEntity
         % Property methods
         % ----------------
 
-        function p = create_property(obj, name, datatype)
+        function r = create_property(obj, name, datatype)
             if(~isa(datatype, 'nix.DataType'))
                 error('Please provide a valid nix.DataType');
             else
-                p = nix.Property(nix_mx('Section::createProperty', ...
+                r = nix.Property(nix_mx('Section::createProperty', ...
                     obj.nix_handle, name, lower(datatype.char)));
-            end;
-        end;
+            end
+        end
 
-        function p = create_property_with_value(obj, name, val)
+        function r = create_property_with_value(obj, name, val)
             if(~iscell(val))
                 val = num2cell(val);
-            end;
-            p = nix.Property(nix_mx('Section::createPropertyWithValue', ...
+            end
+            r = nix.Property(nix_mx('Section::createPropertyWithValue', ...
                 obj.nix_handle, name, val));
-        end;
+        end
 
-        function delCheck = delete_property(obj, del)
+        function r = delete_property(obj, del)
             if(isstruct(del) && isfield(del, 'id'))
                 delID = del.id;
             elseif (strcmp(class(del), 'nix.Property'))
                 delID = del.id;
             else
                 delID = del;
-            end;
-            delCheck = nix_mx('Section::deleteProperty', obj.nix_handle, delID);
-        end;
-
-        function retObj = open_property(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Section::openProperty', id_or_name, @nix.Property);
-        end;
-
-        function retObj = open_property_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Section::openPropertyIdx', idx, @nix.Property);
-        end;
-
-        function c = property_count(obj)
-            c = nix_mx('Section::propertyCount', obj.nix_handle);
+            end
+            r = nix_mx('Section::deleteProperty', obj.nix_handle, delID);
         end
 
-        function filtered = filter_properties(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = open_property(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
+                'Section::openProperty', id_or_name, @nix.Property);
+        end
+
+        function r = open_property_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
+                'Section::openPropertyIdx', idx, @nix.Property);
+        end
+
+        function r = property_count(obj)
+            r = nix_mx('Section::propertyCount', obj.nix_handle);
+        end
+
+        function r = filter_properties(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Section::propertiesFiltered', @nix.Property);
         end
 
@@ -178,27 +177,27 @@ classdef Section < nix.NamedEntity
         % Referring entity methods
         % ----------------
 
-        function ret = referring_data_arrays(obj, varargin)
-            ret = obj.referring_util(@nix.DataArray, 'DataArrays', varargin{:});
+        function r = referring_data_arrays(obj, varargin)
+            r = obj.referring_util(@nix.DataArray, 'DataArrays', varargin{:});
         end
 
-        function ret = referring_tags(obj, varargin)
-            ret = obj.referring_util(@nix.Tag, 'Tags', varargin{:});
+        function r = referring_tags(obj, varargin)
+            r = obj.referring_util(@nix.Tag, 'Tags', varargin{:});
         end
 
-        function ret = referring_multi_tags(obj, varargin)
-            ret = obj.referring_util(@nix.MultiTag, 'MultiTags', varargin{:});
+        function r = referring_multi_tags(obj, varargin)
+            r = obj.referring_util(@nix.MultiTag, 'MultiTags', varargin{:});
         end
 
-        function ret = referring_sources(obj, varargin)
-            ret = obj.referring_util(@nix.Source, 'Sources', varargin{:});
+        function r = referring_sources(obj, varargin)
+            r = obj.referring_util(@nix.Source, 'Sources', varargin{:});
         end
 
-        function ret = referring_blocks(obj)
-            ret = nix.Utils.fetchObjList('Section::referringBlocks', ...
+        function r = referring_blocks(obj)
+            r = nix.Utils.fetchObjList('Section::referringBlocks', ...
                 obj.nix_handle, @nix.Block);
         end
-    end;
+    end
 
     % ----------------
     % Referring utility method
@@ -208,17 +207,18 @@ classdef Section < nix.NamedEntity
         % referring_util receives a nix entityConstructor, part of a function
         % name and varargin to provide abstract access to nix.Section
         % referringXXX and referringXXX(Block) methods.
-        function ret = referring_util(obj, entityConstructor, funcName, varargin)
+        function r = referring_util(obj, entityConstructor, funcName, varargin)
             if (isempty(varargin))
-                ret = nix.Utils.fetchObjList(strcat('Section::referring', funcName), ...
+                r = nix.Utils.fetchObjList(strcat('Section::referring', funcName), ...
                     obj.nix_handle, entityConstructor);
             elseif ((size(varargin, 2) > 1) || ...
                     (~strcmp(class(varargin{1}), 'nix.Block')))
                 error('Provide either empty arguments or a single Block entity');
             else
-                ret = nix.Utils.fetchObjListByEntity(strcat('Section::referringBlock', funcName), ...
+                r = nix.Utils.fetchObjListByEntity(strcat('Section::referringBlock', funcName), ...
                     obj.nix_handle, varargin{1}.nix_handle, entityConstructor);
             end
         end
     end
+
 end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -30,11 +30,7 @@ classdef Section < nix.NamedEntity
 
         function r = parent(obj)
             fname = strcat(obj.alias, '::parent');
-            h = nix_mx(fname, obj.nix_handle);
-            r = {};
-            if h ~= 0
-                r = nix.Section(h);
-            end
+            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Section);
         end
 
         % ----------------
@@ -59,11 +55,7 @@ classdef Section < nix.NamedEntity
 
         function r = openLink(obj)
             fname = strcat(obj.alias, '::openLink');
-            h = nix_mx(fname, obj.nix_handle);
-            r = {};
-            if h ~= 0
-                r = nix.Section(h);
-            end
+            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Section);
         end
 
         function r = inherited_properties(obj)

--- a/+nix/SetDimension.m
+++ b/+nix/SetDimension.m
@@ -7,21 +7,21 @@
 % LICENSE file in the root of the Project.
 
 classdef SetDimension < nix.Entity
-    %SetDimension nix SetDimension object
-    
+    % SetDimension nix SetDimension object
+
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'SetDimension'
     end
-    
+
     methods
         function obj = SetDimension(h)
             obj@nix.Entity(h);
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
             nix.Dynamic.add_dyn_attr(obj, 'labels', 'rw');
         end
     end
+
 end
-   

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -28,64 +28,70 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         % ------------------
 
         function r = source_count(obj)
-            r = nix_mx('Source::sourceCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::sourceCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = create_source(obj, name, type)
-            r = nix.Source(nix_mx('Source::createSource', obj.nix_handle, name, type));
+            fname = strcat(obj.alias, '::createSource');
+            h = nix_mx(fname, obj.nix_handle, name, type);
+            r = nix.Source(h);
         end
 
         function r = has_source(obj, id_or_name)
-            r = nix_mx('Source::hasSource', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasSource');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = delete_source(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Source', 'Source::deleteSource');
+            fname = strcat(obj.alias, '::deleteSource');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Source', fname);
         end
 
         function r = open_source(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'Source::openSource', id_or_name, @nix.Source);
+            fname = strcat(obj.alias, '::openSource');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Source);
         end
 
         function r = open_source_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Source::openSourceIdx', idx, @nix.Source);
+            fname = strcat(obj.alias, '::openSourceIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Source);
         end
 
         function r = parent_source(obj)
-            r = nix.Utils.fetchObj('Source::parentSource', obj.nix_handle, @nix.Source);
+            fname = strcat(obj.alias, '::parentSource');
+            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Source);
         end
 
         function r = referring_data_arrays(obj)
-            r = nix.Utils.fetchObjList('Source::referringDataArrays', ...
-                obj.nix_handle, @nix.DataArray);
+            fname = strcat(obj.alias, '::referringDataArrays');
+            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.DataArray);
         end
 
         function r = referring_tags(obj)
-            r = nix.Utils.fetchObjList('Source::referringTags', ...
-                obj.nix_handle, @nix.Tag);
+            fname = strcat(obj.alias, '::referringTags');
+            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.Tag);
         end
 
         function r = referring_multi_tags(obj)
-            r = nix.Utils.fetchObjList('Source::referringMultiTags', ...
-                obj.nix_handle, @nix.MultiTag);
+            fname = strcat(obj.alias, '::referringMultiTags');
+            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.MultiTag);
         end
 
         function r = filter_sources(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Source::sourcesFiltered', @nix.Source);
+            fname = strcat(obj.alias, '::sourcesFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Source);
         end
 
-        % maxdepth is an index where idx = 0 corresponds to the calling
-        % source
+        % maxdepth is an index where idx = 0 corresponds to the calling source
         function r = find_sources(obj, max_depth)
             r = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
         end
 
-        % maxdepth is an index where idx = 0 corresponds to the calling
-        % source
+        % maxdepth is an index where idx = 0 corresponds to the calling source
         function r = find_filtered_sources(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, ...
-                max_depth, filter, val, 'Source::findSources', @nix.Source);
+            fname = strcat(obj.alias, '::findSources');
+            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Source);
         end
     end
 

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -7,89 +7,86 @@
 % LICENSE file in the root of the Project.
 
 classdef Source < nix.NamedEntity & nix.MetadataMixIn
-    %Source nix Source object
-    
+    % Source nix Source object
+
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'Source'
     end
-    
+
     methods
         function obj = Source(h)
             obj@nix.NamedEntity(h);
             obj@nix.MetadataMixIn();
-           
+
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
-        end;
-        
+        end
+
         % ------------------
         % Sources methods
         % ------------------
 
-        function c = source_count(obj)
-            c = nix_mx('Source::sourceCount', obj.nix_handle);
+        function r = source_count(obj)
+            r = nix_mx('Source::sourceCount', obj.nix_handle);
         end
 
-        function s = create_source(obj, name, type)
-            s = nix.Source(nix_mx('Source::createSource', obj.nix_handle, name, type));
-        end;
-
-        function hasSource = has_source(obj, id_or_name)
-            hasSource = nix_mx('Source::hasSource', obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = delete_source(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
-                'nix.Source', 'Source::deleteSource');
-        end;
-
-        function retObj = open_source(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Source::openSource', id_or_name, @nix.Source);
-        end;
-
-        function retObj = open_source_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Source::openSourceIdx', idx, @nix.Source);
-        end;
-
-        function retObj = parent_source(obj)
-            retObj = nix.Utils.fetchObj('Source::parentSource', ...
-                obj.nix_handle, @nix.Source);
+        function r = create_source(obj, name, type)
+            r = nix.Source(nix_mx('Source::createSource', obj.nix_handle, name, type));
         end
 
-        function retObj = referring_data_arrays(obj)
-            retObj = nix.Utils.fetchObjList('Source::referringDataArrays', ...
+        function r = has_source(obj, id_or_name)
+            r = nix_mx('Source::hasSource', obj.nix_handle, id_or_name);
+        end
+
+        function r = delete_source(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Source', 'Source::deleteSource');
+        end
+
+        function r = open_source(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'Source::openSource', id_or_name, @nix.Source);
+        end
+
+        function r = open_source_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Source::openSourceIdx', idx, @nix.Source);
+        end
+
+        function r = parent_source(obj)
+            r = nix.Utils.fetchObj('Source::parentSource', obj.nix_handle, @nix.Source);
+        end
+
+        function r = referring_data_arrays(obj)
+            r = nix.Utils.fetchObjList('Source::referringDataArrays', ...
                 obj.nix_handle, @nix.DataArray);
         end
 
-        function retObj = referring_tags(obj)
-            retObj = nix.Utils.fetchObjList('Source::referringTags', ...
+        function r = referring_tags(obj)
+            r = nix.Utils.fetchObjList('Source::referringTags', ...
                 obj.nix_handle, @nix.Tag);
         end
 
-        function retObj = referring_multi_tags(obj)
-            retObj = nix.Utils.fetchObjList('Source::referringMultiTags', ...
+        function r = referring_multi_tags(obj)
+            r = nix.Utils.fetchObjList('Source::referringMultiTags', ...
                 obj.nix_handle, @nix.MultiTag);
         end
 
-        function filtered = filter_sources(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = filter_sources(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Source::sourcesFiltered', @nix.Source);
         end
 
         % maxdepth is an index where idx = 0 corresponds to the calling
         % source
-        function sec = find_sources(obj, max_depth)
-            sec = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
+        function r = find_sources(obj, max_depth)
+            r = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
         end
 
         % maxdepth is an index where idx = 0 corresponds to the calling
         % source
-        function sec = find_filtered_sources(obj, max_depth, filter, val)
-            sec = nix.Utils.find(obj, ...
+        function r = find_filtered_sources(obj, max_depth, filter, val)
+            r = nix.Utils.find(obj, ...
                 max_depth, filter, val, 'Source::findSources', @nix.Source);
         end
-    end;
+    end
+
 end

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -7,7 +7,7 @@
 % LICENSE file in the root of the Project.
 
 classdef SourcesMixIn < handle
-    %SourcesMixIn
+    % SourcesMixIn
     % mixin class for nix entities that can be related with sources
 
     properties (Abstract, Hidden)
@@ -18,19 +18,18 @@ classdef SourcesMixIn < handle
         function obj = SourcesMixIn()
             nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
         end
-        
-        function c = source_count(obj)
-            c = nix_mx(strcat(obj.alias, '::sourceCount'), obj.nix_handle);
+
+        function r = source_count(obj)
+            r = nix_mx(strcat(obj.alias, '::sourceCount'), obj.nix_handle);
         end
 
         % has_source supports only check by id, not by name
-        function ret = has_source(obj, id_or_entity)
+        function r = has_source(obj, id_or_entity)
             has = id_or_entity;
             if(strcmp(class(has), 'nix.Source'))
             	has = id_or_entity.id;
-            end;
-            ret = nix_mx(strcat(obj.alias, '::hasSource'), ...
-                            obj.nix_handle, has);
+            end
+            r = nix_mx(strcat(obj.alias, '::hasSource'), obj.nix_handle, has);
         end
 
         function [] = add_source(obj, add_this)
@@ -43,24 +42,23 @@ classdef SourcesMixIn < handle
                 'nix.Source', strcat(obj.alias, '::addSources'));
         end
 
-        function delCheck = remove_source(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
+        function r = remove_source(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
                 'nix.Source', strcat(obj.alias, '::removeSource'));
         end
 
-        function retObj = open_source(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                strcat(obj.alias, '::openSource'), id_or_name, ...
-                @nix.Source);
+        function r = open_source(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
+                strcat(obj.alias, '::openSource'), id_or_name, @nix.Source);
         end
 
-        function retObj = open_source_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
+        function r = open_source_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
                 strcat(obj.alias, '::openSourceIdx'), idx, @nix.Source);
         end
 
-        function filtered = filter_sources(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = filter_sources(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 strcat(obj.alias, '::sourcesFiltered'), @nix.Source);
         end
     end

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -20,46 +20,49 @@ classdef SourcesMixIn < handle
         end
 
         function r = source_count(obj)
-            r = nix_mx(strcat(obj.alias, '::sourceCount'), obj.nix_handle);
+            fname = strcat(obj.alias, '::sourceCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         % has_source supports only check by id, not by name
         function r = has_source(obj, id_or_entity)
             has = id_or_entity;
-            if(strcmp(class(has), 'nix.Source'))
+            if (strcmp(class(has), 'nix.Source'))
             	has = id_or_entity.id;
             end
-            r = nix_mx(strcat(obj.alias, '::hasSource'), obj.nix_handle, has);
+
+            fname = strcat(obj.alias, '::hasSource');
+            r = nix_mx(fname, obj.nix_handle, has);
         end
 
         function [] = add_source(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, ...
-                'nix.Source', strcat(obj.alias, '::addSource'));
+            fname = strcat(obj.alias, '::addSource');
+            nix.Utils.add_entity(obj, add_this, 'nix.Source', fname);
         end
 
         function [] = add_sources(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, add_cell_array, ...
-                'nix.Source', strcat(obj.alias, '::addSources'));
+            fname = strcat(obj.alias, '::addSources');
+            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.Source', fname);
         end
 
         function r = remove_source(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.Source', strcat(obj.alias, '::removeSource'));
+            fname = strcat(obj.alias, '::removeSource');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Source', fname);
         end
 
         function r = open_source(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                strcat(obj.alias, '::openSource'), id_or_name, @nix.Source);
+            fname = strcat(obj.alias, '::openSource');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Source);
         end
 
         function r = open_source_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                strcat(obj.alias, '::openSourceIdx'), idx, @nix.Source);
+            fname = strcat(obj.alias, '::openSourceIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Source);
         end
 
         function r = filter_sources(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                strcat(obj.alias, '::sourcesFiltered'), @nix.Source);
+            fname = strcat(obj.alias, '::sourcesFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Source);
         end
     end
 

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -99,7 +99,11 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
             fname = strcat(obj.alias, '::createFeature');
             h = nix_mx(fname, obj.nix_handle, addID, link_type);
-            r = nix.Feature(h);
+
+            r = {};
+            if (h ~= 0)
+                r = nix.Feature(h);
+            end
         end
 
         function r = has_feature(obj, id_or_name)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -67,17 +67,13 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = retrieve_data(obj, id_or_name)
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nix_handle, id_or_name);
-
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = retrieve_data_idx(obj, idx)
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
-            
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = reference_count(obj)
@@ -129,17 +125,13 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = retrieve_feature_data(obj, id_or_name)
             fname = strcat(obj.alias, '::featureRetrieveData');
             data = nix_mx(fname, obj.nix_handle, id_or_name);
-
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = retrieve_feature_data_idx(obj, idx)
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
-
-            % data must agree with file & dimensions; see mkarray.cc(42)
-            r = permute(data, length(size(data)):-1:1);
+            r = nix.Utils.transpose_array(data);
         end
 
         function r = feature_count(obj)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -35,54 +35,59 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function [] = add_reference(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', 'Tag::addReference');
+            fname = strcat(obj.alias, '::addReference');
+            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
         end
 
         function [] = add_references(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, add_cell_array, ...
-                'nix.DataArray', strcat(obj.alias, '::addReferences'));
+            fname = strcat(obj.alias, '::addReferences');
+            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.DataArray', fname);
         end
 
         function r = has_reference(obj, id_or_name)
-            r = nix_mx('Tag::hasReference', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasReference');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = remove_reference(obj, del)
-            r = nix.Utils.delete_entity(obj, del, ...
-                'nix.DataArray', 'Tag::removeReference');
+            fname = strcat(obj.alias, '::removeReference');
+            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
         end
 
         function r = open_reference(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, ...
-                'Tag::openReferenceDataArray', id_or_name, @nix.DataArray);
+            fname = strcat(obj.alias, '::openReferenceDataArray');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
         end
 
         function r = open_reference_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, ...
-                'Tag::openReferenceIdx', idx, @nix.DataArray);
+            fname = strcat(obj.alias, '::openReferenceIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
         end
 
         function r = retrieve_data(obj, id_or_name)
-            data = nix_mx('Tag::retrieveData', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::retrieveData');
+            data = nix_mx(fname, obj.nix_handle, id_or_name);
 
             % data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = retrieve_data_idx(obj, idx)
-            data = nix_mx('Tag::retrieveDataIdx', obj.nix_handle, idx);
+            fname = strcat(obj.alias, '::retrieveDataIdx');
+            data = nix_mx(fname, obj.nix_handle, idx);
             
             % data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = reference_count(obj)
-            r = nix_mx('Tag::referenceCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::referenceCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_references(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, ...
-                'Tag::referencesFiltered', @nix.DataArray);
+            fname = strcat(obj.alias, '::referencesFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
         end
 
         % ------------------
@@ -90,51 +95,61 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = add_feature(obj, add_this, link_type)
-            if(strcmp(class(add_this), 'nix.DataArray'))
+            if (strcmp(class(add_this), 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;
             end
-            r = nix.Feature(nix_mx('Tag::createFeature', ...
-                obj.nix_handle, addID, link_type));
+
+            fname = strcat(obj.alias, '::createFeature');
+            h = nix_mx(fname, obj.nix_handle, addID, link_type);
+            r = nix.Feature(h);
         end
 
         function r = has_feature(obj, id_or_name)
-            r = nix_mx('Tag::hasFeature', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::hasFeature');
+            r = nix_mx(fname, obj.nix_handle, id_or_name);
         end
 
         function r = remove_feature(obj, del)
-            r = nix.Utils.delete_entity(obj, del, 'nix.Feature', 'Tag::deleteFeature');
+            fname = strcat(obj.alias, '::deleteFeature');
+            r = nix.Utils.delete_entity(obj, del, 'nix.Feature', fname);
         end
 
         function r = open_feature(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'Tag::openFeature', id_or_name, @nix.Feature);
+            fname = strcat(obj.alias, '::openFeature');
+            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Feature);
         end
 
         function r = open_feature_idx(obj, idx)
-            r = nix.Utils.open_entity(obj, 'Tag::openFeatureIdx', idx, @nix.Feature);
+            fname = strcat(obj.alias, '::openFeatureIdx');
+            r = nix.Utils.open_entity(obj, fname, idx, @nix.Feature);
         end
 
         function r = retrieve_feature_data(obj, id_or_name)
-            data = nix_mx('Tag::featureRetrieveData', obj.nix_handle, id_or_name);
+            fname = strcat(obj.alias, '::featureRetrieveData');
+            data = nix_mx(fname, obj.nix_handle, id_or_name);
 
             % data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = retrieve_feature_data_idx(obj, idx)
-            data = nix_mx('Tag::featureRetrieveDataIdx', obj.nix_handle, idx);
+            fname = strcat(obj.alias, '::featureRetrieveDataIdx');
+            data = nix_mx(fname, obj.nix_handle, idx);
 
             % data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = feature_count(obj)
-            r = nix_mx('Tag::featureCount', obj.nix_handle);
+            fname = strcat(obj.alias, '::featureCount');
+            r = nix_mx(fname, obj.nix_handle);
         end
 
         function r = filter_features(obj, filter, val)
-            r = nix.Utils.filter(obj, filter, val, 'Tag::featuresFiltered', @nix.Feature);
+            fname = strcat(obj.alias, '::featuresFiltered');
+            r = nix.Utils.filter(obj, filter, val, fname, @nix.Feature);
         end
     end
 

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -7,143 +7,135 @@
 % LICENSE file in the root of the Project.
 
 classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    %Tag nix Tag object
+    % Tag nix Tag object
 
     properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'Tag'
     end
-    
+
     methods
         function obj = Tag(h)
             obj@nix.NamedEntity(h); % this should be first
             obj@nix.MetadataMixIn();
             obj@nix.SourcesMixIn();
-            
+
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'position', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'extent', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'units', 'rw');
-            
+
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'references', @nix.DataArray);
             nix.Dynamic.add_dyn_relation(obj, 'features', @nix.Feature);
-        end;
+        end
 
         % ------------------
         % References methods
         % ------------------
-        
+
         function [] = add_reference(obj, add_this)
-            nix.Utils.add_entity(obj, add_this, ...
-                'nix.DataArray', 'Tag::addReference');
-        end;
+            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', 'Tag::addReference');
+        end
 
         function [] = add_references(obj, add_cell_array)
             nix.Utils.add_entity_array(obj, add_cell_array, ...
                 'nix.DataArray', strcat(obj.alias, '::addReferences'));
         end
 
-        function hasRef = has_reference(obj, id_or_name)
-            hasRef = nix_mx('Tag::hasReference', obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = remove_reference(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
-                'nix.DataArray', 'Tag::removeReference');
-        end;
-
-        function retObj = open_reference(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Tag::openReferenceDataArray', id_or_name, @nix.DataArray);
-        end;
-
-        function retObj = open_reference_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Tag::openReferenceIdx', idx, @nix.DataArray);
-        end;
-
-        function data = retrieve_data(obj, id_or_name)
-            tmp = nix_mx('Tag::retrieveData', obj.nix_handle, id_or_name);
-
-            % data must agree with file & dimensions
-            % see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
-        end;
-
-        function data = retrieve_data_idx(obj, idx)
-            tmp = nix_mx('Tag::retrieveDataIdx', obj.nix_handle, idx);
-            
-            % data must agree with file & dimensions
-            % see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
-        end;
-
-        function c = reference_count(obj)
-            c = nix_mx('Tag::referenceCount', obj.nix_handle);
+        function r = has_reference(obj, id_or_name)
+            r = nix_mx('Tag::hasReference', obj.nix_handle, id_or_name);
         end
 
-        function filtered = filter_references(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
+        function r = remove_reference(obj, del)
+            r = nix.Utils.delete_entity(obj, del, ...
+                'nix.DataArray', 'Tag::removeReference');
+        end
+
+        function r = open_reference(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, ...
+                'Tag::openReferenceDataArray', id_or_name, @nix.DataArray);
+        end
+
+        function r = open_reference_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, ...
+                'Tag::openReferenceIdx', idx, @nix.DataArray);
+        end
+
+        function r = retrieve_data(obj, id_or_name)
+            data = nix_mx('Tag::retrieveData', obj.nix_handle, id_or_name);
+
+            % data must agree with file & dimensions; see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
+
+        function r = retrieve_data_idx(obj, idx)
+            data = nix_mx('Tag::retrieveDataIdx', obj.nix_handle, idx);
+            
+            % data must agree with file & dimensions; see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
+
+        function r = reference_count(obj)
+            r = nix_mx('Tag::referenceCount', obj.nix_handle);
+        end
+
+        function r = filter_references(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, ...
                 'Tag::referencesFiltered', @nix.DataArray);
         end
 
         % ------------------
         % Features methods
         % ------------------
-        
-        function retObj = add_feature(obj, add_this, link_type)
+
+        function r = add_feature(obj, add_this, link_type)
             if(strcmp(class(add_this), 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;
-            end;
-            retObj = nix.Feature(nix_mx('Tag::createFeature', ...
+            end
+            r = nix.Feature(nix_mx('Tag::createFeature', ...
                 obj.nix_handle, addID, link_type));
-        end;
-
-        function hasFeature = has_feature(obj, id_or_name)
-            hasFeature = nix_mx('Tag::hasFeature', obj.nix_handle, id_or_name);
-        end;
-        
-        function delCheck = remove_feature(obj, del)
-            delCheck = nix.Utils.delete_entity(obj, del, ...
-                'nix.Feature', 'Tag::deleteFeature');
-        end;
-
-        function retObj = open_feature(obj, id_or_name)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Tag::openFeature', id_or_name, @nix.Feature);
-        end;
-
-        function retObj = open_feature_idx(obj, idx)
-            retObj = nix.Utils.open_entity(obj, ...
-                'Tag::openFeatureIdx', idx, @nix.Feature);
-        end;
-
-        function data = retrieve_feature_data(obj, id_or_name)
-            tmp = nix_mx('Tag::featureRetrieveData', obj.nix_handle, id_or_name);
-
-            % data must agree with file & dimensions
-            % see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
         end
 
-        function data = retrieve_feature_data_idx(obj, idx)
-            tmp = nix_mx('Tag::featureRetrieveDataIdx', obj.nix_handle, idx);
-            
-            % data must agree with file & dimensions
-            % see mkarray.cc(42)
-            data = permute(tmp, length(size(tmp)):-1:1);
+        function r = has_feature(obj, id_or_name)
+            r = nix_mx('Tag::hasFeature', obj.nix_handle, id_or_name);
         end
 
-        function c = feature_count(obj)
-            c = nix_mx('Tag::featureCount', obj.nix_handle);
+        function r = remove_feature(obj, del)
+            r = nix.Utils.delete_entity(obj, del, 'nix.Feature', 'Tag::deleteFeature');
         end
 
-        function filtered = filter_features(obj, filter, val)
-            filtered = nix.Utils.filter(obj, filter, val, ...
-                'Tag::featuresFiltered', @nix.Feature);
+        function r = open_feature(obj, id_or_name)
+            r = nix.Utils.open_entity(obj, 'Tag::openFeature', id_or_name, @nix.Feature);
         end
-    end;
+
+        function r = open_feature_idx(obj, idx)
+            r = nix.Utils.open_entity(obj, 'Tag::openFeatureIdx', idx, @nix.Feature);
+        end
+
+        function r = retrieve_feature_data(obj, id_or_name)
+            data = nix_mx('Tag::featureRetrieveData', obj.nix_handle, id_or_name);
+
+            % data must agree with file & dimensions; see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
+
+        function r = retrieve_feature_data_idx(obj, idx)
+            data = nix_mx('Tag::featureRetrieveDataIdx', obj.nix_handle, idx);
+
+            % data must agree with file & dimensions; see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
+
+        function r = feature_count(obj)
+            r = nix_mx('Tag::featureCount', obj.nix_handle);
+        end
+
+        function r = filter_features(obj, filter, val)
+            r = nix.Utils.filter(obj, filter, val, 'Tag::featuresFiltered', @nix.Feature);
+        end
+    end
+
 end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -7,46 +7,47 @@
 % LICENSE file in the root of the Project.
 
 classdef Utils
+
     methods(Static)
 
-        function currData = fetchObjList(nixMxFunc, handle, objConstructor)
+        function rdata = fetchObjList(nixMxFunc, handle, objConstructor)
             currList = nix_mx(nixMxFunc, handle);
-            currData = cell(length(currList), 1);
+            rdata = cell(length(currList), 1);
             for i = 1:length(currList)
-                currData{i} = objConstructor(currList{i});
-            end;
-        end;
+                rdata{i} = objConstructor(currList{i});
+            end
+        end
 
         % This method calls the nix-mx function specified by 'nixMxFunc', handing 
         % over 'handle' as the main nix entity handle and 'related_handle' as a 
         % second nix entity handle related to the first one.
         % 'objConstrucor' requires the Matlab entity constructor of the expected 
         % returned nix Entities.
-        function currData = fetchObjListByEntity(nixMxFunc, handle, related_handle, objConstructor)
+        function rdata = fetchObjListByEntity(nixMxFunc, handle, related_handle, objConstructor)
             currList = nix_mx(nixMxFunc, handle, related_handle);
-            currData = cell(length(currList), 1);
+            rdata = cell(length(currList), 1);
             for i = 1:length(currList)
-                currData{i} = objConstructor(currList{i});
-            end;
-        end;
+                rdata{i} = objConstructor(currList{i});
+            end
+        end
 
-        function retCell = fetchObj(nixMxFunc, handle, objConstructor)
-            sh = nix_mx(nixMxFunc, handle);
-            if sh ~= 0
-                retCell = objConstructor(sh);
+        function rcell = fetchObj(nixMxFunc, handle, objConstructor)
+            h = nix_mx(nixMxFunc, handle);
+            if h ~= 0
+                rcell = objConstructor(h);
             else
-                retCell = {};
-            end;
-        end;
+                rcell = {};
+            end
+        end
 
         function [] = add_entity(obj, add_this, nixEntity, mxMethod)
             if(strcmp(class(add_this), nixEntity))
                 addID = add_this.id;
             else
                 addID = add_this;
-            end;
+            end
             nix_mx(mxMethod, obj.nix_handle, addID);
-        end;
+        end
 
         function [] = add_entity_array(obj, add_cell_array, nixEntity, mxMethod)
             if(~iscell(add_cell_array))
@@ -65,22 +66,22 @@ classdef Utils
         % Function can be used for both nix delete and remove methods.
         % The first actually removes the entity, the latter
         % removes only the reference to the entity.
-        function delCheck = delete_entity(obj, del, nixEntity, mxMethod)
+        function r = delete_entity(obj, del, nixEntity, mxMethod)
             if(strcmp(class(del), nixEntity))
                 delID = del.id;
             else
                 delID = del;
-            end;
-            delCheck = nix_mx(mxMethod, obj.nix_handle, delID);
-        end;
-        
-        function retObj = open_entity(obj, mxMethod, id_or_name, objConstructor)
+            end
+            r = nix_mx(mxMethod, obj.nix_handle, delID);
+        end
+
+        function r = open_entity(obj, mxMethod, id_or_name, objConstructor)
             handle = nix_mx(mxMethod, obj.nix_handle, id_or_name);
-            retObj = {};
+            r = {};
             if handle ~= 0
-                retObj = objConstructor(handle);
-            end;
-        end;
+                r = objConstructor(handle);
+            end
+        end
 
         % -----------------------------------------------------------
         % nix.Filter helper functions
@@ -101,24 +102,24 @@ classdef Utils
             end
         end
 
-        function currData = filter(obj, filter, val, mxMethod, objConstructor)
+        function rdata = filter(obj, filter, val, mxMethod, objConstructor)
             valid = nix.Utils.valid_filter(filter, val);
             if(~isempty(valid))
                 error(valid);
             end
 
             currList = nix_mx(mxMethod, obj.nix_handle, uint8(filter), val);
-            currData = cell(length(currList), 1);
+            rdata = cell(length(currList), 1);
             for i = 1:length(currList)
-                currData{i} = objConstructor(currList{i});
-            end;
+                rdata{i} = objConstructor(currList{i});
+            end
         end
 
         % -----------------------------------------------------------
         % findXXX helper functions
         % -----------------------------------------------------------
 
-        function currData = find(obj, max_depth, filter, val, ...
+        function rdata = find(obj, max_depth, filter, val, ...
                                                 mxMethod, objConstructor)
             if (~isnumeric(max_depth))
                 error('Provide a valid search depth');
@@ -132,11 +133,11 @@ classdef Utils
             currList = nix_mx(mxMethod, ...
                             obj.nix_handle, max_depth, uint8(filter), val);
 
-            currData = cell(length(currList), 1);
+            rdata = cell(length(currList), 1);
             for i = 1:length(currList)
-                currData{i} = objConstructor(currList{i});
-            end;
+                rdata{i} = objConstructor(currList{i});
+            end
         end
+    end
 
-    end;
 end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -31,12 +31,11 @@ classdef Utils
             end
         end
 
-        function rcell = fetchObj(nixMxFunc, handle, objConstructor)
+        function r = fetchObj(nixMxFunc, handle, objConstructor)
+            r = {};
             h = nix_mx(nixMxFunc, handle);
             if (h ~= 0)
-                rcell = objConstructor(h);
-            else
-                rcell = {};
+                r = objConstructor(h);
             end
         end
 

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -33,7 +33,7 @@ classdef Utils
 
         function rcell = fetchObj(nixMxFunc, handle, objConstructor)
             h = nix_mx(nixMxFunc, handle);
-            if h ~= 0
+            if (h ~= 0)
                 rcell = objConstructor(h);
             else
                 rcell = {};
@@ -41,7 +41,7 @@ classdef Utils
         end
 
         function [] = add_entity(obj, add_this, nixEntity, mxMethod)
-            if(strcmp(class(add_this), nixEntity))
+            if (strcmp(class(add_this), nixEntity))
                 addID = add_this.id;
             else
                 addID = add_this;
@@ -50,7 +50,7 @@ classdef Utils
         end
 
         function [] = add_entity_array(obj, add_cell_array, nixEntity, mxMethod)
-            if(~iscell(add_cell_array))
+            if (~iscell(add_cell_array))
                 error('Expected cell array');
             end
             handle_array = cell(1, length(add_cell_array));
@@ -67,7 +67,7 @@ classdef Utils
         % The first actually removes the entity, the latter
         % removes only the reference to the entity.
         function r = delete_entity(obj, del, nixEntity, mxMethod)
-            if(strcmp(class(del), nixEntity))
+            if (strcmp(class(del), nixEntity))
                 delID = del.id;
             else
                 delID = del;
@@ -104,7 +104,7 @@ classdef Utils
 
         function rdata = filter(obj, filter, val, mxMethod, objConstructor)
             valid = nix.Utils.valid_filter(filter, val);
-            if(~isempty(valid))
+            if (~isempty(valid))
                 error(valid);
             end
 
@@ -126,7 +126,7 @@ classdef Utils
             end
 
             valid = nix.Utils.valid_filter(filter, val);
-            if(~isempty(valid))
+            if (~isempty(valid))
                 error(valid);
             end
 

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -138,6 +138,15 @@ classdef Utils
                 rdata{i} = objConstructor(currList{i});
             end
         end
+
+        % -----------------------------------------------------------
+        % c++ to matlab array functions
+        % -----------------------------------------------------------
+
+        function r = transpose_array(data)
+        % Data must agree with file & dimensions; see mkarray.cc(42)
+            r = permute(data, length(size(data)):-1:1);
+        end
     end
 
 end


### PR DESCRIPTION
This PR is the first part of a series of cleanup and refactor steps to reduce code redundancy, increase readability and unify code style. Changes here all affect code on the Matlab side of the nix-mx bindings.

Style changes:
- Unify function return value names to `r` to increase readability.
- Function always returns an empty array when the C++ binding does not return a value.
- Cleanup semicolons after control structures.
- Cleanup whitespaces and function line breaks.

Reducing code redundancy:
- Consistently use entity alias in function calls to C++ to enable easy refactoring of entity alias, reduce redundancy and increase code readability. e.g. `'Block::groupCount'` -> `strcat(obj.alias, '::groupCount')`.
- Add `nix.Utils.transpose_array` function to reduce code redundancy. The function rearranges the C++ NIX DataArray dimensions to fit Matlab array requirements.
- Consistently use `nix.Utils.fetchObj`.
- Consistently use `nix.Utils.add_entity`.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).