### PR TITLE
Remove 'mapping' support

### DIFF
--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -25,7 +25,6 @@ classdef Property < nix.NamedEntity
 
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'mapping', 'rw');
             nix.Dynamic.add_dyn_attr(obj, 'datatype', 'r');
         end
 

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -21,7 +21,6 @@ classdef Section < nix.NamedEntity
 
             % assign dynamic properties
             nix.Dynamic.add_dyn_attr(obj, 'repository', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'mapping', 'rw');
 
             % assign relations
             nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -441,8 +441,6 @@ void mexFunction(int            nlhs,
             .reg("setNoneDefinition", SETTER(const boost::none_t, nix::Property, definition))
             .reg("setUnit", SETTER(const std::string&, nix::Property, unit))
             .reg("setNoneUnit", SETTER(const boost::none_t, nix::Property, unit))
-            .reg("setMapping", SETTER(const std::string&, nix::Property, mapping))
-            .reg("setNoneMapping", SETTER(const boost::none_t, nix::Property, mapping))
             .reg("valueCount", GETTER(nix::ndsize_t, nix::Property, valueCount))
             .reg("setNoneValue", SETTER(const boost::none_t, nix::Property, values));
 

--- a/nix_mx.cc
+++ b/nix_mx.cc
@@ -411,8 +411,6 @@ void mexFunction(int            nlhs,
             .reg("setNoneDefinition", SETTER(const boost::none_t, nix::Section, definition))
             .reg("setRepository", SETTER(const std::string&, nix::Section, repository))
             .reg("setNoneRepository", SETTER(const boost::none_t, nix::Section, repository))
-            .reg("setMapping", SETTER(const std::string&, nix::Section, mapping))
-            .reg("setNoneMapping", SETTER(const boost::none_t, nix::Section, mapping))
             .reg("createSection", &nix::Section::createSection)
             .reg("deleteSection", REMOVER(nix::Section, nix::Section, deleteSection))
             .reg("openProperty", GETBYSTR(nix::Property, nix::Section, getProperty))

--- a/src/nixproperty.cc
+++ b/src/nixproperty.cc
@@ -18,13 +18,12 @@
 namespace nixproperty {
 
     mxArray *describe(const nix::Property &prop) {
-        struct_builder sb({ 1 }, { "id", "name", "definition", "unit", "mapping", "datatype" });
+        struct_builder sb({ 1 }, { "id", "name", "definition", "unit", "datatype" });
 
         sb.set(prop.id());
         sb.set(prop.name());
         sb.set(prop.definition());
         sb.set(prop.unit());
-        sb.set(prop.mapping());
         sb.set(string_nix2mex(prop.dataType()));
 
         return sb.array();

--- a/src/nixsection.cc
+++ b/src/nixsection.cc
@@ -21,7 +21,7 @@ namespace nixsection {
 
     mxArray *describe(const nix::Section &section) {
         struct_builder sb({ 1 }, { 
-            "name", "id", "type", "definition", "repository", "mapping"
+            "name", "id", "type", "definition", "repository"
         });
 
         sb.set(section.name());
@@ -29,7 +29,6 @@ namespace nixsection {
         sb.set(section.type());
         sb.set(section.definition());
         sb.set(section.repository());
-        sb.set(section.mapping());
 
         return sb.array();
     }

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -31,7 +31,6 @@ function [] = test_attrs( varargin )
 
     assert(isempty(p.definition));
     assert(isempty(p.unit));
-    assert(isempty(s.mapping));
 
     p.definition = 'property definition';
     p.unit = 'ms';
@@ -49,7 +48,6 @@ function [] = test_attrs( varargin )
     p.mapping = '';
     assert(isempty(p.definition));
     assert(isempty(p.unit));
-    assert(isempty(s.mapping));
 end
 
 %% Test: Access values

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -34,18 +34,14 @@ function [] = test_attrs( varargin )
 
     p.definition = 'property definition';
     p.unit = 'ms';
-    p.mapping = 'property mapping';
     assert(strcmp(p.definition, 'property definition'));
     assert(strcmp(p.unit, 'ms'));
-    assert(strcmp(p.mapping, 'property mapping'));
 
     p.definition = 'next property definition';
     p.unit = 'mm';
-    p.mapping = 'next property mapping';
 
     p.definition = '';
     p.unit = '';
-    p.mapping = '';
     assert(isempty(p.definition));
     assert(isempty(p.unit));
 end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -159,24 +159,19 @@ function [] = test_attrs( varargin )
     assert(strcmp(s.name, 'foo'));
     assert(strcmp(s.type, 'bar'));
     assert(isempty(s.repository));
-    assert(isempty(s.mapping));
     assert(isempty(s.definition));
 
     s.type = 'nixBlock';
     s.definition = 'section definition';
     s.repository = 'rep1';
-    s.mapping = 'map1';
     assert(strcmp(s.type, 'nixBlock'));
     assert(strcmp(s.definition, 'section definition'));
     assert(strcmp(s.repository, 'rep1'));
-    assert(strcmp(s.mapping, 'map1'));
 
     s.definition = '';
     s.repository = '';
-    s.mapping = '';
     assert(isempty(s.definition));
     assert(isempty(s.repository));
-    assert(isempty(s.mapping));
 end
 
 function [] = test_properties( varargin )


### PR DESCRIPTION
This tiny PR removes mapping support from Section and property in anticipation of its future removal in nix.

Closes #152.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).