### PR TITLE
Refactor and Cleanup, Part II

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -48,23 +48,19 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = get_group(obj, id_or_name)
-            fname = strcat(obj.alias, '::getGroup');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Group);
+            r = nix.Utils.open_entity(obj, 'getGroup', id_or_name, @nix.Group);
         end
 
         function r = open_group_idx(obj, idx)
-            fname = strcat(obj.alias, '::openGroupIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Group);
+            r = nix.Utils.open_entity(obj, 'openGroupIdx', idx, @nix.Group);
         end
 
-        function r = delete_group(obj, del)
-            fname = strcat(obj.alias, '::deleteGroup');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Group', fname);
+        function r = delete_group(obj, idNameEntity)
+            r = nix.Utils.delete_entity(obj, 'deleteGroup', idNameEntity, 'nix.Group');
         end
 
         function r = filter_groups(obj, filter, val)
-            fname = strcat(obj.alias, '::groupsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Group);
+            r = nix.Utils.filter(obj, 'groupsFiltered', filter, val, @nix.Group);
         end
 
         % -----------------
@@ -77,13 +73,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = data_array(obj, id_or_name)
-            fname = strcat(obj.alias, '::openDataArray');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openDataArray', id_or_name, @nix.DataArray);
         end
 
         function r = open_data_array_idx(obj, idx)
-            fname = strcat(obj.alias, '::openDataArrayIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
         function r = create_data_array(obj, name, nixtype, datatype, shape)
@@ -142,13 +136,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = delete_data_array(obj, del)
-            fname = strcat(obj.alias, '::deleteDataArray');
-            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteDataArray', del, 'nix.DataArray');
         end
 
         function r = filter_data_arrays(obj, filter, val)
-            fname = strcat(obj.alias, '::dataArraysFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
+            r = nix.Utils.filter(obj, 'dataArraysFiltered', filter, val, @nix.DataArray);
         end
 
         % -----------------
@@ -162,7 +154,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         function r = create_source(obj, name, type)
             fname = strcat(obj.alias, '::createSource');
-            r = nix.Source(nix_mx(fname, obj.nix_handle, name, type));
+            h = nix_mx(fname, obj.nix_handle, name, type);
+            r = nix.Utils.createEntity(h, @nix.Source);
         end
 
         function r = has_source(obj, id_or_name)
@@ -171,23 +164,19 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = delete_source(obj, del)
-            fname = strcat(obj.alias, '::deleteSource');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Source', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteSource', del, 'nix.Source');
         end
 
         function r = open_source(obj, id_or_name)
-            fname = strcat(obj.alias, '::openSource');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Source);
+            r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
         end
 
         function r = open_source_idx(obj, idx)
-            fname = strcat(obj.alias, '::openSourceIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Source);
+            r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = filter_sources(obj, filter, val)
-            fname = strcat(obj.alias, '::sourcesFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Source);
+            r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
 
         % maxdepth is an index
@@ -197,8 +186,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         % maxdepth is an index
         function r = find_filtered_sources(obj, max_depth, filter, val)
-            fname = strcat(obj.alias, '::findSources');
-            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Source);
+            r = nix.Utils.find(obj, 'findSources', max_depth, filter, val, @nix.Source);
         end
 
         % -----------------
@@ -216,13 +204,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = open_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::openTag');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Tag);
+            r = nix.Utils.open_entity(obj, 'openTag', id_or_name, @nix.Tag);
         end
 
         function r = open_tag_idx(obj, idx)
-            fname = strcat(obj.alias, '::openTagIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Tag);
+            r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
         function r = create_tag(obj, name, type, position)
@@ -232,13 +218,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = delete_tag(obj, del)
-            fname = strcat(obj.alias, '::deleteTag');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteTag', del, 'nix.Tag');
         end
 
         function r = filter_tags(obj, filter, val)
-            fname = strcat(obj.alias, '::tagsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Tag);
+            r = nix.Utils.filter(obj, 'tagsFiltered', filter, val, @nix.Tag);
         end
 
         % -----------------
@@ -256,13 +240,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = open_multi_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::openMultiTag');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.MultiTag);
+            r = nix.Utils.open_entity(obj, 'openMultiTag', id_or_name, @nix.MultiTag);
         end
 
         function r = open_multi_tag_idx(obj, idx)
-            fname = strcat(obj.alias, '::openMultiTagIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.MultiTag);
+            r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
         %-- Creating a multitag requires an already existing data array
@@ -274,13 +256,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = delete_multi_tag(obj, del)
-            fname = strcat(obj.alias, '::deleteMultiTag');
-            r = nix.Utils.delete_entity(obj, del, 'nix.MultiTag', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteMultiTag', del, 'nix.MultiTag');
         end
 
         function r = filter_multi_tags(obj, filter, val)
-            fname = strcat(obj.alias, '::multiTagsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.MultiTag);
+            r = nix.Utils.filter(obj, 'multiTagsFiltered', filter, val, @nix.MultiTag);
         end
     end
 

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -42,8 +42,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_group(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasGroup');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasGroup', id_or_name);
         end
 
         function r = get_group(obj, id_or_name)
@@ -129,8 +128,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_data_array(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasDataArray');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', id_or_name);
         end
 
         function r = delete_data_array(obj, del)
@@ -156,8 +154,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_source(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasSource');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasSource', id_or_name);
         end
 
         function r = delete_source(obj, del)
@@ -195,8 +192,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasTag');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasTag', id_or_name);
         end
 
         function r = open_tag(obj, id_or_name)
@@ -230,8 +226,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_multi_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasMultiTag');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', id_or_name);
         end
 
         function r = open_multi_tag(obj, id_or_name)

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -32,8 +32,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = group_count(obj)
-            fname = strcat(obj.alias, '::groupCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'groupCount');
         end
 
         function r = create_group(obj, name, nixtype)
@@ -68,8 +67,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = data_array_count(obj)
-            fname = strcat(obj.alias, '::dataArrayCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'dataArrayCount');
         end
 
         function r = data_array(obj, id_or_name)
@@ -148,8 +146,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = source_count(obj)
-            fname = strcat(obj.alias, '::sourceCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
         function r = create_source(obj, name, type)
@@ -194,8 +191,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = tag_count(obj)
-            fname = strcat(obj.alias, '::tagCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'tagCount');
         end
 
         function r = has_tag(obj, id_or_name)
@@ -230,8 +226,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = multi_tag_count(obj)
-            fname = strcat(obj.alias, '::multiTagCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'multiTagCount');
         end
 
         function r = has_multi_tag(obj, id_or_name)

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -267,15 +267,10 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         %-- Creating a multitag requires an already existing data array
         function r = create_multi_tag(obj, name, type, add_data_array)
-            if (isa(add_data_array, 'nix.DataArray'))
-                addID = add_data_array.id;
-            else
-                addID = add_data_array;
-            end
-
             fname = strcat(obj.alias, '::createMultiTag');
-            h = nix_mx(fname, obj.nix_handle, name, type, addID);
-            r = nix.MultiTag(h);
+            id = nix.Utils.parseEntityId(add_data_array, 'nix.DataArray');
+            h = nix_mx(fname, obj.nix_handle, name, type, id);
+            r = nix.Utils.createEntity(h, @nix.MultiTag);
         end
 
         function r = delete_multi_tag(obj, del)

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -267,7 +267,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         %-- Creating a multitag requires an already existing data array
         function r = create_multi_tag(obj, name, type, add_data_array)
-            if (strcmp(class(add_data_array), 'nix.DataArray'))
+            if (isa(add_data_array, 'nix.DataArray'))
                 addID = add_data_array.id;
             else
                 addID = add_data_array;

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -86,7 +86,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 shape(2:size(shape, 2));
             end
 
-            err.identifier = 'Block:unsupportedDataType';
+            err.identifier = 'NIXMX:UnsupportedDataType';
             if (~isa(datatype, 'nix.DataType'))
                 err.message = 'Please provide a valid nix.DataType';
                 error(err);
@@ -110,7 +110,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 shape = size(data, 2);
             end
 
-            err.identifier = 'Block:unsupportedDataType';
+            err.identifier = 'NIXMX:UnsupportedDataType';
             if (ischar(data))
                 err.message = 'Writing char/string DataArrays is currently not supported.';
                 error(err);

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -91,15 +91,15 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             %-- 1D data arrays created with this function.
             %-- e.g. size([1 2 3]) returns shape [1 3], which would not
             %-- be accepted when trying to add an alias range dimension.
-            if(shape(1) == 1)
+            if (shape(1) == 1)
                 shape(2:size(shape, 2));
             end
 
             errorStruct.identifier = 'Block:unsupportedDataType';
-            if(~isa(datatype, 'nix.DataType'))
+            if (~isa(datatype, 'nix.DataType'))
                 errorStruct.message = 'Please provide a valid nix.DataType';
                 error(errorStruct);
-            elseif(isequal(datatype, nix.DataType.String))
+            elseif (isequal(datatype, nix.DataType.String))
                 errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
                 error(errorStruct);
             else
@@ -115,17 +115,17 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             %-- 1D data arrays created with this function.
             %-- e.g. size([1 2 3]) returns shape [1 3], which would not
             %-- be accepted when trying to add an alias range dimension.
-            if(shape(1) == 1)
+            if (shape(1) == 1)
                 shape = size(data, 2);
             end
 
             errorStruct.identifier = 'Block:unsupportedDataType';
-            if(ischar(data))
+            if (ischar(data))
                 errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
                 error(errorStruct);
-            elseif(islogical(data))
+            elseif (islogical(data))
                 dtype = nix.DataType.Bool;
-            elseif(isnumeric(data))
+            elseif (isnumeric(data))
                 dtype = nix.DataType.Double;
             else
                 errorStruct.message = 'DataType of provided data is not supported.';
@@ -267,7 +267,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         %-- Creating a multitag requires an already existing data array
         function r = create_multi_tag(obj, name, type, add_data_array)
-            if(strcmp(class(add_data_array), 'nix.DataArray'))
+            if (strcmp(class(add_data_array), 'nix.DataArray'))
                 addID = add_data_array.id;
             else
                 addID = add_data_array;

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -39,7 +39,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function r = create_group(obj, name, nixtype)
             fname = strcat(obj.alias, '::createGroup');
             h = nix_mx(fname, obj.nix_handle, name, nixtype);
-            r = nix.Group(h);
+            r = nix.Utils.createEntity(h, @nix.Group);
         end
 
         function r = has_group(obj, id_or_name)
@@ -105,7 +105,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             else
                 fname = strcat(obj.alias, '::createDataArray');
                 h = nix_mx(fname, obj.nix_handle, name, nixtype, lower(datatype.char), shape);
-                r = nix.DataArray(h);
+                r = nix.Utils.createEntity(h, @nix.DataArray);
             end
         end
 
@@ -228,7 +228,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function r = create_tag(obj, name, type, position)
             fname = strcat(obj.alias, '::createTag');
             h = nix_mx(fname, obj.nix_handle, name, type, position);
-            r = nix.Tag(h);
+            r = nix.Utils.createEntity(h, @nix.Tag);
         end
 
         function r = delete_tag(obj, del)

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -95,13 +95,13 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 shape(2:size(shape, 2));
             end
 
-            errorStruct.identifier = 'Block:unsupportedDataType';
+            err.identifier = 'Block:unsupportedDataType';
             if (~isa(datatype, 'nix.DataType'))
-                errorStruct.message = 'Please provide a valid nix.DataType';
-                error(errorStruct);
+                err.message = 'Please provide a valid nix.DataType';
+                error(err);
             elseif (isequal(datatype, nix.DataType.String))
-                errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
-                error(errorStruct);
+                err.message = 'Writing char/string DataArrays is currently not supported.';
+                error(err);
             else
                 fname = strcat(obj.alias, '::createDataArray');
                 h = nix_mx(fname, obj.nix_handle, name, nixtype, lower(datatype.char), shape);
@@ -119,17 +119,17 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 shape = size(data, 2);
             end
 
-            errorStruct.identifier = 'Block:unsupportedDataType';
+            err.identifier = 'Block:unsupportedDataType';
             if (ischar(data))
-                errorStruct.message = 'Writing Strings to DataArrays is not supported as of yet.';
-                error(errorStruct);
+                err.message = 'Writing char/string DataArrays is currently not supported.';
+                error(err);
             elseif (islogical(data))
                 dtype = nix.DataType.Bool;
             elseif (isnumeric(data))
                 dtype = nix.DataType.Double;
             else
-                errorStruct.message = 'DataType of provided data is not supported.';
-                error(errorStruct);
+                err.message = 'DataType of provided data is not supported.';
+                error(err);
             end
 
             r = obj.create_data_array(name, nixtype, dtype, shape);

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -123,7 +123,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 disp('Warning: Writing Float data to an Integer DataArray');
             end
 
-            err.identifier = 'DataArray:improperDataType';
+            err.identifier = 'NIXMX:improperDataType';
             if (islogical(obj.read_all) && ~islogical(data))
                 m = sprintf('Trying to write %s to a logical DataArray', class(data));
                 err.message = m;
@@ -136,7 +136,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 %-- Should actually not be reachable at the moment, 
                 %-- since writing Strings to DataArrays is not supported,
                 %-- but safety first.
-                err.identifier = 'DataArray:unsupportedDataType';
+                err.identifier = 'NIXMX:unsupportedDataType';
                 err.message = 'Writing char/string DataArrays is currently not supported.';
                 error(err);
             end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -43,11 +43,14 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             for i = 1:length(currList)
                 switch currList(i).dtype
                     case 'set'
-                        dimensions{i} = nix.SetDimension(currList(i).dimension);
+                        dimensions{i} = nix.Utils.createEntity(currList(i).dimension, ...
+                            @nix.SetDimension);
                     case 'sample'
-                        dimensions{i} = nix.SampledDimension(currList(i).dimension);
+                        dimensions{i} = nix.Utils.createEntity(currList(i).dimension, ...
+                            @nix.SampledDimension);
                     case 'range'
-                        dimensions{i} = nix.RangeDimension(currList(i).dimension);
+                        dimensions{i} = nix.Utils.createEntity(currList(i).dimension, ...
+                            @nix.RangeDimension);
                     otherwise
                        disp('some dimension type is unknown! skip')
                 end
@@ -57,25 +60,25 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = append_set_dimension(obj)
             fname = strcat(obj.alias, '::appendSetDimension');
             h = nix_mx(fname, obj.nix_handle);
-            r = nix.SetDimension(h);
+            r = nix.Utils.createEntity(h, @nix.SetDimension);
         end
 
         function r = append_sampled_dimension(obj, interval)
             fname = strcat(obj.alias, '::appendSampledDimension');
             h = nix_mx(fname, obj.nix_handle, interval);
-            r = nix.SampledDimension(h);
+            r = nix.Utils.createEntity(h, @nix.SampledDimension);
         end
 
         function r = append_range_dimension(obj, ticks)
             fname = strcat(obj.alias, '::appendRangeDimension');
             h = nix_mx(fname, obj.nix_handle, ticks);
-            r = nix.RangeDimension(h);
+            r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
         function r = append_alias_range_dimension(obj)
             fname = strcat(obj.alias, '::appendAliasRangeDimension');
             h = nix_mx(fname, obj.nix_handle);
-            r = nix.RangeDimension(h);
+            r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
         function r = open_dimension_idx(obj, idx)
@@ -85,11 +88,11 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             dim = nix_mx(fname, obj.nix_handle, idx);
             switch (dim.dimension_type)
                 case 'set'
-                    r = nix.SetDimension(dim.handle);
+                    r = nix.Utils.createEntity(dim.handle, @nix.SetDimension);
                 case 'sampled'
-                    r = nix.SampledDimension(dim.handle);
+                    r = nix.Utils.createEntity(dim.handle, @nix.SampledDimension);
                 case 'range'
-                    r = nix.RangeDimension(dim.handle);
+                    r = nix.Utils.createEntity(dim.handle, @nix.RangeDimension);
             end
         end
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -121,27 +121,26 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 disp('Warning: Writing Float data to an Integer DataArray');
             end
 
-            errorStruct.identifier = 'DataArray:improperDataType';
+            err.identifier = 'DataArray:improperDataType';
             if (islogical(obj.read_all) && ~islogical(data))
-                errorStruct.message = strcat('Trying to write', ...
-                    32, class(data), ' to a logical DataArray.');
-                error(errorStruct);
+                m = sprintf('Trying to write %s to a logical DataArray', class(data));
+                err.message = m;
+                error(err);
             elseif (isnumeric(obj.read_all) && ~isnumeric(data))
-                errorStruct.message = strcat('Trying to write', ...
-                    32, class(data), ' to a ', 32, class(obj.read_all), ...
-                    ' DataArray.');
-                error(errorStruct);
+                m = sprintf('Trying to write %s to a %s DataArray', class(data), class(obj.read_all));
+                err.message = m;
+                error(err);
             elseif (ischar(data))
                 %-- Should actually not be reachable at the moment, 
                 %-- since writing Strings to DataArrays is not supported,
                 %-- but safety first.
-                errorStruct.identifier = 'DataArray:unsupportedDataType';
-                errorStruct.message = ('Writing char/string DataArrays is not supported as of yet.');
-                error(errorStruct);
-            else
-                fname = strcat(obj.alias, '::writeAll');
-                nix_mx(fname, obj.nix_handle, nix.Utils.transpose_array(data));
+                err.identifier = 'DataArray:unsupportedDataType';
+                err.message = 'Writing char/string DataArrays is currently not supported.';
+                error(err);
             end
+
+            fname = strcat(obj.alias, '::writeAll');
+            nix_mx(fname, obj.nix_handle, nix.Utils.transpose_array(data));
         end
 
         function r = datatype(obj)

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -160,8 +160,6 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function [] = set_data_extent(obj, extent)
             fname = strcat(obj.alias, '::setDataExtent');
             nix_mx(fname, obj.nix_handle, extent);
-            % update changed dataExtent in obj.info
-            obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
         end
     end
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -102,8 +102,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = dimension_count(obj)
-            fname = strcat(obj.alias, '::dimensionCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'dimensionCount');
         end
 
         % -----------------

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -14,7 +14,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         alias = 'DataArray'
     end
 
-    properties(Dependent)
+    properties (Dependent)
         dimensions % should not be dynamic due to complex set operation
     end
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -83,7 +83,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % instead of 0 compared to all other index functions.
             fname = strcat(obj.alias, '::openDimensionIdx');
             dim = nix_mx(fname, obj.nix_handle, idx);
-            switch(dim.dimension_type)
+            switch (dim.dimension_type)
                 case 'set'
                     r = nix.SetDimension(dim.handle);
                 case 'sampled'
@@ -117,21 +117,21 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         %-- If a DataArray has been created as boolean or numeric,
         %-- provide that only values of the proper DataType can be written.
         function [] = write_all(obj, data)
-            if(isinteger(obj.read_all) && isfloat(data))
+            if (isinteger(obj.read_all) && isfloat(data))
                 disp('Warning: Writing Float data to an Integer DataArray');
             end
 
             errorStruct.identifier = 'DataArray:improperDataType';
-            if(islogical(obj.read_all) && ~islogical(data))
+            if (islogical(obj.read_all) && ~islogical(data))
                 errorStruct.message = strcat('Trying to write', ...
                     32, class(data), ' to a logical DataArray.');
                 error(errorStruct);
-            elseif(isnumeric(obj.read_all) && ~isnumeric(data))
+            elseif (isnumeric(obj.read_all) && ~isnumeric(data))
                 errorStruct.message = strcat('Trying to write', ...
                     32, class(data), ' to a ', 32, class(obj.read_all), ...
                     ' DataArray.');
                 error(errorStruct);
-            elseif(ischar(data))
+            elseif (ischar(data))
                 %-- Should actually not be reachable at the moment, 
                 %-- since writing Strings to DataArrays is not supported,
                 %-- but safety first.

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -25,9 +25,8 @@ classdef Dynamic
 
             function set_method(obj, val)
                 if (strcmp(mode, 'r'))
-                    ME = MException('MATLAB:class:SetProhibited', sprintf(...
-                      'You cannot set the read-only property ''%s'' of %s', ...
-                      prop, class(obj)));
+                    msg = 'You cannot set the read-only property ''%s'' of %s';
+                    ME = MException('MATLAB:class:SetProhibited', msg, prop, class(obj));
                     throwAsCaller(ME);
                 end
 
@@ -37,8 +36,8 @@ classdef Dynamic
                 elseif ((strcmp(prop, 'units') || strcmp(prop, 'labels')) && (~iscell(val)))
                 %-- BUGFIX: Matlab crashes, if units in Tags and MultiTags
                 %-- or labels of SetDimension are set using anything else than a cell.
-                    ME = MException('MATLAB:class:SetProhibited', sprintf(...
-                      'This value only supports cells.'));
+                    msg = 'This value only supports cells.';
+                    ME = MException('MATLAB:class:SetProhibited', msg);
                     throwAsCaller(ME);
                 else
                     fname = strcat(obj.alias, '::set', upper(prop(1)), prop(2:end));

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -67,9 +67,7 @@ classdef Dynamic
             rel_map.Hidden = true;
 
             function val = get_method(obj)
-                obj.(dataAttr) = nix.Utils.fetchObjList(...
-                    strcat(obj.alias, '::', name), obj.nix_handle, ...
-                    constructor);
+                obj.(dataAttr) = nix.Utils.fetchObjList(obj, name, constructor);
                 val = obj.(dataAttr);
             end
 

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -12,7 +12,7 @@ classdef Dynamic
 
     methods (Static)
         function add_dyn_attr(obj, prop, mode)
-            if nargin < 3
+            if (nargin < 3)
                 mode = 'r'; 
             end
 
@@ -24,7 +24,7 @@ classdef Dynamic
             p.SetMethod = @set_method;
 
             function set_method(obj, val)
-                if strcmp(mode, 'r')
+                if (strcmp(mode, 'r'))
                     ME = MException('MATLAB:class:SetProhibited', sprintf(...
                       'You cannot set the read-only property ''%s'' of %s', ...
                       prop, class(obj)));
@@ -34,7 +34,7 @@ classdef Dynamic
                 if (isempty(val))
                     fname = strcat(obj.alias, '::setNone', upper(prop(1)), prop(2:end));
                     nix_mx(fname, obj.nix_handle, 0);
-                elseif((strcmp(prop, 'units') || strcmp(prop, 'labels')) && (~iscell(val)))
+                elseif ((strcmp(prop, 'units') || strcmp(prop, 'labels')) && (~iscell(val)))
                 %-- BUGFIX: Matlab crashes, if units in Tags and MultiTags
                 %-- or labels of SetDimension are set using anything else than a cell.
                     ME = MException('MATLAB:class:SetProhibited', sprintf(...
@@ -78,7 +78,7 @@ classdef Dynamic
                 val = containers.Map();
                 props = obj.(name);
 
-                for i=1:length(props)
+                for i = 1:length(props)
                     val(props{i}.name) = cell2mat(props{i}.values);
                 end
             end

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -44,7 +44,6 @@ classdef Dynamic
                     fname = strcat(obj.alias, '::set', upper(prop(1)), prop(2:end));
                     nix_mx(fname, obj.nix_handle, val);
                 end
-                obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
             end
 
             function val = get_method(obj)

--- a/+nix/Entity.m
+++ b/+nix/Entity.m
@@ -12,6 +12,9 @@ classdef Entity < dynamicprops
 
     properties (Hidden)
         nix_handle
+    end
+
+    properties (SetAccess=private, GetAccess=public, Hidden)
         info
     end
 
@@ -22,9 +25,6 @@ classdef Entity < dynamicprops
     methods
         function obj = Entity(h)
             obj.nix_handle = h;
-
-            % fetch all object attrs
-            obj.info = nix_mx(strcat(obj.alias, '::describe'), obj.nix_handle);
         end
 
         function [] = delete(obj)
@@ -33,6 +33,11 @@ classdef Entity < dynamicprops
 
         function r = updatedAt(obj)
             r = nix_mx('Entity::updatedAt', obj.nix_handle);
+        end
+
+        function r = get.info(obj)
+            fname = strcat(obj.alias, '::describe');
+            r = nix_mx(fname, obj.nix_handle);
         end
     end
 

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -45,7 +45,7 @@ classdef Feature < nix.Entity
         end
 
         function [] = set_data(obj, setData)
-            if(strcmp(class(setData), 'nix.DataArray'))
+            if (strcmp(class(setData), 'nix.DataArray'))
                 setData = setData.id;
             end
             fname = strcat(obj.alias, '::setData');

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -41,7 +41,7 @@ classdef Feature < nix.Entity
         function r = open_data(obj)
             fname = strcat(obj.alias, '::openData');
             h = nix_mx(fname, obj.nix_handle);
-            r = nix.DataArray(h);
+            r = nix.Utils.createEntity(h, @nix.DataArray);
         end
 
         function [] = set_data(obj, setData)

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -14,7 +14,7 @@ classdef Feature < nix.Entity
         alias = 'Feature'
     end
 
-    properties(Dependent)
+    properties (Dependent)
         id
         linkType
     end
@@ -45,7 +45,7 @@ classdef Feature < nix.Entity
         end
 
         function [] = set_data(obj, setData)
-            if (strcmp(class(setData), 'nix.DataArray'))
+            if (isa(setData, 'nix.DataArray'))
                 setData = setData.id;
             end
             fname = strcat(obj.alias, '::setData');

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -45,11 +45,9 @@ classdef Feature < nix.Entity
         end
 
         function [] = set_data(obj, setData)
-            if (isa(setData, 'nix.DataArray'))
-                setData = setData.id;
-            end
+            id = nix.Utils.parseEntityId(setData, 'nix.DataArray');
             fname = strcat(obj.alias, '::setData');
-            nix_mx(fname, obj.nix_handle, setData);
+            nix_mx(fname, obj.nix_handle, id);
         end
     end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -54,8 +54,7 @@ classdef File < nix.Entity
         end
 
         function r = block_count(obj)
-            fname = strcat(obj.alias, '::blockCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'blockCount');
         end
 
         function r = has_block(obj, id_or_name)
@@ -90,8 +89,7 @@ classdef File < nix.Entity
         end
 
         function r = section_count(obj)
-            fname = strcat(obj.alias, '::sectionCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
         function r = has_section(obj, id_or_name)

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -50,7 +50,7 @@ classdef File < nix.Entity
         function r = create_block(obj, name, type)
             fname = strcat(obj.alias, '::createBlock');
             h = nix_mx(fname, obj.nix_handle, name, type);
-            r = nix.Block(h);
+            r = nix.Utils.createEntity(h, @nix.Block);
         end
 
         function r = block_count(obj)
@@ -90,7 +90,7 @@ classdef File < nix.Entity
         function r = create_section(obj, name, type)
             fname = strcat(obj.alias, '::createSection');
             h = nix_mx(fname, obj.nix_handle, name, type);
-            r = nix.Section(h);
+            r = nix.Utils.createEntity(h, @nix.Section);
         end
 
         function r = section_count(obj)

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -58,8 +58,7 @@ classdef File < nix.Entity
         end
 
         function r = has_block(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasBlock');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasBlock', id_or_name);
         end
 
         function r = open_block(obj, id_or_name)
@@ -93,8 +92,7 @@ classdef File < nix.Entity
         end
 
         function r = has_section(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasSection');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasSection', id_or_name);
         end
 
         function r = open_section(obj, id_or_name)

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -16,7 +16,7 @@ classdef File < nix.Entity
 
     methods
         function obj = File(path, mode)
-            if ~exist('mode', 'var')
+            if (~exist('mode', 'var'))
                 mode = nix.FileMode.ReadWrite; %default to ReadWrite
             end
             h = nix_mx('File::open', path, mode); 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -64,23 +64,19 @@ classdef File < nix.Entity
         end
 
         function r = open_block(obj, id_or_name)
-            fname = strcat(obj.alias, '::openBlock');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Block);
+            r = nix.Utils.open_entity(obj, 'openBlock', id_or_name, @nix.Block);
         end
 
         function r = open_block_idx(obj, idx)
-            fname = strcat(obj.alias, '::openBlockIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Block);
+            r = nix.Utils.open_entity(obj, 'openBlockIdx', idx, @nix.Block);
         end
 
         function r = delete_block(obj, del)
-            fname = strcat(obj.alias, '::deleteBlock');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Block', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteBlock', del, 'nix.Block');
         end
 
         function r = filter_blocks(obj, filter, val)
-            fname = strcat(obj.alias, '::blocksFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Block);
+            r = nix.Utils.filter(obj, 'blocksFiltered', filter, val, @nix.Block);
         end
 
         % ----------------
@@ -104,23 +100,19 @@ classdef File < nix.Entity
         end
 
         function r = open_section(obj, id_or_name)
-            fname = strcat(obj.alias, '::openSection');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Section);
+            r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
         end
 
         function r = open_section_idx(obj, idx)
-            fname = strcat(obj.alias, '::openSectionIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Section);
+            r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
         function r = delete_section(obj, del)
-            fname = strcat(obj.alias, '::deleteSection');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Section', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteSection', del, 'nix.Section');
         end
 
         function r = filter_sections(obj, filter, val)
-            fname = strcat(obj.alias, '::sectionsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Section);
+            r = nix.Utils.filter(obj, 'sectionsFiltered', filter, val, @nix.Section);
         end
 
         % maxdepth is an index
@@ -130,8 +122,7 @@ classdef File < nix.Entity
 
         % maxdepth is an index
         function r = find_filtered_sections(obj, max_depth, filter, val)
-            fname = strcat(obj.alias, '::findSections');
-            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Section);
+            r = nix.Utils.find(obj, 'findSections', max_depth, filter, val, @nix.Section);
         end
     end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -25,8 +25,6 @@ classdef File < nix.Entity
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'blocks', @nix.Block);
             nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
-
-            obj.info = nix_mx('File::describe', obj.nix_handle);
         end
 
         % braindead...

--- a/+nix/FileMode.m
+++ b/+nix/FileMode.m
@@ -10,9 +10,9 @@ classdef FileMode
     % FILEMODE nix file open modes
 
     properties (Constant)
-        ReadOnly = uint8(0)
-        ReadWrite = uint8(1)
-        Overwrite = uint8(2)
+        ReadOnly = uint8(0);
+        ReadWrite = uint8(1);
+        Overwrite = uint8(2);
     end
 
 end

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -31,8 +31,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function r = data_array_count(obj)
-            fname = strcat(obj.alias, '::dataArrayCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'dataArrayCount');
         end
 
         function r = has_data_array(obj, id_or_name)
@@ -94,8 +93,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = tag_count(obj)
-            fname = strcat(obj.alias, '::tagCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'tagCount');
         end
 
         function r = filter_tags(obj, filter, val)
@@ -132,8 +130,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = multi_tag_count(obj)
-            fname = strcat(obj.alias, '::multiTagCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'multiTagCount');
         end
 
         function r = filter_multi_tags(obj, filter, val)

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -41,33 +41,27 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = get_data_array(obj, id_or_name)
-            fname = strcat(obj.alias, '::getDataArray');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'getDataArray', id_or_name, @nix.DataArray);
         end
 
         function r = open_data_array_idx(obj, idx)
-            fname = strcat(obj.alias, '::openDataArrayIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
         function [] = add_data_array(obj, add_this)
-            fname = strcat(obj.alias, '::addDataArray');
-            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
+            nix.Utils.add_entity(obj, 'addDataArray', add_this, 'nix.DataArray');
         end
 
         function [] = add_data_arrays(obj, add_cell_array)
-            fname = strcat(obj.alias, '::addDataArrays');
-            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.DataArray', fname);
+            nix.Utils.add_entity_array(obj, 'addDataArrays', add_cell_array, 'nix.DataArray');
         end
 
         function r = remove_data_array(obj, del)
-            fname = strcat(obj.alias, '::removeDataArray');
-            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
+            r = nix.Utils.delete_entity(obj, 'removeDataArray', del, 'nix.DataArray');
         end
 
         function r = filter_data_arrays(obj, filter, val)
-            fname = strcat(obj.alias, '::dataArraysFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
+            r = nix.Utils.filter(obj, 'dataArraysFiltered', filter, val, @nix.DataArray);
         end
 
         % -----------------
@@ -75,13 +69,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = add_tag(obj, add_this)
-            fname = strcat(obj.alias, '::addTag');
-            nix.Utils.add_entity(obj, add_this, 'nix.Tag', fname);
+            nix.Utils.add_entity(obj, 'addTag', add_this, 'nix.Tag');
         end
 
         function [] = add_tags(obj, add_cell_array)
-            fname = strcat(obj.alias, '::addTags');
-            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.Tag', fname);
+            nix.Utils.add_entity_array(obj, 'addTags', add_cell_array, 'nix.Tag');
         end
 
         function r = has_tag(obj, id_or_name)
@@ -90,18 +82,15 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = get_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::getTag');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Tag);
+            r = nix.Utils.open_entity(obj, 'getTag', id_or_name, @nix.Tag);
         end
 
         function r = open_tag_idx(obj, idx)
-            fname = strcat(obj.alias, '::openTagIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Tag);
+            r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
         function r = remove_tag(obj, del)
-            fname = strcat(obj.alias, '::removeTag');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Tag', fname);
+            r = nix.Utils.delete_entity(obj, 'removeTag', del, 'nix.Tag');
         end
 
         function r = tag_count(obj)
@@ -110,8 +99,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = filter_tags(obj, filter, val)
-            fname = strcat(obj.alias, '::tagsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Tag);
+            r = nix.Utils.filter(obj, 'tagsFiltered', filter, val, @nix.Tag);
         end
 
         % -----------------
@@ -119,13 +107,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = add_multi_tag(obj, add_this)
-            fname = strcat(obj.alias, '::addMultiTag');
-            nix.Utils.add_entity(obj, add_this, 'nix.MultiTag', fname);
+            nix.Utils.add_entity(obj, 'addMultiTag', add_this, 'nix.MultiTag');
         end
 
         function [] = add_multi_tags(obj, add_cell_array)
-            fname = strcat(obj.alias, '::addMultiTags');
-            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.MultiTag', fname);
+            nix.Utils.add_entity_array(obj, 'addMultiTags', add_cell_array, 'nix.MultiTag');
         end
 
         function r = has_multi_tag(obj, id_or_name)
@@ -134,18 +120,15 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = get_multi_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::getMultiTag');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.MultiTag);
+            r = nix.Utils.open_entity(obj, 'getMultiTag', id_or_name, @nix.MultiTag);
         end
 
         function r = open_multi_tag_idx(obj, idx)
-            fname = strcat(obj.alias, '::openMultiTagIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.MultiTag);
+            r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
         function r = remove_multi_tag(obj, del)
-            fname = strcat(obj.alias, '::removeMultiTag');
-            r = nix.Utils.delete_entity(obj, del, 'nix.MultiTag', fname);
+            r = nix.Utils.delete_entity(obj, 'removeMultiTag', del, 'nix.MultiTag');
         end
 
         function r = multi_tag_count(obj)
@@ -154,8 +137,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = filter_multi_tags(obj, filter, val)
-            fname = strcat(obj.alias, '::multiTagsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.MultiTag);
+            r = nix.Utils.filter(obj, 'multiTagsFiltered', filter, val, @nix.MultiTag);
         end
     end
 

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -35,8 +35,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_data_array(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasDataArray');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', id_or_name);
         end
 
         function r = get_data_array(obj, id_or_name)
@@ -76,8 +75,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasTag');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasTag', id_or_name);
         end
 
         function r = get_tag(obj, id_or_name)
@@ -113,8 +111,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_multi_tag(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasMultiTag');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', id_or_name);
         end
 
         function r = get_multi_tag(obj, id_or_name)

--- a/+nix/LinkType.m
+++ b/+nix/LinkType.m
@@ -10,9 +10,9 @@ classdef LinkType
     % LINKTYPE nix link types
 
     properties (Constant)
-        Tagged = uint8(0)
-        Untagged = uint8(1)
-        Indexed = uint8(2)
+        Tagged = uint8(0);
+        Untagged = uint8(1);
+        Indexed = uint8(2);
     end
 
 end

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -18,8 +18,7 @@ classdef MetadataMixIn < handle
 
     methods
         function r = open_metadata(obj)
-            fname = strcat(obj.alias, '::openMetadataSection');
-            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Section);
+            r = nix.Utils.fetchObj(obj, 'openMetadataSection', @nix.Section);
         end
 
         function [] = set_metadata(obj, val)
@@ -27,8 +26,7 @@ classdef MetadataMixIn < handle
                 fname = strcat(obj.alias, '::setNoneMetadata');
                 nix_mx(fname, obj.nix_handle, val);
             else
-                fname = strcat(obj.alias, '::setMetadata');
-                nix.Utils.add_entity(obj, val, 'nix.Section', fname);
+                nix.Utils.add_entity(obj, 'setMetadata', val, 'nix.Section');
             end
         end
     end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -33,13 +33,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function [] = add_reference(obj, add_this)
-            fname = strcat(obj.alias, '::addReference');
-            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
+            nix.Utils.add_entity(obj, 'addReference', add_this, 'nix.DataArray');
         end
 
         function [] = add_references(obj, add_cell_array)
-            fname = strcat(obj.alias, '::addReferences');
-            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.DataArray', fname);
+            nix.Utils.add_entity_array(obj, 'addReferences', add_cell_array, 'nix.DataArray');
         end
 
         function r = has_reference(obj, id_or_name)
@@ -48,18 +46,15 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = remove_reference(obj, del)
-            fname = strcat(obj.alias, '::removeReference');
-            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
+            r = nix.Utils.delete_entity(obj, 'removeReference', del, 'nix.DataArray');
         end
 
         function r = open_reference(obj, id_or_name)
-            fname = strcat(obj.alias, '::openReferences');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openReferences', id_or_name, @nix.DataArray);
         end
 
         function r = open_reference_idx(obj, idx)
-            fname = strcat(obj.alias, '::openReferenceIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
         function r = retrieve_data(obj, pos_idx, id_or_name)
@@ -80,8 +75,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = filter_references(obj, filter, val)
-            fname = strcat(obj.alias, '::referencesFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
+            r = nix.Utils.filter(obj, 'referencesFiltered', filter, val, @nix.DataArray);
         end
 
         % ------------------
@@ -101,18 +95,15 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = remove_feature(obj, del)
-            fname = strcat(obj.alias, '::deleteFeature');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Feature', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteFeature', del, 'nix.Feature');
         end
 
         function r = open_feature(obj, id_or_name)
-            fname = strcat(obj.alias, '::openFeature');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Feature);
+            r = nix.Utils.open_entity(obj, 'openFeature', id_or_name, @nix.Feature);
         end
 
         function r = open_feature_idx(obj, idx)
-            fname = strcat(obj.alias, '::openFeatureIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Feature);
+            r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
         function r = retrieve_feature_data(obj, pos_idx, id_or_name)
@@ -133,8 +124,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = filter_features(obj, filter, val)
-            fname = strcat(obj.alias, '::featuresFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Feature);
+            r = nix.Utils.filter(obj, 'featuresFiltered', filter, val, @nix.Feature);
         end
 
         % ------------------
@@ -147,13 +137,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = open_positions(obj)
-            fname = strcat(obj.alias, '::openPositions');
-            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.DataArray);
+            r = nix.Utils.fetchObj(obj, 'openPositions', @nix.DataArray);
         end
 
         function [] = add_positions(obj, add_this)
-            fname = strcat(obj.alias, '::addPositions');
-            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
+            nix.Utils.add_entity(obj, 'addPositions', add_this, 'nix.DataArray');
         end
 
         % ------------------
@@ -161,8 +149,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = open_extents(obj)
-            fname = strcat(obj.alias, '::openExtents');
-            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.DataArray);
+            r = nix.Utils.fetchObj(obj, 'openExtents', @nix.DataArray);
         end
 
         function [] = set_extents(obj, add_this)
@@ -170,8 +157,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 fname = strcat(obj.alias, '::setNoneExtents');
                 nix_mx(fname, obj.nix_handle, 0);
             else
-                fname = strcat(obj.alias, '::setExtents');
-                nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
+                nix.Utils.add_entity(obj, 'setExtents', add_this, 'nix.DataArray');
             end
         end
     end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -70,8 +70,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = reference_count(obj)
-            fname = strcat(obj.alias, '::referenceCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'referenceCount');
         end
 
         function r = filter_references(obj, filter, val)
@@ -119,8 +118,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = feature_count(obj)
-            fname = strcat(obj.alias, '::featureCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'featureCount');
         end
 
         function r = filter_features(obj, filter, val)

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -97,11 +97,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
             fname = strcat(obj.alias, '::createFeature');
             h = nix_mx(fname, obj.nix_handle, addID, link_type);
-
-            r = {};
-            if (h ~= 0)
-                r = nix.Feature(h);
-            end
+            r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
         function r = has_feature(obj, id_or_name)

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -89,7 +89,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = add_feature(obj, add_this, link_type)
-            if (strcmp(class(add_this), 'nix.DataArray'))
+            if (isa(add_this, 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -41,8 +41,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_reference(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasReference');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasReference', id_or_name);
         end
 
         function r = remove_reference(obj, del)
@@ -89,8 +88,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_feature(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasFeature');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', id_or_name);
         end
 
         function r = remove_feature(obj, del)

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -89,7 +89,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = add_feature(obj, add_this, link_type)
-            if(strcmp(class(add_this), 'nix.DataArray'))
+            if (strcmp(class(add_this), 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;
@@ -175,7 +175,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function [] = set_extents(obj, add_this)
-            if(isempty(add_this))
+            if (isempty(add_this))
                 fname = strcat(obj.alias, '::setNoneExtents');
                 nix_mx(fname, obj.nix_handle, 0);
             else

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -89,14 +89,9 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = add_feature(obj, add_this, link_type)
-            if (isa(add_this, 'nix.DataArray'))
-                addID = add_this.id;
-            else
-                addID = add_this;
-            end
-
+            addId = nix.Utils.parseEntityId(add_this, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nix_handle, addID, link_type);
+            h = nix_mx(fname, obj.nix_handle, addId, link_type);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -24,7 +24,7 @@ classdef NamedEntity < nix.Entity
         function r = compare(obj, entity)
         % Compares first name and second id, return > 0 if the entity 
         % is larger than the other, 0 if both are equal, and < 0 otherwise.
-            if(~strcmp(class(obj), class(entity)))
+            if (~strcmp(class(obj), class(entity)))
                 error('Only entities of the same class can be compared.');
             end
             fname = strcat(obj.alias, '::compare');

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -24,7 +24,7 @@ classdef NamedEntity < nix.Entity
         function r = compare(obj, entity)
         % Compares first name and second id, return > 0 if the entity 
         % is larger than the other, 0 if both are equal, and < 0 otherwise.
-            if (~strcmp(class(obj), class(entity)))
+            if (~isa(obj, class(entity)))
                 error('Only entities of the same class can be compared.');
             end
             fname = strcat(obj.alias, '::compare');

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -25,7 +25,9 @@ classdef NamedEntity < nix.Entity
         % Compares first name and second id, return > 0 if the entity 
         % is larger than the other, 0 if both are equal, and < 0 otherwise.
             if (~isa(obj, class(entity)))
-                error('Only entities of the same class can be compared.');
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Only entities of the same class can be compared.';
+                error(err);
             end
             fname = strcat(obj.alias, '::compare');
             r = nix_mx(fname, obj.nix_handle, entity.nix_handle);

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -10,12 +10,12 @@ classdef Property < nix.NamedEntity
     % PROPERTY Metadata Property class
     %   NIX metadata property
 
-    properties(Hidden)
+    properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'Property'
     end
 
-    properties(Dependent)
+    properties (Dependent)
         values
     end
 
@@ -69,7 +69,7 @@ classdef Property < nix.NamedEntity
         % return value 0 means name and id of two properties are
         % identical, any other value means either name or id differ.
         function r = compare(obj, property)
-            if (~strcmp(class(property), class(obj)))
+            if (~isa(property, class(obj)))
                error('Function only supports comparison of Properties.');
             end
 

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -48,7 +48,9 @@ classdef Property < nix.NamedEntity
                 end
 
                 if (~strcmpi(class(curr), obj.datatype))
-                    error('Values do not match property data type!');
+                    err.identifier = 'NIXMX:InvalidArgument';
+                    err.message = sprintf('Value #%d does not match property data type', i);
+                    error(err);
                 end
             end
 

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -57,8 +57,7 @@ classdef Property < nix.NamedEntity
         end
 
         function r = value_count(obj)
-            fname = strcat(obj.alias, '::valueCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'valueCount');
         end
 
         function [] = values_delete(obj)

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -65,17 +65,6 @@ classdef Property < nix.NamedEntity
             fname = strcat(obj.alias, '::deleteValues');
             nix_mx(fname, obj.nix_handle);
         end
-
-        % return value 0 means name and id of two properties are
-        % identical, any other value means either name or id differ.
-        function r = compare(obj, property)
-            if (~isa(property, class(obj)))
-               error('Function only supports comparison of Properties.');
-            end
-
-            fname = strcat(obj.alias, '::compare');
-            r = nix_mx(fname, obj.nix_handle, property.nix_handle);
-        end
     end
 
 end

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -27,7 +27,7 @@ classdef RangeDimension < nix.Entity
         end
 
         function r = tick_at(obj, index)
-            if index > 0
+            if (index > 0)
                 index = index - 1;
             end
             fname = strcat(obj.alias, '::tickAt');
@@ -40,11 +40,11 @@ classdef RangeDimension < nix.Entity
         end
 
         function r = axis(obj, count, startIndex)
-            if nargin < 3
+            if (nargin < 3)
                 startIndex = 0;
             end
 
-            if(startIndex > 0)
+            if (startIndex > 0)
                 startIndex = startIndex - 1;
             end
 

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -32,7 +32,7 @@ classdef SampledDimension < nix.Entity
         end
 
         function r = position_at(obj, index)
-            if index > 0
+            if (index > 0)
                 index = index - 1;
             end
 
@@ -41,11 +41,11 @@ classdef SampledDimension < nix.Entity
         end
 
         function r = axis(obj, count, startIndex)
-            if nargin < 3
+            if (nargin < 3)
                 startIndex = 0;
             end
 
-            if startIndex > 0
+            if (startIndex > 0)
                 startIndex = startIndex - 1;
             end
 

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -76,8 +76,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = has_section(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasSection');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasSection', id_or_name);
         end
 
         function r = section_count(obj)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -142,15 +142,13 @@ classdef Section < nix.NamedEntity
 
         function r = delete_property(obj, del)
             if (isstruct(del) && isfield(del, 'id'))
-                delID = del.id;
-            elseif (isa(del, 'nix.Property'))
-                delID = del.id;
+                id = del.id;
             else
-                delID = del;
+                id = nix.Utils.parseEntityId(del, 'nix.Property');
             end
 
             fname = strcat(obj.alias, '::deleteProperty');
-            r = nix_mx(fname, obj.nix_handle, delID);
+            r = nix_mx(fname, obj.nix_handle, id);
         end
 
         function r = open_property(obj, id_or_name)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -29,8 +29,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = parent(obj)
-            fname = strcat(obj.alias, '::parent');
-            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Section);
+            r = nix.Utils.fetchObj(obj, 'parent', @nix.Section);
         end
 
         % ----------------
@@ -42,19 +41,16 @@ classdef Section < nix.NamedEntity
                 fname = strcat(obj.alias, '::setNoneLink');
                 nix_mx(fname, obj.nix_handle);
             else
-                fname = strcat(obj.alias, '::setLink');
-                nix.Utils.add_entity(obj, val, 'nix.Section', fname);
+                nix.Utils.add_entity(obj, 'setLink', val, 'nix.Section');
             end
         end
 
         function r = openLink(obj)
-            fname = strcat(obj.alias, '::openLink');
-            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Section);
+            r = nix.Utils.fetchObj(obj, 'openLink', @nix.Section);
         end
 
         function r = inherited_properties(obj)
-            fname = strcat(obj.alias, '::inheritedProperties');
-            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.Property);
+            r = nix.Utils.fetchObjList(obj, 'inheritedProperties', @nix.Property);
         end
 
         % ----------------
@@ -68,18 +64,15 @@ classdef Section < nix.NamedEntity
         end
 
         function r = delete_section(obj, del)
-            fname = strcat(obj.alias, '::deleteSection');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Section', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteSection', del, 'nix.Section');
         end
 
         function r = open_section(obj, id_or_name)
-            fname = strcat(obj.alias, '::openSection');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Section);
+            r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
         end
 
         function r = open_section_idx(obj, idx)
-            fname = strcat(obj.alias, '::openSectionIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Section);
+            r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
         function r = has_section(obj, id_or_name)
@@ -93,8 +86,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = filter_sections(obj, filter, val)
-            fname = strcat(obj.alias, '::sectionsFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Section);
+            r = nix.Utils.filter(obj, 'sectionsFiltered', filter, val, @nix.Section);
         end
 
         % find_related returns the nearest occurrence downstream of a
@@ -102,8 +94,7 @@ classdef Section < nix.NamedEntity
         % If no section can be found downstream, it will look for the
         % nearest occurrence upstream of a nix.Section matching the filter.
         function r = find_related(obj, filter, val)
-            fname = strcat(obj.alias, '::findRelated');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Section);
+            r = nix.Utils.filter(obj, 'findRelated', filter, val, @nix.Section);
         end
 
         % maxdepth is an index
@@ -113,8 +104,7 @@ classdef Section < nix.NamedEntity
 
         % maxdepth is an index
         function r = find_filtered_sections(obj, max_depth, filter, val)
-            fname = strcat(obj.alias, '::findSections');
-            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Section);
+            r = nix.Utils.find(obj, 'findSections', max_depth, filter, val, @nix.Section);
         end
 
         % ----------------
@@ -152,13 +142,11 @@ classdef Section < nix.NamedEntity
         end
 
         function r = open_property(obj, id_or_name)
-            fname = strcat(obj.alias, '::openProperty');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Property);
+            r = nix.Utils.open_entity(obj, 'openProperty', id_or_name, @nix.Property);
         end
 
         function r = open_property_idx(obj, idx)
-            fname = strcat(obj.alias, '::openPropertyIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Property);
+            r = nix.Utils.open_entity(obj, 'openPropertyIdx', idx, @nix.Property);
         end
 
         function r = property_count(obj)
@@ -167,8 +155,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = filter_properties(obj, filter, val)
-            fname = strcat(obj.alias, '::propertiesFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Property);
+            r = nix.Utils.filter(obj, 'propertiesFiltered', filter, val, @nix.Property);
         end
 
         % ----------------
@@ -192,8 +179,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = referring_blocks(obj)
-            fname = strcat(obj.alias, '::referringBlocks');
-            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.Block);
+            r = nix.Utils.fetchObjList(obj, 'referringBlocks', @nix.Block);
         end
     end
 
@@ -207,14 +193,14 @@ classdef Section < nix.NamedEntity
         % referringXXX and referringXXX(Block) methods.
         function r = referring_util(obj, entityConstructor, fsuffix, varargin)
             if (isempty(varargin))
-                fname = strcat(obj.alias, '::referring', fsuffix);
-                r = nix.Utils.fetchObjList(fname, obj.nix_handle, entityConstructor);
+                fname = strcat('referring', fsuffix);
+                r = nix.Utils.fetchObjList(obj, fname, entityConstructor);
             elseif ((size(varargin, 2) > 1) || (~isa(varargin{1}, 'nix.Block')))
                 error('Provide either empty arguments or a single Block entity');
             else
-                fname = strcat(obj.alias, '::referringBlock', fsuffix);
-                r = nix.Utils.fetchObjListByEntity(fname, ...
-                    obj.nix_handle, varargin{1}.nix_handle, entityConstructor);
+                fname = strcat('referringBlock', fsuffix);
+                r = nix.Utils.fetchObjListByEntity(obj, fname, ...
+                                            varargin{1}.nix_handle, entityConstructor);
             end
         end
     end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -64,7 +64,7 @@ classdef Section < nix.NamedEntity
         function r = create_section(obj, name, type)
             fname = strcat(obj.alias, '::createSection');
             h = nix_mx(fname, obj.nix_handle, name, type);
-            r = nix.Section(h);
+            r = nix.Utils.createEntity(h, @nix.Section);
         end
 
         function r = delete_section(obj, del)
@@ -127,7 +127,7 @@ classdef Section < nix.NamedEntity
             else
                 fname = strcat(obj.alias, '::createProperty');
                 h = nix_mx(fname, obj.nix_handle, name, lower(datatype.char));
-                r = nix.Property(h);
+                r = nix.Utils.createEntity(h, @nix.Property);
             end
         end
 
@@ -137,7 +137,7 @@ classdef Section < nix.NamedEntity
             end
             fname = strcat(obj.alias, '::createPropertyWithValue');
             h = nix_mx(fname, obj.nix_handle, name, val);
-            r = nix.Property(h);
+            r = nix.Utils.createEntity(h, @nix.Property);
         end
 
         function r = delete_property(obj, del)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -81,8 +81,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = section_count(obj)
-            fname = strcat(obj.alias, '::sectionCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
         function r = filter_sections(obj, filter, val)
@@ -150,8 +149,7 @@ classdef Section < nix.NamedEntity
         end
 
         function r = property_count(obj)
-            fname = strcat(obj.alias, '::propertyCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'propertyCount');
         end
 
         function r = filter_properties(obj, filter, val)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -111,7 +111,9 @@ classdef Section < nix.NamedEntity
 
         function r = create_property(obj, name, datatype)
             if (~isa(datatype, 'nix.DataType'))
-                error('Please provide a valid nix.DataType');
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Please provide a valid nix.DataType';
+                error(err);
             else
                 fname = strcat(obj.alias, '::createProperty');
                 h = nix_mx(fname, obj.nix_handle, name, lower(datatype.char));
@@ -193,7 +195,9 @@ classdef Section < nix.NamedEntity
                 fname = strcat('referring', fsuffix);
                 r = nix.Utils.fetchObjList(obj, fname, entityConstructor);
             elseif ((size(varargin, 2) > 1) || (~isa(varargin{1}, 'nix.Block')))
-                error('Provide either empty arguments or a single Block entity');
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Provide either empty arguments or a single Block entity';
+                error(err);
             else
                 fname = strcat('referringBlock', fsuffix);
                 r = nix.Utils.fetchObjListByEntity(obj, fname, ...

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -10,7 +10,7 @@ classdef Section < nix.NamedEntity
     % SECTION Metadata Section class
     %   NIX metadata section
 
-    properties(Hidden)
+    properties (Hidden)
         % namespace reference for nix-mx functions
         alias = 'Section'
     end
@@ -143,7 +143,7 @@ classdef Section < nix.NamedEntity
         function r = delete_property(obj, del)
             if (isstruct(del) && isfield(del, 'id'))
                 delID = del.id;
-            elseif (strcmp(class(del), 'nix.Property'))
+            elseif (isa(del, 'nix.Property'))
                 delID = del.id;
             else
                 delID = del;
@@ -203,7 +203,7 @@ classdef Section < nix.NamedEntity
     % Referring utility method
     % ----------------
 
-    methods(Access=protected)
+    methods (Access=protected)
         % referring_util receives a nix entityConstructor, part of a function
         % name and varargin to provide abstract access to nix.Section
         % referringXXX and referringXXX(Block) methods.
@@ -211,8 +211,7 @@ classdef Section < nix.NamedEntity
             if (isempty(varargin))
                 fname = strcat(obj.alias, '::referring', fsuffix);
                 r = nix.Utils.fetchObjList(fname, obj.nix_handle, entityConstructor);
-            elseif ((size(varargin, 2) > 1) || ...
-                    (~strcmp(class(varargin{1}), 'nix.Block')))
+            elseif ((size(varargin, 2) > 1) || (~isa(varargin{1}, 'nix.Block')))
                 error('Provide either empty arguments or a single Block entity');
             else
                 fname = strcat(obj.alias, '::referringBlock', fsuffix);

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -35,7 +35,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         function r = create_source(obj, name, type)
             fname = strcat(obj.alias, '::createSource');
             h = nix_mx(fname, obj.nix_handle, name, type);
-            r = nix.Source(h);
+            r = nix.Utils.createEntity(h, @nix.Source);
         end
 
         function r = has_source(obj, id_or_name)

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -28,8 +28,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         % ------------------
 
         function r = source_count(obj)
-            fname = strcat(obj.alias, '::sourceCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
         function r = create_source(obj, name, type)

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -44,43 +44,35 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = delete_source(obj, del)
-            fname = strcat(obj.alias, '::deleteSource');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Source', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteSource', del, 'nix.Source');
         end
 
         function r = open_source(obj, id_or_name)
-            fname = strcat(obj.alias, '::openSource');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Source);
+            r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
         end
 
         function r = open_source_idx(obj, idx)
-            fname = strcat(obj.alias, '::openSourceIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Source);
+            r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = parent_source(obj)
-            fname = strcat(obj.alias, '::parentSource');
-            r = nix.Utils.fetchObj(fname, obj.nix_handle, @nix.Source);
+            r = nix.Utils.fetchObj(obj, 'parentSource', @nix.Source);
         end
 
         function r = referring_data_arrays(obj)
-            fname = strcat(obj.alias, '::referringDataArrays');
-            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.DataArray);
+            r = nix.Utils.fetchObjList(obj, 'referringDataArrays', @nix.DataArray);
         end
 
         function r = referring_tags(obj)
-            fname = strcat(obj.alias, '::referringTags');
-            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.Tag);
+            r = nix.Utils.fetchObjList(obj, 'referringTags', @nix.Tag);
         end
 
         function r = referring_multi_tags(obj)
-            fname = strcat(obj.alias, '::referringMultiTags');
-            r = nix.Utils.fetchObjList(fname, obj.nix_handle, @nix.MultiTag);
+            r = nix.Utils.fetchObjList(obj, 'referringMultiTags', @nix.MultiTag);
         end
 
         function r = filter_sources(obj, filter, val)
-            fname = strcat(obj.alias, '::sourcesFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Source);
+            r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
 
         % maxdepth is an index where idx = 0 corresponds to the calling source
@@ -90,8 +82,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
 
         % maxdepth is an index where idx = 0 corresponds to the calling source
         function r = find_filtered_sources(obj, max_depth, filter, val)
-            fname = strcat(obj.alias, '::findSources');
-            r = nix.Utils.find(obj, max_depth, filter, val, fname, @nix.Source);
+            r = nix.Utils.find(obj, 'findSources', max_depth, filter, val, @nix.Source);
         end
     end
 

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -38,8 +38,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = has_source(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasSource');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasSource', id_or_name);
         end
 
         function r = delete_source(obj, del)

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -20,8 +20,7 @@ classdef SourcesMixIn < handle
         end
 
         function r = source_count(obj)
-            fname = strcat(obj.alias, '::sourceCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
         % has_source supports only check by id, not by name

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -32,33 +32,27 @@ classdef SourcesMixIn < handle
         end
 
         function [] = add_source(obj, add_this)
-            fname = strcat(obj.alias, '::addSource');
-            nix.Utils.add_entity(obj, add_this, 'nix.Source', fname);
+            nix.Utils.add_entity(obj, 'addSource', add_this, 'nix.Source');
         end
 
         function [] = add_sources(obj, add_cell_array)
-            fname = strcat(obj.alias, '::addSources');
-            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.Source', fname);
+            nix.Utils.add_entity_array(obj, 'addSources', add_cell_array, 'nix.Source');
         end
 
         function r = remove_source(obj, del)
-            fname = strcat(obj.alias, '::removeSource');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Source', fname);
+            r = nix.Utils.delete_entity(obj, 'removeSource', del, 'nix.Source');
         end
 
         function r = open_source(obj, id_or_name)
-            fname = strcat(obj.alias, '::openSource');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Source);
+            r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
         end
 
         function r = open_source_idx(obj, idx)
-            fname = strcat(obj.alias, '::openSourceIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Source);
+            r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = filter_sources(obj, filter, val)
-            fname = strcat(obj.alias, '::sourcesFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Source);
+            r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
     end
 

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -27,7 +27,7 @@ classdef SourcesMixIn < handle
         % has_source supports only check by id, not by name
         function r = has_source(obj, id_or_entity)
             has = id_or_entity;
-            if (strcmp(class(has), 'nix.Source'))
+            if (isa(has, 'nix.Source'))
             	has = id_or_entity.id;
             end
 

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -26,8 +26,7 @@ classdef SourcesMixIn < handle
         % has_source supports only check by id, not by name
         function r = has_source(obj, id_or_entity)
             has = nix.Utils.parseEntityId(id_or_entity, 'nix.Source');
-            fname = strcat(obj.alias, '::hasSource');
-            r = nix_mx(fname, obj.nix_handle, has);
+            r = nix.Utils.fetchHasEntity(obj, 'hasSource', has);
         end
 
         function [] = add_source(obj, add_this)

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -26,11 +26,7 @@ classdef SourcesMixIn < handle
 
         % has_source supports only check by id, not by name
         function r = has_source(obj, id_or_entity)
-            has = id_or_entity;
-            if (isa(has, 'nix.Source'))
-            	has = id_or_entity.id;
-            end
-
+            has = nix.Utils.parseEntityId(id_or_entity, 'nix.Source');
             fname = strcat(obj.alias, '::hasSource');
             r = nix_mx(fname, obj.nix_handle, has);
         end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -72,8 +72,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = reference_count(obj)
-            fname = strcat(obj.alias, '::referenceCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'referenceCount');
         end
 
         function r = filter_references(obj, filter, val)
@@ -121,8 +120,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = feature_count(obj)
-            fname = strcat(obj.alias, '::featureCount');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix.Utils.fetchEntityCount(obj, 'featureCount');
         end
 
         function r = filter_features(obj, filter, val)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -99,11 +99,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
             fname = strcat(obj.alias, '::createFeature');
             h = nix_mx(fname, obj.nix_handle, addID, link_type);
-
-            r = {};
-            if (h ~= 0)
-                r = nix.Feature(h);
-            end
+            r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
         function r = has_feature(obj, id_or_name)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -91,14 +91,9 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = add_feature(obj, add_this, link_type)
-            if (isa(add_this, 'nix.DataArray'))
-                addID = add_this.id;
-            else
-                addID = add_this;
-            end
-
+            id = nix.Utils.parseEntityId(add_this, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nix_handle, addID, link_type);
+            h = nix_mx(fname, obj.nix_handle, id, link_type);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -91,7 +91,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = add_feature(obj, add_this, link_type)
-            if (strcmp(class(add_this), 'nix.DataArray'))
+            if (isa(add_this, 'nix.DataArray'))
                 addID = add_this.id;
             else
                 addID = add_this;

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -35,13 +35,11 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function [] = add_reference(obj, add_this)
-            fname = strcat(obj.alias, '::addReference');
-            nix.Utils.add_entity(obj, add_this, 'nix.DataArray', fname);
+            nix.Utils.add_entity(obj, 'addReference', add_this, 'nix.DataArray');
         end
 
         function [] = add_references(obj, add_cell_array)
-            fname = strcat(obj.alias, '::addReferences');
-            nix.Utils.add_entity_array(obj, add_cell_array, 'nix.DataArray', fname);
+            nix.Utils.add_entity_array(obj, 'addReferences', add_cell_array, 'nix.DataArray');
         end
 
         function r = has_reference(obj, id_or_name)
@@ -50,18 +48,15 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = remove_reference(obj, del)
-            fname = strcat(obj.alias, '::removeReference');
-            r = nix.Utils.delete_entity(obj, del, 'nix.DataArray', fname);
+            r = nix.Utils.delete_entity(obj, 'removeReference', del, 'nix.DataArray');
         end
 
         function r = open_reference(obj, id_or_name)
-            fname = strcat(obj.alias, '::openReferenceDataArray');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openReferenceDataArray', id_or_name, @nix.DataArray);
         end
 
         function r = open_reference_idx(obj, idx)
-            fname = strcat(obj.alias, '::openReferenceIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.DataArray);
+            r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
         function r = retrieve_data(obj, id_or_name)
@@ -82,8 +77,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = filter_references(obj, filter, val)
-            fname = strcat(obj.alias, '::referencesFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.DataArray);
+            r = nix.Utils.filter(obj, 'referencesFiltered', filter, val, @nix.DataArray);
         end
 
         % ------------------
@@ -103,18 +97,15 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = remove_feature(obj, del)
-            fname = strcat(obj.alias, '::deleteFeature');
-            r = nix.Utils.delete_entity(obj, del, 'nix.Feature', fname);
+            r = nix.Utils.delete_entity(obj, 'deleteFeature', del, 'nix.Feature');
         end
 
         function r = open_feature(obj, id_or_name)
-            fname = strcat(obj.alias, '::openFeature');
-            r = nix.Utils.open_entity(obj, fname, id_or_name, @nix.Feature);
+            r = nix.Utils.open_entity(obj, 'openFeature', id_or_name, @nix.Feature);
         end
 
         function r = open_feature_idx(obj, idx)
-            fname = strcat(obj.alias, '::openFeatureIdx');
-            r = nix.Utils.open_entity(obj, fname, idx, @nix.Feature);
+            r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
         function r = retrieve_feature_data(obj, id_or_name)
@@ -135,8 +126,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = filter_features(obj, filter, val)
-            fname = strcat(obj.alias, '::featuresFiltered');
-            r = nix.Utils.filter(obj, filter, val, fname, @nix.Feature);
+            r = nix.Utils.filter(obj, 'featuresFiltered', filter, val, @nix.Feature);
         end
     end
 

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -43,8 +43,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_reference(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasReference');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasReference', id_or_name);
         end
 
         function r = remove_reference(obj, del)
@@ -91,8 +90,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = has_feature(obj, id_or_name)
-            fname = strcat(obj.alias, '::hasFeature');
-            r = nix_mx(fname, obj.nix_handle, id_or_name);
+            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', id_or_name);
         end
 
         function r = remove_feature(obj, del)

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -36,8 +36,9 @@ classdef Utils
             end
         end
 
-        function r = fetchObjList(nixMxFunc, handle, objConstructor)
-            list = nix_mx(nixMxFunc, handle);
+        function r = fetchObjList(obj, mxMethodName, objConstructor)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
+            list = nix_mx(mxMethod, obj.nix_handle);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
@@ -46,22 +47,25 @@ classdef Utils
         % second nix entity handle related to the first one.
         % 'objConstructor' requires the Matlab entity constructor of the expected 
         % returned nix Entities.
-        function r = fetchObjListByEntity(nixMxFunc, handle, related_handle, objConstructor)
-            list = nix_mx(nixMxFunc, handle, related_handle);
+        function r = fetchObjListByEntity(obj, mxMethodName, related_handle, objConstructor)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
+            list = nix_mx(mxMethod, obj.nix_handle, related_handle);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
-        function r = fetchObj(nixMxFunc, handle, objConstructor)
-            h = nix_mx(nixMxFunc, handle);
+        function r = fetchObj(obj, mxMethodName, objConstructor)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
+            h = nix_mx(mxMethod, obj.nix_handle);
             r = nix.Utils.createEntity(h, objConstructor);
         end
 
-        function [] = add_entity(obj, idNameEntity, nixEntity, mxMethod)
+        function [] = add_entity(obj, mxMethodName, idNameEntity, nixEntity)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
             id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
             nix_mx(mxMethod, obj.nix_handle, id);
         end
 
-        function [] = add_entity_array(obj, add_cell_array, nixEntity, mxMethod)
+        function [] = add_entity_array(obj, mxMethodName, add_cell_array, nixEntity)
             if (~iscell(add_cell_array))
                 error('Expected cell array');
             end
@@ -72,18 +76,21 @@ classdef Utils
                 end
                 handle_array{i} = add_cell_array{i}.nix_handle;
             end
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
             nix_mx(mxMethod, obj.nix_handle, handle_array);
         end
 
         % Function can be used for both nix delete and remove methods.
         % The first actually removes the entity, the latter
         % removes only the reference to the entity.
-        function r = delete_entity(obj, idNameEntity, nixEntity, mxMethod)
+        function r = delete_entity(obj, mxMethodName, idNameEntity, nixEntity)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
             id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
             r = nix_mx(mxMethod, obj.nix_handle, id);
         end
 
-        function r = open_entity(obj, mxMethod, id_or_name, objConstructor)
+        function r = open_entity(obj, mxMethodName, id_or_name, objConstructor)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
             h = nix_mx(mxMethod, obj.nix_handle, id_or_name);
             r = nix.Utils.createEntity(h, objConstructor);
         end
@@ -107,12 +114,13 @@ classdef Utils
             end
         end
 
-        function r = filter(obj, filter, val, mxMethod, objConstructor)
+        function r = filter(obj, mxMethodName, filter, val, objConstructor)
             valid = nix.Utils.valid_filter(filter, val);
             if (~isempty(valid))
                 error(valid);
             end
 
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nix_handle, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
@@ -121,7 +129,7 @@ classdef Utils
         % findXXX helper functions
         % -----------------------------------------------------------
 
-        function r = find(obj, max_depth, filter, val, mxMethod, objConstructor)
+        function r = find(obj, mxMethodName, max_depth, filter, val, objConstructor)
             if (~isnumeric(max_depth))
                 error('Provide a valid search depth');
             end
@@ -131,6 +139,7 @@ classdef Utils
                 error(valid);
             end
 
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nix_handle, max_depth, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -77,7 +77,7 @@ classdef Utils
         function r = open_entity(obj, mxMethod, id_or_name, objConstructor)
             handle = nix_mx(mxMethod, obj.nix_handle, id_or_name);
             r = {};
-            if handle ~= 0
+            if (handle ~= 0)
                 r = objConstructor(handle);
             end
         end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -10,25 +10,26 @@ classdef Utils
 
     methods(Static)
 
-        function rdata = fetchObjList(nixMxFunc, handle, objConstructor)
-            currList = nix_mx(nixMxFunc, handle);
-            rdata = cell(length(currList), 1);
-            for i = 1:length(currList)
-                rdata{i} = objConstructor(currList{i});
+        function r = createEntityArray(list, objConstructor)
+            r = cell(length(list), 1);
+            for i = 1:length(list)
+                r{i} = objConstructor(list{i});
             end
+        end
+
+        function r = fetchObjList(nixMxFunc, handle, objConstructor)
+            list = nix_mx(nixMxFunc, handle);
+            r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
         % This method calls the nix-mx function specified by 'nixMxFunc', handing 
         % over 'handle' as the main nix entity handle and 'related_handle' as a 
         % second nix entity handle related to the first one.
-        % 'objConstrucor' requires the Matlab entity constructor of the expected 
+        % 'objConstructor' requires the Matlab entity constructor of the expected 
         % returned nix Entities.
-        function rdata = fetchObjListByEntity(nixMxFunc, handle, related_handle, objConstructor)
-            currList = nix_mx(nixMxFunc, handle, related_handle);
-            rdata = cell(length(currList), 1);
-            for i = 1:length(currList)
-                rdata{i} = objConstructor(currList{i});
-            end
+        function r = fetchObjListByEntity(nixMxFunc, handle, related_handle, objConstructor)
+            list = nix_mx(nixMxFunc, handle, related_handle);
+            r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
         function r = fetchObj(nixMxFunc, handle, objConstructor)
@@ -101,25 +102,21 @@ classdef Utils
             end
         end
 
-        function rdata = filter(obj, filter, val, mxMethod, objConstructor)
+        function r = filter(obj, filter, val, mxMethod, objConstructor)
             valid = nix.Utils.valid_filter(filter, val);
             if (~isempty(valid))
                 error(valid);
             end
 
-            currList = nix_mx(mxMethod, obj.nix_handle, uint8(filter), val);
-            rdata = cell(length(currList), 1);
-            for i = 1:length(currList)
-                rdata{i} = objConstructor(currList{i});
-            end
+            list = nix_mx(mxMethod, obj.nix_handle, uint8(filter), val);
+            r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
         % -----------------------------------------------------------
         % findXXX helper functions
         % -----------------------------------------------------------
 
-        function rdata = find(obj, max_depth, filter, val, ...
-                                                mxMethod, objConstructor)
+        function r = find(obj, max_depth, filter, val, mxMethod, objConstructor)
             if (~isnumeric(max_depth))
                 error('Provide a valid search depth');
             end
@@ -129,13 +126,8 @@ classdef Utils
                 error(valid);
             end
 
-            currList = nix_mx(mxMethod, ...
-                            obj.nix_handle, max_depth, uint8(filter), val);
-
-            rdata = cell(length(currList), 1);
-            for i = 1:length(currList)
-                rdata{i} = objConstructor(currList{i});
-            end
+            list = nix_mx(mxMethod, obj.nix_handle, max_depth, uint8(filter), val);
+            r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
         % -----------------------------------------------------------

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -109,26 +109,24 @@ classdef Utils
         % nix.Filter helper functions
         % -----------------------------------------------------------
 
-        function err = valid_filter(filter, val)
-            err = '';
+        function [] = valid_filter(filter, val)
             if (~isa(filter, 'nix.Filter'))
-                err = 'Valid nix.Filter required';
-                return
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Valid nix.Filter required';
+                error(err);
             end
 
             % Currently matlab will crash, if anything other than
             % a cell array is handed over to a nix.Filter.ids.
             if (filter == nix.Filter.ids && ~iscell(val))
-                err = 'nix.Filter.ids requires a cell array';
-                return
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'nix.Filter.ids requires a cell array';
+                error(err)
             end
         end
 
         function r = filter(obj, mxMethodName, filter, val, objConstructor)
-            valid = nix.Utils.valid_filter(filter, val);
-            if (~isempty(valid))
-                error(valid);
-            end
+            nix.Utils.valid_filter(filter, val);
 
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nix_handle, uint8(filter), val);
@@ -141,13 +139,12 @@ classdef Utils
 
         function r = find(obj, mxMethodName, max_depth, filter, val, objConstructor)
             if (~isnumeric(max_depth))
-                error('Provide a valid search depth');
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Provide a valid search depth';
+                error(err);
             end
 
-            valid = nix.Utils.valid_filter(filter, val);
-            if (~isempty(valid))
-                error(valid);
-            end
+            nix.Utils.valid_filter(filter, val);
 
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nix_handle, max_depth, uint8(filter), val);

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -10,6 +10,18 @@ classdef Utils
 
     methods(Static)
 
+        function r = parseEntityId(id_or_entity, nixEntity)
+            if (isa(id_or_entity, nixEntity))
+                r = id_or_entity.id;
+            elseif (isa(id_or_entity, 'char'))
+                r = id_or_entity;
+            else
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = sprintf('Expected an id, name or %s entity', nixEntity);
+                error(err);
+            end
+        end
+
         function r = createEntity(handle, objConstructor)
             r = {};
             if (handle ~= 0)
@@ -44,13 +56,9 @@ classdef Utils
             r = nix.Utils.createEntity(h, objConstructor);
         end
 
-        function [] = add_entity(obj, add_this, nixEntity, mxMethod)
-            if (isa(add_this, nixEntity))
-                addID = add_this.id;
-            else
-                addID = add_this;
-            end
-            nix_mx(mxMethod, obj.nix_handle, addID);
+        function [] = add_entity(obj, idNameEntity, nixEntity, mxMethod)
+            id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
+            nix_mx(mxMethod, obj.nix_handle, id);
         end
 
         function [] = add_entity_array(obj, add_cell_array, nixEntity, mxMethod)
@@ -70,13 +78,9 @@ classdef Utils
         % Function can be used for both nix delete and remove methods.
         % The first actually removes the entity, the latter
         % removes only the reference to the entity.
-        function r = delete_entity(obj, del, nixEntity, mxMethod)
-            if (isa(del, nixEntity))
-                delID = del.id;
-            else
-                delID = del;
-            end
-            r = nix_mx(mxMethod, obj.nix_handle, delID);
+        function r = delete_entity(obj, idNameEntity, nixEntity, mxMethod)
+            id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
+            r = nix_mx(mxMethod, obj.nix_handle, id);
         end
 
         function r = open_entity(obj, mxMethod, id_or_name, objConstructor)

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -10,6 +10,13 @@ classdef Utils
 
     methods(Static)
 
+        function r = createEntity(handle, objConstructor)
+            r = {};
+            if (handle ~= 0)
+                r = objConstructor(handle);
+            end
+        end
+
         function r = createEntityArray(list, objConstructor)
             r = cell(length(list), 1);
             for i = 1:length(list)
@@ -33,11 +40,8 @@ classdef Utils
         end
 
         function r = fetchObj(nixMxFunc, handle, objConstructor)
-            r = {};
             h = nix_mx(nixMxFunc, handle);
-            if (h ~= 0)
-                r = objConstructor(h);
-            end
+            r = nix.Utils.createEntity(h, objConstructor);
         end
 
         function [] = add_entity(obj, add_this, nixEntity, mxMethod)
@@ -76,11 +80,8 @@ classdef Utils
         end
 
         function r = open_entity(obj, mxMethod, id_or_name, objConstructor)
-            handle = nix_mx(mxMethod, obj.nix_handle, id_or_name);
-            r = {};
-            if (handle ~= 0)
-                r = objConstructor(handle);
-            end
+            h = nix_mx(mxMethod, obj.nix_handle, id_or_name);
+            r = nix.Utils.createEntity(h, objConstructor);
         end
 
         % -----------------------------------------------------------

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -77,15 +77,21 @@ classdef Utils
 
         function [] = add_entity_array(obj, mxMethodName, add_cell_array, nixEntity)
             if (~iscell(add_cell_array))
-                error('Expected cell array');
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Expected cell array';
+                error(err);
             end
+
             handle_array = cell(1, length(add_cell_array));
             for i = 1:length(add_cell_array)
                 if (~strcmpi(class(add_cell_array{i}), nixEntity))
-                    error(sprintf('Element #%s is not a %s.', num2str(i), nixEntity));
+                    err.identifier = 'NIXMX:InvalidArgument';
+                    err.message = sprintf('Element #%s is not a %s.', num2str(i), nixEntity);
+                    error(err);
                 end
                 handle_array{i} = add_cell_array{i}.nix_handle;
             end
+
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             nix_mx(mxMethod, obj.nix_handle, handle_array);
         end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -41,6 +41,11 @@ classdef Utils
             r = nix_mx(mxMethod, obj.nix_handle);
         end
 
+        function r = fetchHasEntity(obj, mxMethodName, identifier)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
+            r = nix_mx(mxMethod, obj.nix_handle, identifier);
+        end
+
         function r = fetchObjList(obj, mxMethodName, objConstructor)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nix_handle);

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -40,7 +40,7 @@ classdef Utils
         end
 
         function [] = add_entity(obj, add_this, nixEntity, mxMethod)
-            if (strcmp(class(add_this), nixEntity))
+            if (isa(add_this, nixEntity))
                 addID = add_this.id;
             else
                 addID = add_this;
@@ -66,7 +66,7 @@ classdef Utils
         % The first actually removes the entity, the latter
         % removes only the reference to the entity.
         function r = delete_entity(obj, del, nixEntity, mxMethod)
-            if (strcmp(class(del), nixEntity))
+            if (isa(del, nixEntity))
                 delID = del.id;
             else
                 delID = del;

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -32,7 +32,7 @@ classdef Utils
         function r = createEntityArray(list, objConstructor)
             r = cell(length(list), 1);
             for i = 1:length(list)
-                r{i} = objConstructor(list{i});
+                r{i} = nix.Utils.createEntity(list{i}, objConstructor);
             end
         end
 

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -36,6 +36,11 @@ classdef Utils
             end
         end
 
+        function r = fetchEntityCount(obj, mxMethodName)
+            mxMethod = strcat(obj.alias, '::', mxMethodName);
+            r = nix_mx(mxMethod, obj.nix_handle);
+        end
+
         function r = fetchObjList(obj, mxMethodName, objConstructor)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nix_handle);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -104,6 +104,13 @@ void mexFunction(int            nlhs,
         classdef<nix::File>("File", methods)
             .desc(&nixfile::describe)
             .add("open", nixfile::open)
+            .add("fileMode", nixfile::fileMode)
+            .add("validate", nixfile::validate)
+            .add("openBlockIdx", nixfile::openBlockIdx)
+            .add("openSectionIdx", nixfile::openSectionIdx)
+            .add("sectionsFiltered", nixfile::sectionsFiltered)
+            .add("blocksFiltered", nixfile::blocksFiltered)
+            .add("findSections", nixfile::findSections)
             .reg("blocks", GETTER(std::vector<nix::Block>, nix::File, blocks))
             .reg("sections", GETTER(std::vector<nix::Section>, nix::File, sections))
             .reg("hasBlock", GETBYSTR(bool, nix::File, hasBlock))
@@ -117,16 +124,24 @@ void mexFunction(int            nlhs,
             .reg("blockCount", GETTER(nix::ndsize_t, nix::File, blockCount))
             .reg("sectionCount", GETTER(nix::ndsize_t, nix::File, sectionCount))
             .reg("isOpen", GETTER(bool, nix::File, isOpen));
-        methods->add("File::fileMode", nixfile::fileMode);
-        methods->add("File::validate", nixfile::validate);
-        methods->add("File::openBlockIdx", nixfile::openBlockIdx);
-        methods->add("File::openSectionIdx", nixfile::openSectionIdx);
-        methods->add("File::sectionsFiltered", nixfile::sectionsFiltered);
-        methods->add("File::blocksFiltered", nixfile::blocksFiltered);
-        methods->add("File::findSections", nixfile::findSections);
 
         classdef<nix::Block>("Block", methods)
             .desc(&nixblock::describe)
+            .add("createDataArray", nixblock::createDataArray)
+            .add("createMultiTag", nixblock::createMultiTag)
+            .add("createGroup", nixblock::createGroup)
+            .add("openGroupIdx", nixblock::openGroupIdx)
+            .add("openDataArrayIdx", nixblock::openDataArrayIdx)
+            .add("openTagIdx", nixblock::openTagIdx)
+            .add("openMultiTagIdx", nixblock::openMultiTagIdx)
+            .add("openSourceIdx", nixblock::openSourceIdx)
+            .add("compare", nixblock::compare)
+            .add("sourcesFiltered", nixblock::sourcesFiltered)
+            .add("groupsFiltered", nixblock::groupsFiltered)
+            .add("tagsFiltered", nixblock::tagsFiltered)
+            .add("multiTagsFiltered", nixblock::multiTagsFiltered)
+            .add("dataArraysFiltered", nixblock::dataArraysFiltered)
+            .add("findSources", nixblock::findSources)
             .reg("createSource", &nix::Block::createSource)
             .reg("createTag", &nix::Block::createTag)
             .reg("dataArrays", &nix::Block::dataArrays)
@@ -160,24 +175,26 @@ void mexFunction(int            nlhs,
             .reg("tagCount", GETTER(nix::ndsize_t, nix::Block, tagCount))
             .reg("multiTagCount", GETTER(nix::ndsize_t, nix::Block, multiTagCount))
             .reg("groupCount", GETTER(nix::ndsize_t, nix::Block, groupCount));
-        methods->add("Block::createDataArray", nixblock::createDataArray);
-        methods->add("Block::createMultiTag", nixblock::createMultiTag);
-        methods->add("Block::createGroup", nixblock::createGroup);
-        methods->add("Block::openGroupIdx", nixblock::openGroupIdx);
-        methods->add("Block::openDataArrayIdx", nixblock::openDataArrayIdx);
-        methods->add("Block::openTagIdx", nixblock::openTagIdx);
-        methods->add("Block::openMultiTagIdx", nixblock::openMultiTagIdx);
-        methods->add("Block::openSourceIdx", nixblock::openSourceIdx);
-        methods->add("Block::compare", nixblock::compare);
-        methods->add("Block::sourcesFiltered", nixblock::sourcesFiltered);
-        methods->add("Block::groupsFiltered", nixblock::groupsFiltered);
-        methods->add("Block::tagsFiltered", nixblock::tagsFiltered);
-        methods->add("Block::multiTagsFiltered", nixblock::multiTagsFiltered);
-        methods->add("Block::dataArraysFiltered", nixblock::dataArraysFiltered);
-        methods->add("Block::findSources", nixblock::findSources);
 
         classdef<nix::Group>("Group", methods)
             .desc(&nixgroup::describe)
+            .add("addDataArray", nixgroup::addDataArray)
+            .add("addDataArrays", nixgroup::addDataArrays)
+            .add("addSource", nixgroup::addSource)
+            .add("addSources", nixgroup::addSources)
+            .add("addTag", nixgroup::addTag)
+            .add("addTags", nixgroup::addTags)
+            .add("addMultiTag", nixgroup::addMultiTag)
+            .add("addMultiTags", nixgroup::addMultiTags)
+            .add("openDataArrayIdx", nixgroup::openDataArrayIdx)
+            .add("openTagIdx", nixgroup::openTagIdx)
+            .add("openMultiTagIdx", nixgroup::openMultiTagIdx)
+            .add("openSourceIdx", nixgroup::openSourceIdx)
+            .add("compare", nixgroup::compare)
+            .add("sourcesFiltered", nixgroup::sourcesFiltered)
+            .add("tagsFiltered", nixgroup::tagsFiltered)
+            .add("multiTagsFiltered", nixgroup::multiTagsFiltered)
+            .add("dataArraysFiltered", nixgroup::dataArraysFiltered)
             .reg("dataArrays", FILTER(std::vector<nix::DataArray>, nix::Group, , dataArrays))
             .reg("sources", FILTER(std::vector<nix::Source>, nix::Group, std::function<bool(const nix::Source &)>, sources))
             .reg("tags", FILTER(std::vector<nix::Tag>, nix::Group, , tags))
@@ -204,26 +221,27 @@ void mexFunction(int            nlhs,
             .reg("dataArrayCount", GETTER(nix::ndsize_t, nix::Group, dataArrayCount))
             .reg("tagCount", GETTER(nix::ndsize_t, nix::Group, tagCount))
             .reg("multiTagCount", GETTER(nix::ndsize_t, nix::Group, multiTagCount));
-        methods->add("Group::addDataArray", nixgroup::addDataArray);
-        methods->add("Group::addDataArrays", nixgroup::addDataArrays);
-        methods->add("Group::addSource", nixgroup::addSource);
-        methods->add("Group::addSources", nixgroup::addSources);
-        methods->add("Group::addTag", nixgroup::addTag);
-        methods->add("Group::addTags", nixgroup::addTags);
-        methods->add("Group::addMultiTag", nixgroup::addMultiTag);
-        methods->add("Group::addMultiTags", nixgroup::addMultiTags);
-        methods->add("Group::openDataArrayIdx", nixgroup::openDataArrayIdx);
-        methods->add("Group::openTagIdx", nixgroup::openTagIdx);
-        methods->add("Group::openMultiTagIdx", nixgroup::openMultiTagIdx);
-        methods->add("Group::openSourceIdx", nixgroup::openSourceIdx);
-        methods->add("Group::compare", nixgroup::compare);
-        methods->add("Group::sourcesFiltered", nixgroup::sourcesFiltered);
-        methods->add("Group::tagsFiltered", nixgroup::tagsFiltered);
-        methods->add("Group::multiTagsFiltered", nixgroup::multiTagsFiltered);
-        methods->add("Group::dataArraysFiltered", nixgroup::dataArraysFiltered);
 
+        // REMOVER for DataArray.removeSource leads to an error, therefore use .add() for now
         classdef<nix::DataArray>("DataArray", methods)
             .desc(&nixdataarray::describe)
+            .add("deleteDimensions", nixdataarray::deleteDimensions)
+            .add("readAll", nixdataarray::readAll)
+            .add("writeAll", nixdataarray::writeAll)
+            .add("addSource", nixdataarray::addSource)
+            .add("addSources", nixdataarray::addSources)
+            .add("removeSource", nixdataarray::removeSource)
+            .add("openSource", nixdataarray::getSource)
+            .add("hasSource", nixdataarray::hasSource)
+            .add("sourceCount", nixdataarray::sourceCount)
+            .add("dimensionCount", nixdataarray::dimensionCount)
+            .add("setPolynomCoefficients", nixdataarray::polynomCoefficients)
+            .add("dataType", nixdataarray::dataType)
+            .add("setDataExtent", nixdataarray::setDataExtent)
+            .add("openSourceIdx", nixdataarray::openSourceIdx)
+            .add("openDimensionIdx", nixdataarray::openDimensionIdx)
+            .add("compare", nixdataarray::compare)
+            .add("sourcesFiltered", nixdataarray::sourcesFiltered)
             .reg("sources", IDATAARRAY(std::vector<nix::Source>, EntityWithSources, std::function<bool(const nix::Source &)>, sources, const))
             .reg("openMetadataSection", IDATAARRAY(nix::Section, EntityWithMetadata, , metadata, const))
             .reg("setMetadata", IDATAARRAY(void, EntityWithMetadata, const std::string&, metadata, ))
@@ -247,27 +265,13 @@ void mexFunction(int            nlhs,
             .reg("createRangeDimension", &nix::DataArray::createRangeDimension)
             .reg("createAliasRangeDimension", &nix::DataArray::createAliasRangeDimension)
             .reg("createSampledDimension", &nix::DataArray::createSampledDimension);
-        methods->add("DataArray::deleteDimensions", nixdataarray::deleteDimensions);
-        methods->add("DataArray::readAll", nixdataarray::readAll);
-        methods->add("DataArray::writeAll", nixdataarray::writeAll);
-        methods->add("DataArray::addSource", nixdataarray::addSource);
-        methods->add("DataArray::addSources", nixdataarray::addSources);
-        // REMOVER for DataArray.removeSource leads to an error, therefore use method->add for now
-        methods->add("DataArray::removeSource", nixdataarray::removeSource);
-        methods->add("DataArray::openSource", nixdataarray::getSource);
-        methods->add("DataArray::hasSource", nixdataarray::hasSource);
-        methods->add("DataArray::sourceCount", nixdataarray::sourceCount);
-        methods->add("DataArray::dimensionCount", nixdataarray::dimensionCount);
-        methods->add("DataArray::setPolynomCoefficients", nixdataarray::polynomCoefficients);
-        methods->add("DataArray::dataType", nixdataarray::dataType);
-        methods->add("DataArray::setDataExtent", nixdataarray::setDataExtent);
-        methods->add("DataArray::openSourceIdx", nixdataarray::openSourceIdx);
-        methods->add("DataArray::openDimensionIdx", nixdataarray::openDimensionIdx);
-        methods->add("DataArray::compare", nixdataarray::compare);
-        methods->add("DataArray::sourcesFiltered", nixdataarray::sourcesFiltered);
 
         classdef<nix::Source>("Source", methods)
             .desc(&nixsource::describe)
+            .add("openSourceIdx", nixsource::openSourceIdx)
+            .add("compare", nixsource::compare)
+            .add("sourcesFiltered", nixsource::sourcesFiltered)
+            .add("findSources", nixsource::findSources)
             .reg("createSource", &nix::Source::createSource)
             .reg("deleteSource", REMOVER(nix::Source, nix::Source, deleteSource))
             .reg("sources", &nix::Source::sources)
@@ -284,13 +288,25 @@ void mexFunction(int            nlhs,
             .reg("referringDataArrays", GETTER(std::vector<nix::DataArray>, nix::Source, referringDataArrays))
             .reg("referringTags", GETTER(std::vector<nix::Tag>, nix::Source, referringTags))
             .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Source, referringMultiTags));
-        methods->add("Source::openSourceIdx", nixsource::openSourceIdx);
-        methods->add("Source::compare", nixsource::compare);
-        methods->add("Source::sourcesFiltered", nixsource::sourcesFiltered);
-        methods->add("Source::findSources", nixsource::findSources);
 
         classdef<nix::Tag>("Tag", methods)
             .desc(&nixtag::describe)
+            .add("addReference", nixtag::addReference)
+            .add("addReferences", nixtag::addReferences)
+            .add("addSource", nixtag::addSource)
+            .add("addSources", nixtag::addSources)
+            .add("createFeature", nixtag::createFeature)
+            .add("openReferenceIdx", nixtag::openReferenceIdx)
+            .add("openFeatureIdx", nixtag::openFeatureIdx)
+            .add("openSourceIdx", nixtag::openSourceIdx)
+            .add("compare", nixtag::compare)
+            .add("sourcesFiltered", nixtag::sourcesFiltered)
+            .add("referencesFiltered", nixtag::referencesFiltered)
+            .add("featuresFiltered", nixtag::featuresFiltered)
+            .add("retrieveData", nixtag::retrieveData)
+            .add("retrieveDataIdx", nixtag::retrieveDataIdx)
+            .add("featureRetrieveData", nixtag::retrieveFeatureData)
+            .add("featureRetrieveDataIdx", nixtag::retrieveFeatureDataIdx)
             .reg("references", GETTER(std::vector<nix::DataArray>, nix::Tag, references))
             .reg("features", &nix::Tag::features)
             .reg("sources", FILTER(std::vector<nix::Source>, nix::Tag, std::function<bool(const nix::Source &)>, sources))
@@ -317,25 +333,26 @@ void mexFunction(int            nlhs,
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::Tag, sourceCount))
             .reg("referenceCount", GETTER(nix::ndsize_t, nix::Tag, referenceCount))
             .reg("featureCount", GETTER(nix::ndsize_t, nix::Tag, featureCount));
-        methods->add("Tag::addReference", nixtag::addReference);
-        methods->add("Tag::addReferences", nixtag::addReferences);
-        methods->add("Tag::addSource", nixtag::addSource);
-        methods->add("Tag::addSources", nixtag::addSources);
-        methods->add("Tag::createFeature", nixtag::createFeature);
-        methods->add("Tag::openReferenceIdx", nixtag::openReferenceIdx);
-        methods->add("Tag::openFeatureIdx", nixtag::openFeatureIdx);
-        methods->add("Tag::openSourceIdx", nixtag::openSourceIdx);
-        methods->add("Tag::compare", nixtag::compare);
-        methods->add("Tag::sourcesFiltered", nixtag::sourcesFiltered);
-        methods->add("Tag::referencesFiltered", nixtag::referencesFiltered);
-        methods->add("Tag::featuresFiltered", nixtag::featuresFiltered);
-        methods->add("Tag::retrieveData", nixtag::retrieveData);
-        methods->add("Tag::retrieveDataIdx", nixtag::retrieveDataIdx);
-        methods->add("Tag::featureRetrieveData", nixtag::retrieveFeatureData);
-        methods->add("Tag::featureRetrieveDataIdx", nixtag::retrieveFeatureDataIdx);
 
         classdef<nix::MultiTag>("MultiTag", methods)
             .desc(&nixmultitag::describe)
+            .add("addReference", nixmultitag::addReference)
+            .add("addReferences", nixmultitag::addReferences)
+            .add("addSource", nixmultitag::addSource)
+            .add("addSources", nixmultitag::addSources)
+            .add("createFeature", nixmultitag::createFeature)
+            .add("addPositions", nixmultitag::addPositions)
+            .add("openReferenceIdx", nixmultitag::openReferenceIdx)
+            .add("openFeatureIdx", nixmultitag::openFeatureIdx)
+            .add("openSourceIdx", nixmultitag::openSourceIdx)
+            .add("compare", nixmultitag::compare)
+            .add("sourcesFiltered", nixmultitag::sourcesFiltered)
+            .add("referencesFiltered", nixmultitag::referencesFiltered)
+            .add("featuresFiltered", nixmultitag::featuresFiltered)
+            .add("retrieveData", nixmultitag::retrieveData)
+            .add("retrieveDataIdx", nixmultitag::retrieveDataIdx)
+            .add("featureRetrieveData", nixmultitag::retrieveFeatureData)
+            .add("featureRetrieveDataIdx", nixmultitag::retrieveFeatureDataIdx)
             .reg("references", GETTER(std::vector<nix::DataArray>, nix::MultiTag, references))
             .reg("features", &nix::MultiTag::features)
             .reg("sources", FILTER(std::vector<nix::Source>, nix::MultiTag, std::function<bool(const nix::Source &)>, sources))
@@ -364,26 +381,22 @@ void mexFunction(int            nlhs,
             .reg("sourceCount", GETTER(nix::ndsize_t, nix::MultiTag, sourceCount))
             .reg("referenceCount", GETTER(nix::ndsize_t, nix::MultiTag, referenceCount))
             .reg("featureCount", GETTER(nix::ndsize_t, nix::MultiTag, featureCount));
-        methods->add("MultiTag::addReference", nixmultitag::addReference);
-        methods->add("MultiTag::addReferences", nixmultitag::addReferences);
-        methods->add("MultiTag::addSource", nixmultitag::addSource);
-        methods->add("MultiTag::addSources", nixmultitag::addSources);
-        methods->add("MultiTag::createFeature", nixmultitag::createFeature);
-        methods->add("MultiTag::addPositions", nixmultitag::addPositions);
-        methods->add("MultiTag::openReferenceIdx", nixmultitag::openReferenceIdx);
-        methods->add("MultiTag::openFeatureIdx", nixmultitag::openFeatureIdx);
-        methods->add("MultiTag::openSourceIdx", nixmultitag::openSourceIdx);
-        methods->add("MultiTag::compare", nixmultitag::compare);
-        methods->add("MultiTag::sourcesFiltered", nixmultitag::sourcesFiltered);
-        methods->add("MultiTag::referencesFiltered", nixmultitag::referencesFiltered);
-        methods->add("MultiTag::featuresFiltered", nixmultitag::featuresFiltered);
-        methods->add("MultiTag::retrieveData", nixmultitag::retrieveData);
-        methods->add("MultiTag::retrieveDataIdx", nixmultitag::retrieveDataIdx);
-        methods->add("MultiTag::featureRetrieveData", nixmultitag::retrieveFeatureData);
-        methods->add("MultiTag::featureRetrieveDataIdx", nixmultitag::retrieveFeatureDataIdx);
 
         classdef<nix::Section>("Section", methods)
             .desc(&nixsection::describe)
+            .add("createProperty", nixsection::createProperty)
+            .add("createPropertyWithValue", nixsection::createPropertyWithValue)
+            .add("referringBlockSources", nixsection::referringBlockSources)
+            .add("referringBlockTags", nixsection::referringBlockTags)
+            .add("referringBlockMultiTags", nixsection::referringBlockMultiTags)
+            .add("referringBlockDataArrays", nixsection::referringBlockDataArrays)
+            .add("openSectionIdx", nixsection::openSectionIdx)
+            .add("openPropertyIdx", nixsection::openPropertyIdx)
+            .add("compare", nixsection::compare)
+            .add("sectionsFiltered", nixsection::sectionsFiltered)
+            .add("propertiesFiltered", nixsection::propertiesFiltered)
+            .add("findSections", nixsection::findSections)
+            .add("findRelated", nixsection::findRelated)
             .reg("sections", &nix::Section::sections)
             .reg("properties", &nix::Section::properties)
             .reg("openSection", GETBYSTR(nix::Section, nix::Section, getSection))
@@ -412,29 +425,20 @@ void mexFunction(int            nlhs,
             .reg("referringMultiTags", GETTER(std::vector<nix::MultiTag>, nix::Section, referringMultiTags))
             .reg("referringSources", GETTER(std::vector<nix::Source>, nix::Section, referringSources))
             .reg("referringBlocks", GETTER(std::vector<nix::Block>, nix::Section, referringBlocks));
-        methods->add("Section::createProperty", nixsection::createProperty);
-        methods->add("Section::createPropertyWithValue", nixsection::createPropertyWithValue);
-        methods->add("Section::referringBlockSources", nixsection::referringBlockSources);
-        methods->add("Section::referringBlockTags", nixsection::referringBlockTags);
-        methods->add("Section::referringBlockMultiTags", nixsection::referringBlockMultiTags);
-        methods->add("Section::referringBlockDataArrays", nixsection::referringBlockDataArrays);
-        methods->add("Section::openSectionIdx", nixsection::openSectionIdx);
-        methods->add("Section::openPropertyIdx", nixsection::openPropertyIdx);
-        methods->add("Section::compare", nixsection::compare);
-        methods->add("Section::sectionsFiltered", nixsection::sectionsFiltered);
-        methods->add("Section::propertiesFiltered", nixsection::propertiesFiltered);
-        methods->add("Section::findSections", nixsection::findSections);
-        methods->add("Section::findRelated", nixsection::findRelated);
 
         classdef<nix::Feature>("Feature", methods)
             .desc(&nixfeature::describe)
+            .add("setLinkType", nixfeature::setLinkType)
             .reg("openData", GETCONTENT(nix::DataArray, nix::Feature, data))
             .reg("setData", SETTER(const std::string&, nix::Feature, data))
             .reg("getLinkType", GETCONTENT(nix::LinkType, nix::Feature, linkType));
-        methods->add("Feature::setLinkType", nixfeature::setLinkType);
 
         classdef<nix::Property>("Property", methods)
             .desc(&nixproperty::describe)
+            .add("values", nixproperty::values)
+            .add("updateValues", nixproperty::updateValues)
+            .add("deleteValues", nixproperty::deleteValues)
+            .add("compare", nixproperty::compare)
             .reg("setDefinition", SETTER(const std::string&, nix::Property, definition))
             .reg("setNoneDefinition", SETTER(const boost::none_t, nix::Property, definition))
             .reg("setUnit", SETTER(const std::string&, nix::Property, unit))
@@ -443,10 +447,6 @@ void mexFunction(int            nlhs,
             .reg("setNoneMapping", SETTER(const boost::none_t, nix::Property, mapping))
             .reg("valueCount", GETTER(nix::ndsize_t, nix::Property, valueCount))
             .reg("setNoneValue", SETTER(const boost::none_t, nix::Property, values));
-        methods->add("Property::values", nixproperty::values);
-        methods->add("Property::updateValues", nixproperty::updateValues);
-        methods->add("Property::deleteValues", nixproperty::deleteValues);
-        methods->add("Property::compare", nixproperty::compare);
 
         classdef<nix::SetDimension>("SetDimension", methods)
             .desc(&nixdimensions::describe)
@@ -455,6 +455,8 @@ void mexFunction(int            nlhs,
 
         classdef<nix::SampledDimension>("SampledDimension", methods)
             .desc(&nixdimensions::describe)
+            .add("positionAt", nixdimensions::sampledPositionAt)
+            .add("axis", nixdimensions::sampledAxis)
             .reg("setLabel", SETTER(const std::string&, nix::SampledDimension, label))
             .reg("setNoneLabel", SETTER(const boost::none_t, nix::SampledDimension, label))
             .reg("setUnit", SETTER(const std::string&, nix::SampledDimension, unit))
@@ -463,19 +465,17 @@ void mexFunction(int            nlhs,
             .reg("setOffset", SETTER(double, nix::SampledDimension, offset))
             .reg("setNoneOffset", SETTER(const boost::none_t, nix::SampledDimension, offset))
             .reg("indexOf", &nix::SampledDimension::indexOf);
-        methods->add("SampledDimension::positionAt", nixdimensions::sampledPositionAt);
-        methods->add("SampledDimension::axis", nixdimensions::sampledAxis);
 
         classdef<nix::RangeDimension>("RangeDimension", methods)
             .desc(&nixdimensions::describe)
+            .add("tickAt", nixdimensions::rangeTickAt)
+            .add("axis", nixdimensions::rangeAxis)
             .reg("setLabel", SETTER(const std::string&, nix::RangeDimension, label))
             .reg("setNoneLabel", SETTER(const boost::none_t, nix::RangeDimension, label))
             .reg("setUnit", SETTER(const std::string&, nix::RangeDimension, unit))
             .reg("setNoneUnit", SETTER(const boost::none_t, nix::RangeDimension, unit))
             .reg("setTicks", SETTER(const std::vector<double>&, nix::RangeDimension, ticks))
             .reg("indexOf", &nix::RangeDimension::indexOf);
-        methods->add("RangeDimension::tickAt", nixdimensions::rangeTickAt);
-        methods->add("RangeDimension::axis", nixdimensions::rangeAxis);
 
         mexAtExit(on_exit);
     });

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -98,13 +98,13 @@ function [] = test_create_data_array( varargin )
     try
         b.create_data_array('stringDataArray', dtype, nix.DataType.String, [1 5]);
     catch ME
-        assert(strcmp(ME.identifier, 'Block:unsupportedDataType'));
+        assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
     
     try
         b.create_data_array('I will crash and burn', dtype, 'Thou shalt not work!', [1 5]);
     catch ME
-        assert(strcmp(ME.identifier, 'Block:unsupportedDataType'));
+        assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
 
     da = b.create_data_array('floatDataArray', dtype, nix.DataType.Float, [3 3]);
@@ -153,13 +153,13 @@ function [] = test_create_data_array_from_data( varargin )
     try
         b.create_data_array_from_data('stringDataArray', daType, ['a' 'b']);
     catch ME
-        assert(strcmp(ME.identifier, 'Block:unsupportedDataType'));
+        assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
     
     try
         b.create_data_array_from_data('I will crash and burn', daType, {1 2 3});
     catch ME
-        assert(strcmp(ME.identifier, 'Block:unsupportedDataType'));
+        assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
     
     assert(~isempty(b.dataArrays));

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -190,18 +190,18 @@ function [] = test_write_data_double( varargin )
     try
         da.write_all(logData);
     catch ME
-        assert(strcmp(ME.identifier, 'DataArray:improperDataType'));
-    end;
+        assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
+    end
     try
         da.write_all(charData);
     catch ME
-        assert(strcmp(ME.identifier, 'DataArray:improperDataType'));
-    end;
+        assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
+    end
     try
         da.write_all(cellData);
     catch ME
-        assert(strcmp(ME.identifier, 'DataArray:improperDataType'));
-    end;
+        assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
+    end
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
@@ -225,13 +225,13 @@ function [] = test_write_data_logical( varargin )
     try
         da.write_all(numData);
     catch ME
-        assert(strcmp(ME.identifier, 'DataArray:improperDataType'));
-    end;
+        assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
+    end
     try
         da.write_all(charData);
     catch ME
-        assert(strcmp(ME.identifier, 'DataArray:improperDataType'));
-    end;
+        assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
+    end
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -149,7 +149,7 @@ end
 
 %% Test: Compare properties
 function [] = test_property_compare( varargin )
-    testFile = fullfile(pwd,'tests','testRW.h5');
+    testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s1 = f.create_section('testSection1', 'nixSection');
     s2 = f.create_section('testSection2', 'nixSection');
@@ -159,14 +159,17 @@ function [] = test_property_compare( varargin )
     % test invalid property comparison
     try
         p.compare('I shall crash and burn');
+        err.identifier = 'Test:UnraisedError';
+        error(err);
     catch ME
-        assert(strcmp(ME.message, 'Function only supports comparison of Properties.'));
+        msg = 'Only entities of the same class can be compared.';
+        assert(strcmp(ME.message, msg), 'Compare exception fail');
     end
-    
+
     % test property equal comparison
     assert(~p.compare(p));
 
     % test property not eqal
     pNEq = s2.create_property_with_value('property', {true, false});
-    assert(p.compare(pNEq)~=0);
+    assert(p.compare(pNEq) ~= 0);
 end


### PR DESCRIPTION
This PR is the second part of a series of cleanup and refactor steps to reduce code redundancy, increase readability and unify code style. Changes here all affect code on the Matlab and the C++ side of the nix-mx bindings.

Style changes:
- Cleanup of whitespace and semicolons at conditionals and constants.
- Consistently uses `isa` for class comparison.
- Changes custom error identifier, style and string format in various files to increase consistency and testability.
- [C++] Always use `classdef.add()` instead of `methods->add()` in the c++ registry part to stay consistent.

Reducing code redundancy:
- Removes obsolete Property.compare method.
- Introduces nix.Utils.createEntityArray function.
- Introduces nix.Utils.createEntity function.
- Introduces nix.Utils.parseEntityId function.
- Introduces nix.Utils.fetchEntityCount function.
- Introduces nix.Utils.fetchHasEntity function.

'Entity.info' can potentially be stale or overwritten
- Closes #151
- Adds SetAttribute=private to Entity.info property.
- Adds getter to prevent Entity.info from getting stale.
- Removes obj.info setters from File, Dynamic and DataArray.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).

Don't loose heart, it looks more intimidating than it is!