### PR TITLE
Refactor index handling on Matlab side

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -49,7 +49,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             r = nix.Utils.open_entity(obj, 'getGroup', id_or_name, @nix.Group);
         end
 
-        function r = open_group_idx(obj, idx)
+        function r = open_group_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openGroupIdx', idx, @nix.Group);
         end
 
@@ -73,7 +74,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             r = nix.Utils.open_entity(obj, 'openDataArray', id_or_name, @nix.DataArray);
         end
 
-        function r = open_data_array_idx(obj, idx)
+        function r = open_data_array_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
@@ -165,7 +167,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
         end
 
-        function r = open_source_idx(obj, idx)
+        function r = open_source_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
@@ -199,7 +202,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             r = nix.Utils.open_entity(obj, 'openTag', id_or_name, @nix.Tag);
         end
 
-        function r = open_tag_idx(obj, idx)
+        function r = open_tag_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
@@ -233,7 +237,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             r = nix.Utils.open_entity(obj, 'openMultiTag', id_or_name, @nix.MultiTag);
         end
 
-        function r = open_multi_tag_idx(obj, idx)
+        function r = open_multi_tag_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -52,7 +52,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                         dimensions{i} = nix.Utils.createEntity(currList(i).dimension, ...
                             @nix.RangeDimension);
                     otherwise
-                       disp('some dimension type is unknown! skip')
+                       disp('some dimension type is unknown! skip');
                 end
             end
         end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -65,7 +65,8 @@ classdef File < nix.Entity
             r = nix.Utils.open_entity(obj, 'openBlock', id_or_name, @nix.Block);
         end
 
-        function r = open_block_idx(obj, idx)
+        function r = open_block_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openBlockIdx', idx, @nix.Block);
         end
 
@@ -99,7 +100,8 @@ classdef File < nix.Entity
             r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
         end
 
-        function r = open_section_idx(obj, idx)
+        function r = open_section_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -42,7 +42,8 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'getDataArray', id_or_name, @nix.DataArray);
         end
 
-        function r = open_data_array_idx(obj, idx)
+        function r = open_data_array_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
@@ -82,7 +83,8 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'getTag', id_or_name, @nix.Tag);
         end
 
-        function r = open_tag_idx(obj, idx)
+        function r = open_tag_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
@@ -118,7 +120,8 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'getMultiTag', id_or_name, @nix.MultiTag);
         end
 
-        function r = open_multi_tag_idx(obj, idx)
+        function r = open_multi_tag_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -52,17 +52,21 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'openReferences', id_or_name, @nix.DataArray);
         end
 
-        function r = open_reference_idx(obj, idx)
+        function r = open_reference_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
-        function r = retrieve_data(obj, pos_idx, id_or_name)
+        function r = retrieve_data(obj, position_idx, id_or_name)
+            pos_idx = nix.Utils.handle_index(position_idx);
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_data_idx(obj, pos_idx, ref_idx)
+        function r = retrieve_data_idx(obj, position_idx, reference_idx)
+            pos_idx = nix.Utils.handle_index(position_idx);
+            ref_idx = nix.Utils.handle_index(reference_idx);
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, pos_idx, ref_idx);
             r = nix.Utils.transpose_array(data);
@@ -99,17 +103,21 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'openFeature', id_or_name, @nix.Feature);
         end
 
-        function r = open_feature_idx(obj, idx)
+        function r = open_feature_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
-        function r = retrieve_feature_data(obj, pos_idx, id_or_name)
+        function r = retrieve_feature_data(obj, position_idx, id_or_name)
+            pos_idx = nix.Utils.handle_index(position_idx);
             fname = strcat(obj.alias, '::featureRetrieveData');
             data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_feature_data_idx(obj, pos_idx, feat_idx)
+        function r = retrieve_feature_data_idx(obj, position_idx, feature_idx)
+            pos_idx = nix.Utils.handle_index(position_idx);
+            feat_idx = nix.Utils.handle_index(feature_idx);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, pos_idx, feat_idx);
             r = nix.Utils.transpose_array(data);

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -27,9 +27,7 @@ classdef RangeDimension < nix.Entity
         end
 
         function r = tick_at(obj, index)
-            if (index > 0)
-                index = index - 1;
-            end
+            index = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::tickAt');
             r = nix_mx(fname, obj.nix_handle, index);
         end
@@ -41,12 +39,10 @@ classdef RangeDimension < nix.Entity
 
         function r = axis(obj, count, startIndex)
             if (nargin < 3)
-                startIndex = 0;
+                startIndex = 1;
             end
 
-            if (startIndex > 0)
-                startIndex = startIndex - 1;
-            end
+            startIndex = nix.Utils.handle_index(startIndex);
 
             fname = strcat(obj.alias, '::axis');
             r = nix_mx(fname, obj.nix_handle, count, startIndex);

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -32,23 +32,17 @@ classdef SampledDimension < nix.Entity
         end
 
         function r = position_at(obj, index)
-            if (index > 0)
-                index = index - 1;
-            end
-
+            index = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::positionAt');
             r = nix_mx(fname, obj.nix_handle, index);
         end
 
         function r = axis(obj, count, startIndex)
             if (nargin < 3)
-                startIndex = 0;
+                startIndex = 1;
             end
 
-            if (startIndex > 0)
-                startIndex = startIndex - 1;
-            end
-
+            startIndex = nix.Utils.handle_index(startIndex);
             fname = strcat(obj.alias, '::axis');
             r = nix_mx(fname, obj.nix_handle, count, startIndex);
         end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -70,7 +70,8 @@ classdef Section < nix.NamedEntity
             r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
         end
 
-        function r = open_section_idx(obj, idx)
+        function r = open_section_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
@@ -144,7 +145,8 @@ classdef Section < nix.NamedEntity
             r = nix.Utils.open_entity(obj, 'openProperty', id_or_name, @nix.Property);
         end
 
-        function r = open_property_idx(obj, idx)
+        function r = open_property_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openPropertyIdx', idx, @nix.Property);
         end
 

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -95,12 +95,12 @@ classdef Section < nix.NamedEntity
             r = nix.Utils.filter(obj, 'findRelated', filter, val, @nix.Section);
         end
 
-        % maxdepth is an index
+        % maxdepth is handled like an index
         function r = find_sections(obj, max_depth)
             r = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
         end
 
-        % maxdepth is an index
+        % maxdepth is handled like an index
         function r = find_filtered_sections(obj, max_depth, filter, val)
             r = nix.Utils.find(obj, 'findSections', max_depth, filter, val, @nix.Section);
         end

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -49,7 +49,8 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
         end
 
-        function r = open_source_idx(obj, idx)
+        function r = open_source_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -45,7 +45,8 @@ classdef SourcesMixIn < handle
             r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
         end
 
-        function r = open_source_idx(obj, idx)
+        function r = open_source_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -54,7 +54,8 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'openReferenceDataArray', id_or_name, @nix.DataArray);
         end
 
-        function r = open_reference_idx(obj, idx)
+        function r = open_reference_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
@@ -64,7 +65,8 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_data_idx(obj, idx)
+        function r = retrieve_data_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
             r = nix.Utils.transpose_array(data);
@@ -101,7 +103,8 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.open_entity(obj, 'openFeature', id_or_name, @nix.Feature);
         end
 
-        function r = open_feature_idx(obj, idx)
+        function r = open_feature_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
@@ -111,7 +114,8 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_feature_data_idx(obj, idx)
+        function r = retrieve_feature_data_idx(obj, index)
+            idx = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
             r = nix.Utils.transpose_array(data);

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -158,12 +158,25 @@ classdef Utils
         end
 
         % -----------------------------------------------------------
-        % c++ to matlab array functions
+        % c++ vs matlab helper functions
         % -----------------------------------------------------------
 
         function r = transpose_array(data)
         % Data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
+        end
+        
+        function r = handle_index(idx)
+        % Matlab uses 1-based indexing opposed to 0 based indexing in C++.
+        % handle_index transforms a Matlab style index to a C++ style
+        % index and raises the appropriate Matlab error in case of an
+        % invalid subscript.
+            if (idx < 1)
+                err.identifier = 'MATLAB:badsubscript';
+                err.message = 'Subscript indices must either be real positive integers or logicals.';
+                error(err);
+            end
+            r = idx - 1;
         end
     end
 

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -152,8 +152,11 @@ classdef Utils
 
             nix.Utils.valid_filter(filter, val);
 
+            % transform matlab to c++ style index
+            md = nix.Utils.handle_index(max_depth);
+
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            list = nix_mx(mxMethod, obj.nix_handle, max_depth, uint8(filter), val);
+            list = nix_mx(mxMethod, obj.nix_handle, md, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
@@ -165,7 +168,7 @@ classdef Utils
         % Data must agree with file & dimensions; see mkarray.cc(42)
             r = permute(data, length(size(data)):-1:1);
         end
-        
+
         function r = handle_index(idx)
         % Matlab uses 1-based indexing opposed to 0 based indexing in C++.
         % handle_index transforms a Matlab style index to a C++ style

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -438,9 +438,9 @@ function [] = test_open_group_idx( varargin )
     g2 = b.create_group('testGroup2', 'nixGroup');
     g3 = b.create_group('testGroup3', 'nixGroup');
 
-    assert(strcmp(f.blocks{1}.open_group_idx(0).name, g1.name));
-    assert(strcmp(f.blocks{1}.open_group_idx(1).name, g2.name));
-    assert(strcmp(f.blocks{1}.open_group_idx(2).name, g3.name));
+    assert(strcmp(f.blocks{1}.open_group_idx(1).name, g1.name));
+    assert(strcmp(f.blocks{1}.open_group_idx(2).name, g2.name));
+    assert(strcmp(f.blocks{1}.open_group_idx(3).name, g3.name));
 end
 
 function [] = test_open_data_array_idx( varargin )
@@ -451,9 +451,9 @@ function [] = test_open_data_array_idx( varargin )
     d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
     d3 = b.create_data_array('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
 
-    assert(strcmp(f.blocks{1}.open_data_array_idx(0).name, d1.name));
-    assert(strcmp(f.blocks{1}.open_data_array_idx(1).name, d2.name));
-    assert(strcmp(f.blocks{1}.open_data_array_idx(2).name, d3.name));
+    assert(strcmp(f.blocks{1}.open_data_array_idx(1).name, d1.name));
+    assert(strcmp(f.blocks{1}.open_data_array_idx(2).name, d2.name));
+    assert(strcmp(f.blocks{1}.open_data_array_idx(3).name, d3.name));
 end
 
 function [] = test_open_tag_idx( varargin )
@@ -464,9 +464,9 @@ function [] = test_open_tag_idx( varargin )
     t2 = b.create_tag('testTag2', 'nixTag', [1 2]);
     t3 = b.create_tag('testTag3', 'nixTag', [1 2]);
 
-    assert(strcmp(f.blocks{1}.open_tag_idx(0).name, t1.name));
-    assert(strcmp(f.blocks{1}.open_tag_idx(1).name, t2.name));
-    assert(strcmp(f.blocks{1}.open_tag_idx(2).name, t3.name));
+    assert(strcmp(f.blocks{1}.open_tag_idx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.open_tag_idx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.open_tag_idx(3).name, t3.name));
 end
 
 function [] = test_open_multi_tag_idx( varargin )
@@ -478,9 +478,9 @@ function [] = test_open_multi_tag_idx( varargin )
     t2 = b.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
     t3 = b.create_multi_tag('testMultiTag3', 'nixMultiTag', d);
 
-    assert(strcmp(f.blocks{1}.open_multi_tag_idx(0).name, t1.name));
-    assert(strcmp(f.blocks{1}.open_multi_tag_idx(1).name, t2.name));
-    assert(strcmp(f.blocks{1}.open_multi_tag_idx(2).name, t3.name));
+    assert(strcmp(f.blocks{1}.open_multi_tag_idx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.open_multi_tag_idx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.open_multi_tag_idx(3).name, t3.name));
 end
 
 function [] = test_open_source_idx( varargin )
@@ -491,9 +491,9 @@ function [] = test_open_source_idx( varargin )
     s2 = b.create_source('testSource2', 'nixSource');
     s3 = b.create_source('testSource3', 'nixSource');
 
-    assert(strcmp(f.blocks{1}.open_source_idx(0).name, s1.name));
-    assert(strcmp(f.blocks{1}.open_source_idx(1).name, s2.name));
-    assert(strcmp(f.blocks{1}.open_source_idx(2).name, s3.name));
+    assert(strcmp(f.blocks{1}.open_source_idx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.open_source_idx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.open_source_idx(3).name, s3.name));
 end
 
 function [] = test_has_multitag( varargin )
@@ -1165,9 +1165,9 @@ function [] = test_find_source_filtered
     sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
 
     % test find by id
-    filtered = b.find_filtered_sources(0, nix.Filter.id, sl41.id);
+    filtered = b.find_filtered_sources(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(3, nix.Filter.id, sl41.id);
+    filtered = b.find_filtered_sources(4, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -1125,23 +1125,23 @@ function [] = test_find_source
     end
 
     % find all
-    filtered = b.find_sources(4);
+    filtered = b.find_sources(5);
     assert(size(filtered, 1) == 10);
 
     % find until level 4
-    filtered = b.find_sources(3);
+    filtered = b.find_sources(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
-    filtered = b.find_sources(2);
+    filtered = b.find_sources(3);
     assert(size(filtered, 1) == 6);
 
     % find until level 2
-    filtered = b.find_sources(1);
+    filtered = b.find_sources(2);
     assert(size(filtered, 1) == 3);
 
     % find until level 1
-    filtered = b.find_sources(0);
+    filtered = b.find_sources(1);
     assert(size(filtered, 1) == 1);
 end
 
@@ -1165,46 +1165,46 @@ function [] = test_find_source_filtered
     sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
 
     % test find by id
-    filtered = b.find_filtered_sources(1, nix.Filter.id, sl41.id);
+    filtered = b.find_filtered_sources(2, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(4, nix.Filter.id, sl41.id);
+    filtered = b.find_filtered_sources(5, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = b.find_filtered_sources(0, nix.Filter.ids, filterids);
+    filtered = b.find_filtered_sources(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = b.find_filtered_sources(3, nix.Filter.ids, filterids);
+    filtered = b.find_filtered_sources(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = b.find_filtered_sources(0, nix.Filter.name, sl41.name);
+    filtered = b.find_filtered_sources(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(3, nix.Filter.name, sl41.name);
+    filtered = b.find_filtered_sources(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = b.find_filtered_sources(0, nix.Filter.type, findSource);
+    filtered = b.find_filtered_sources(1, nix.Filter.type, findSource);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(3, nix.Filter.type, findSource);
+    filtered = b.find_filtered_sources(4, nix.Filter.type, findSource);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSource));
 
     % test nix.Filter.metadata
     sec = f.create_section('testSection', 'nixSection');
     sl43.set_metadata(sec);
-    filtered = b.find_filtered_sources(0, nix.Filter.metadata, sec.id);
+    filtered = b.find_filtered_sources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(3, nix.Filter.metadata, sec.id);
+    filtered = b.find_filtered_sources(4, nix.Filter.metadata, sec.id);
     assert(size(filtered, 1) == 1);
     strcmp(filtered{1}.id, sl43.id);
 
     % test nix.Filter.source
-    filtered = b.find_filtered_sources(0, nix.Filter.source, sl44.id);
+    filtered = b.find_filtered_sources(1, nix.Filter.source, sl44.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(3, nix.Filter.source, sl44.id);
+    filtered = b.find_filtered_sources(4, nix.Filter.source, sl44.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl31.id));
 end

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -384,9 +384,9 @@ function [] = test_open_source_idx( varargin )
     d.add_source(s2);
     d.add_source(s3);
 
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(0).name, s1.name));
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(1).name, s2.name));
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(2).name, s3.name));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(3).name, s3.name));
 end
 
 %% Test: Remove sources by entity and id

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -65,7 +65,7 @@ function [] = test_sample_dimension( varargin )
     assert(d1.samplingInterval == 200);
     assert(isempty(d1.offset));
 
-    axis = d1.axis(10, 0);
+    axis = d1.axis(10, 1);
     assert(axis(1) == 0);
     assert(length(axis) == 10);
     assert(axis(end) == (length(axis) - 1) * d1.samplingInterval);
@@ -80,12 +80,12 @@ function [] = test_sample_dimension( varargin )
     assert(d1.samplingInterval == 325);
     assert(d1.offset == 500);
     
-    axis = d1.axis(10, 0);
+    axis = d1.axis(10, 1);
     assert(axis(1) == d1.offset);
     assert(length(axis) == 10);
     assert(axis(end) == (length(axis) - 1) * d1.samplingInterval + d1.offset);
     
-    assert(d1.position_at(0) == d1.offset);
+    assert(d1.position_at(1) == d1.offset);
     assert(d1.position_at(10) == d1.offset + 9 * d1.samplingInterval);
 
     d1.label = '';
@@ -97,11 +97,11 @@ function [] = test_sample_dimension( varargin )
     assert(d1.samplingInterval == 325);
     assert(d1.offset == 0);
 
-    axis = d1.axis(10, 0);
+    axis = d1.axis(10, 1);
     assert(axis(1) == 0);
     assert(axis(end) == (length(axis) - 1) * d1.samplingInterval + d1.offset);
     
-    assert(d1.position_at(0) == d1.offset);
+    assert(d1.position_at(1) == d1.offset);
     assert(d1.position_at(10) == d1.offset + 9 * d1.samplingInterval);
 end
 
@@ -119,12 +119,12 @@ function [] = test_range_dimension( varargin )
     assert(isempty(d1.unit));
     assert(isequal(d1.ticks, ticks));
 
-    axis = d1.axis(3, 0);
+    axis = d1.axis(3, 1);
     assert(axis(1) == ticks(1));
     assert(length(axis) == 3);
     assert(axis(end) == ticks(length(axis)));
 
-    assert(d1.tick_at(0) == ticks(1));
+    assert(d1.tick_at(1) == ticks(1));
     assert(d1.tick_at(3) == ticks(3));
 
     new_ticks = [5 6 7 8];

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -440,23 +440,23 @@ function [] = test_find_section
     end
 
     % find all
-    filtered = f.find_sections(4);
+    filtered = f.find_sections(5);
     assert(size(filtered, 1) == 10);
 
     % find until level 4
-    filtered = f.find_sections(3);
+    filtered = f.find_sections(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
-    filtered = f.find_sections(2);
+    filtered = f.find_sections(3);
     assert(size(filtered, 1) == 6);
 
     % find until level 2
-    filtered = f.find_sections(1);
+    filtered = f.find_sections(2);
     assert(size(filtered, 1) == 3);
 
     % find until level 1
-    filtered = f.find_sections(0);
+    filtered = f.find_sections(1);
     assert(size(filtered, 1) == 1);
 end
 
@@ -479,30 +479,30 @@ function [] = test_find_section_filtered
     sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
 
     % test find by id
-    filtered = f.find_filtered_sections(0, nix.Filter.id, sl41.id);
+    filtered = f.find_filtered_sections(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = f.find_filtered_sections(3, nix.Filter.id, sl41.id);
+    filtered = f.find_filtered_sections(4, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = f.find_filtered_sections(0, nix.Filter.ids, filterids);
+    filtered = f.find_filtered_sections(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = f.find_filtered_sections(3, nix.Filter.ids, filterids);
+    filtered = f.find_filtered_sections(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = f.find_filtered_sections(0, nix.Filter.name, sl41.name);
+    filtered = f.find_filtered_sections(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = f.find_filtered_sections(3, nix.Filter.name, sl41.name);
+    filtered = f.find_filtered_sections(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = f.find_filtered_sections(0, nix.Filter.type, findSection);
+    filtered = f.find_filtered_sections(1, nix.Filter.type, findSection);
     assert(isempty(filtered));
-    filtered = f.find_filtered_sections(3, nix.Filter.type, findSection);
+    filtered = f.find_filtered_sections(4, nix.Filter.type, findSection);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSection));
 

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -236,9 +236,9 @@ function [] = test_open_section_idx( varargin )
     s2 = f.create_section('testSection2', 'nixSection');
     s3 = f.create_section('testSection3', 'nixSection');
 
-    assert(strcmp(f.open_section_idx(0).name, s1.name));
-    assert(strcmp(f.open_section_idx(1).name, s2.name));
-    assert(strcmp(f.open_section_idx(2).name, s3.name));
+    assert(strcmp(f.open_section_idx(1).name, s1.name));
+    assert(strcmp(f.open_section_idx(2).name, s2.name));
+    assert(strcmp(f.open_section_idx(3).name, s3.name));
 end
 
 function [] = test_open_block( varargin )
@@ -263,9 +263,9 @@ function [] = test_open_block_idx( varargin )
     b2 = f.create_block('testBlock2', 'nixBlock');
     b3 = f.create_block('testBlock3', 'nixBlock');
 
-    assert(strcmp(f.open_block_idx(0).name, b1.name));
-    assert(strcmp(f.open_block_idx(1).name, b2.name));
-    assert(strcmp(f.open_block_idx(2).name, b3.name));
+    assert(strcmp(f.open_block_idx(1).name, b1.name));
+    assert(strcmp(f.open_block_idx(2).name, b2.name));
+    assert(strcmp(f.open_block_idx(3).name, b3.name));
 end
 
 %% Test: nix.File has nix.Block by ID or name

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -854,9 +854,9 @@ function [] = test_open_source_idx( varargin )
     g.add_source(s2);
     g.add_source(s3);
 
-    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(0).name, s1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(1).name, s2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(2).name, s3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(3).name, s3.name));
 end
 
 function [] = test_compare( varargin )

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -802,9 +802,9 @@ function [] = test_open_data_array_idx( varargin )
     g.add_data_array(d2);
     g.add_data_array(d3);
     
-    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(0).name, d1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(1).name, d2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(2).name, d3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(1).name, d1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(2).name, d2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(3).name, d3.name));
 end
 
 function [] = test_open_tag_idx( varargin )
@@ -819,9 +819,9 @@ function [] = test_open_tag_idx( varargin )
     g.add_tag(t2);
     g.add_tag(t3);
 
-    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(0).name, t1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(1).name, t2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(2).name, t3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(3).name, t3.name));
 end
 
 function [] = test_open_multi_tag_idx( varargin )
@@ -837,9 +837,9 @@ function [] = test_open_multi_tag_idx( varargin )
     g.add_multi_tag(t2);
     g.add_multi_tag(t3);
     
-    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(0).name, t1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(1).name, t2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(2).name, t3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(3).name, t3.name));
 end
 
 function [] = test_open_source_idx( varargin )

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -431,9 +431,9 @@ function [] = test_open_feature_idx( varargin )
     t.add_feature(f2, nix.LinkType.Untagged);
     t.add_feature(f3, nix.LinkType.Indexed);
 
-    assert(f.blocks{1}.multiTags{1}.open_feature_idx(0).linkType == nix.LinkType.Tagged);
-    assert(f.blocks{1}.multiTags{1}.open_feature_idx(1).linkType == nix.LinkType.Untagged);
-    assert(f.blocks{1}.multiTags{1}.open_feature_idx(2).linkType == nix.LinkType.Indexed);
+    assert(f.blocks{1}.multiTags{1}.open_feature_idx(1).linkType == nix.LinkType.Tagged);
+    assert(f.blocks{1}.multiTags{1}.open_feature_idx(2).linkType == nix.LinkType.Untagged);
+    assert(f.blocks{1}.multiTags{1}.open_feature_idx(3).linkType == nix.LinkType.Indexed);
 end
 
 %% Test: Open reference by ID or name
@@ -470,9 +470,9 @@ function [] = test_open_reference_idx( varargin )
     t.add_reference(r2);
     t.add_reference(r3);
 
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(0).name, r1.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(1).name, r2.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(2).name, r3.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(1).name, r1.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(2).name, r2.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(3).name, r3.name));
 end
 
 %% Test: Feature count
@@ -696,7 +696,7 @@ function [] = test_retrieve_data( varargin )
 
     % test invalid reference name
     try
-        t.retrieve_data(0, 'I do not exist');
+        t.retrieve_data(1, 'I do not exist');
     catch ME
         assert(~isempty(strfind(ME.message, 'no DataArray with the specified name or id')), ...
             'Invalid reference name failed');
@@ -704,9 +704,9 @@ function [] = test_retrieve_data( varargin )
     assert(exist('ME') == 1, 'Invalid reference name fail, error not raised');
     clear ME;
  
-    assert(isequal(t.retrieve_data(0, d1.name), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
-    assert(isequal(t.retrieve_data(1, d1.id), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
-    assert(isequal(t.retrieve_data(2, d2.id), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
+    assert(isequal(t.retrieve_data(1, d1.name), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
+    assert(isequal(t.retrieve_data(2, d1.id), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
+    assert(isequal(t.retrieve_data(3, d2.id), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
 end
 
 %% Test: Retrieve reference data by index
@@ -749,7 +749,7 @@ function [] = test_retrieve_data_idx( varargin )
 
     % test invalid position idx
     try
-        t.retrieve_data_idx(100, 0);
+        t.retrieve_data_idx(100, 1);
     catch ME
         assert(~isempty(strfind(ME.message, 'ounds of positions or extents')), ...
             'Invalid position index failed');
@@ -757,15 +757,15 @@ function [] = test_retrieve_data_idx( varargin )
 
     % test invalid reference idx
     try
-        t.retrieve_data_idx(0, 100);
+        t.retrieve_data_idx(1, 100);
     catch ME
         assert(~isempty(strfind(ME.message, 'out of bounds')), ...
             'Invalid reference index failed');
     end
     
-    assert(isequal(t.retrieve_data_idx(0, 0), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
-    assert(isequal(t.retrieve_data_idx(1, 0), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
-    assert(isequal(t.retrieve_data_idx(2, 1), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
+    assert(isequal(t.retrieve_data_idx(1, 1), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
+    assert(isequal(t.retrieve_data_idx(2, 1), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
+    assert(isequal(t.retrieve_data_idx(3, 2), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
 end
 
 %% Test: Retrieve feature data by id or name
@@ -817,7 +817,7 @@ function [] = test_retrieve_feature_data( varargin )
 
     % test invalid name or id
     try
-        t.retrieve_feature_data(0, 'I do not exist');
+        t.retrieve_feature_data(1, 'I do not exist');
     catch ME
         assert(~isempty(strfind(ME.message, 'no Feature with the specified name or id')), ...
             'Invalid reference name failed');
@@ -830,25 +830,25 @@ function [] = test_retrieve_feature_data( varargin )
     assert(isequal(raw_feat1, retData), 'Untagged fail');
 
     % test tagged properly applies position and extents
-    retData = t.retrieve_feature_data(0, da_feat2.id);
+    retData = t.retrieve_feature_data(1, da_feat2.id);
     assert(isequal(retData, [21]), 'Tagged pos 1 fail');
 
-    retData = t.retrieve_feature_data(1, da_feat2.name);
+    retData = t.retrieve_feature_data(2, da_feat2.name);
     assert(isequal(retData, [24]), 'Tagged pos 2 fail');
 
-    retData = t.retrieve_feature_data(2, da_feat2.id);
+    retData = t.retrieve_feature_data(3, da_feat2.id);
     assert(isequal(retData, [26, 27, 28]), 'Tagged pos 3 fail');
 
     % test indexed returns first and last index value
-    retData = t.retrieve_feature_data(0, da_feat3.id);
+    retData = t.retrieve_feature_data(1, da_feat3.id);
     assert(isequal(retData, raw_feat3(1)), 'Indexed first pos fail');
     
-    retData = t.retrieve_feature_data(7, da_feat3.name);
+    retData = t.retrieve_feature_data(8, da_feat3.name);
     assert(isequal(retData, raw_feat3(end)), 'Indexed last pos fail');
     
     % test indexed fail when accessing position > length of referenced array
     try
-        t.retrieve_feature_data(size(raw_feat3, 2) + 1, da_feat3.id);
+        t.retrieve_feature_data(size(raw_feat3, 2) + 2, da_feat3.id);
     catch ME
         assert(~isempty(strfind(ME.message, 'than the data stored in the feature')), ...
             'Indexed out of length fail');
@@ -896,9 +896,9 @@ function [] = test_retrieve_feature_data_idx( varargin )
 
     % test invalid position idx
     try
-        t.retrieve_feature_data_idx(100, 1);
+        t.retrieve_feature_data_idx(100, 2);
     catch ME
-        assert(isempty(strfind(ME.message, 'ounds of positions or extents')), ...
+        assert(~isempty(strfind(ME.message, 'ounds of positions')), ...
             'Invalid position index failed');
     end
     assert(exist('ME') == 1, 'Invalid position index fail, error not raised');
@@ -906,7 +906,7 @@ function [] = test_retrieve_feature_data_idx( varargin )
 
     % test invalid feature idx
     try
-        t.retrieve_feature_data_idx(0, 100);
+        t.retrieve_feature_data_idx(1, 100);
     catch ME
         assert(~isempty(strfind(ME.message, 'out of bounds')), ...
             'Invalid reference index failed');
@@ -915,29 +915,29 @@ function [] = test_retrieve_feature_data_idx( varargin )
     clear ME;
 
     % test untagged ignores position and returns full data
-    retData = t.retrieve_feature_data_idx(100, 0);
+    retData = t.retrieve_feature_data_idx(100, 1);
     assert(isequal(raw_feat1, retData), 'Untagged fail');
 
     % test tagged properly applies position and extents
-    retData = t.retrieve_feature_data_idx(0, 1);
+    retData = t.retrieve_feature_data_idx(1, 2);
     assert(isequal(retData, [21]), 'Tagged pos 1 fail');
 
-    retData = t.retrieve_feature_data_idx(1, 1);
+    retData = t.retrieve_feature_data_idx(2, 2);
     assert(isequal(retData, [24]), 'Tagged pos 2 fail');
 
-    retData = t.retrieve_feature_data_idx(2, 1);
+    retData = t.retrieve_feature_data_idx(3, 2);
     assert(isequal(retData, [26, 27, 28]), 'Tagged pos 3 fail');
 
     % test indexed returns first and last index value
-    retData = t.retrieve_feature_data_idx(0, 2);
+    retData = t.retrieve_feature_data_idx(1, 3);
     assert(isequal(retData, raw_feat3(1)), 'Indexed first pos fail');
     
-    retData = t.retrieve_feature_data_idx(7, 2);
+    retData = t.retrieve_feature_data_idx(8, 3);
     assert(isequal(retData, raw_feat3(end)), 'Indexed last pos fail');
     
     % test indexed fail when accessing position > length of referenced array
     try
-        t.retrieve_feature_data_idx(size(raw_feat3, 2) + 1, 2);
+        t.retrieve_feature_data_idx(size(raw_feat3, 2) + 2, 3);
     catch ME
         assert(~isempty(strfind(ME.message, 'than the data stored in the feature')), ...
             'Indexed out of length fail');

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -360,9 +360,9 @@ function [] = test_open_source_idx( varargin )
     t.add_source(s2);
     t.add_source(s3);
 
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(0).name, s1.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(1).name, s2.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(2).name, s3.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(3).name, s3.name));
 end
 
 %% Test: has nix.Source by ID or entity

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -106,9 +106,9 @@ function [] = test_open_section_idx( varargin )
     s2 = s.create_section('testSection2', 'nixSection');
     s3 = s.create_section('testSection3', 'nixSection');
 
-    assert(strcmp(f.sections{1}.open_section_idx(0).name, s1.name));
-    assert(strcmp(f.sections{1}.open_section_idx(1).name, s2.name));
-    assert(strcmp(f.sections{1}.open_section_idx(2).name, s3.name));
+    assert(strcmp(f.sections{1}.open_section_idx(1).name, s1.name));
+    assert(strcmp(f.sections{1}.open_section_idx(2).name, s2.name));
+    assert(strcmp(f.sections{1}.open_section_idx(3).name, s3.name));
 end
 
 function [] = test_parent( varargin )
@@ -292,9 +292,9 @@ function [] = test_open_property_idx( varargin )
     p2 = s.create_property('testProperty2', nix.DataType.Bool);
     p3 = s.create_property('testProperty3', nix.DataType.String);
 
-    assert(strcmp(f.sections{1}.open_property_idx(0).name, p1.name));
-    assert(strcmp(f.sections{1}.open_property_idx(1).name, p2.name));
-    assert(strcmp(f.sections{1}.open_property_idx(2).name, p3.name));
+    assert(strcmp(f.sections{1}.open_property_idx(1).name, p1.name));
+    assert(strcmp(f.sections{1}.open_property_idx(2).name, p2.name));
+    assert(strcmp(f.sections{1}.open_property_idx(3).name, p3.name));
 end
 
 %% Test: Property count

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -753,23 +753,23 @@ function [] = test_find_section
     end
 
     % find all
-    filtered = sl1.find_sections(4);
+    filtered = sl1.find_sections(5);
     assert(size(filtered, 1) == 10);
 
     % find until level 4
-    filtered = sl1.find_sections(3);
+    filtered = sl1.find_sections(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
-    filtered = sl1.find_sections(2);
+    filtered = sl1.find_sections(3);
     assert(size(filtered, 1) == 6);
 
     % find until level 2
-    filtered = sl1.find_sections(1);
+    filtered = sl1.find_sections(2);
     assert(size(filtered, 1) == 3);
 
     % find until level 1
-    filtered = sl1.find_sections(0);
+    filtered = sl1.find_sections(1);
     assert(size(filtered, 1) == 1);
 end
 
@@ -797,32 +797,32 @@ function [] = test_find_section_filtered
     side1 = side.create_section(sideName, 'nixSection');
 
     % test find by id
-    filtered = sl1.find_filtered_sections(0, nix.Filter.id, sl41.id);
+    filtered = sl1.find_filtered_sections(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(3, nix.Filter.id, sl41.id);
+    filtered = sl1.find_filtered_sections(4, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = sl1.find_filtered_sections(0, nix.Filter.ids, filterids);
+    filtered = sl1.find_filtered_sections(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = sl1.find_filtered_sections(3, nix.Filter.ids, filterids);
+    filtered = sl1.find_filtered_sections(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = sl1.find_filtered_sections(4, nix.Filter.name, sideName);
+    filtered = sl1.find_filtered_sections(5, nix.Filter.name, sideName);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(0, nix.Filter.name, sl41.name);
+    filtered = sl1.find_filtered_sections(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(3, nix.Filter.name, sl41.name);
+    filtered = sl1.find_filtered_sections(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = sl1.find_filtered_sections(0, nix.Filter.type, findSection);
+    filtered = sl1.find_filtered_sections(1, nix.Filter.type, findSection);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(3, nix.Filter.type, findSection);
+    filtered = sl1.find_filtered_sections(4, nix.Filter.type, findSection);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSection));
 

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -82,9 +82,9 @@ function [] = test_open_source_idx( varargin )
     s2 = s.create_source('testSource2', 'nixSource');
     s3 = s.create_source('testSource3', 'nixSource');
 
-    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(0).name, s1.name));
-    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(1).name, s2.name));
-    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(2).name, s3.name));
+    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(3).name, s3.name));
 end
 
 %% Test: Source count

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -400,23 +400,23 @@ function [] = test_find_source
     end
 
     % find all
-    filtered = s.find_sources(4);
+    filtered = s.find_sources(5);
     assert(size(filtered, 1) == 11);
 
     % find until level 3
-    filtered = s.find_sources(3);
+    filtered = s.find_sources(4);
     assert(size(filtered, 1) == 7);
 
     % find until level 2
-    filtered = s.find_sources(2);
+    filtered = s.find_sources(3);
     assert(size(filtered, 1) == 4);
 
     % find until level 1
-    filtered = s.find_sources(1);
+    filtered = s.find_sources(2);
     assert(size(filtered, 1) == 2);
 
     % find until level 0
-    filtered = s.find_sources(0);
+    filtered = s.find_sources(1);
     assert(size(filtered, 1) == 1);
 end
 
@@ -441,46 +441,46 @@ function [] = test_find_source_filtered
     sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
 
     % test find by id
-    filtered = s.find_filtered_sources(0, nix.Filter.id, sl41.id);
+    filtered = s.find_filtered_sources(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(4, nix.Filter.id, sl41.id);
+    filtered = s.find_filtered_sources(5, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = s.find_filtered_sources(1, nix.Filter.ids, filterids);
+    filtered = s.find_filtered_sources(2, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = s.find_filtered_sources(4, nix.Filter.ids, filterids);
+    filtered = s.find_filtered_sources(5, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = s.find_filtered_sources(0, nix.Filter.name, sl41.name);
+    filtered = s.find_filtered_sources(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(4, nix.Filter.name, sl41.name);
+    filtered = s.find_filtered_sources(5, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = s.find_filtered_sources(0, nix.Filter.type, findSource);
+    filtered = s.find_filtered_sources(1, nix.Filter.type, findSource);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(4, nix.Filter.type, findSource);
+    filtered = s.find_filtered_sources(5, nix.Filter.type, findSource);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSource));
 
     % test nix.Filter.metadata
     sec = f.create_section('testSection', 'nixSection');
     sl43.set_metadata(sec);
-    filtered = s.find_filtered_sources(0, nix.Filter.metadata, sec.id);
+    filtered = s.find_filtered_sources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(4, nix.Filter.metadata, sec.id);
+    filtered = s.find_filtered_sources(5, nix.Filter.metadata, sec.id);
     assert(size(filtered, 1) == 1);
     strcmp(filtered{1}.id, sl43.id);
 
     % test nix.Filter.source
-    filtered = s.find_filtered_sources(0, nix.Filter.source, sl44.id);
+    filtered = s.find_filtered_sources(1, nix.Filter.source, sl44.id);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(4, nix.Filter.source, sl44.id);
+    filtered = s.find_filtered_sources(5, nix.Filter.source, sl44.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl31.id));
 end

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -440,9 +440,9 @@ function [] = test_open_feature_idx( varargin )
     t.add_feature(d2, nix.LinkType.Untagged);
     t.add_feature(d3, nix.LinkType.Indexed);
 
-    assert(f.blocks{1}.tags{1}.open_feature_idx(0).linkType == nix.LinkType.Tagged);
-    assert(f.blocks{1}.tags{1}.open_feature_idx(1).linkType == nix.LinkType.Untagged);
-    assert(f.blocks{1}.tags{1}.open_feature_idx(2).linkType == nix.LinkType.Indexed);
+    assert(f.blocks{1}.tags{1}.open_feature_idx(1).linkType == nix.LinkType.Tagged);
+    assert(f.blocks{1}.tags{1}.open_feature_idx(2).linkType == nix.LinkType.Untagged);
+    assert(f.blocks{1}.tags{1}.open_feature_idx(3).linkType == nix.LinkType.Indexed);
 end
 
 %% Test: Open reference by ID or name
@@ -477,9 +477,9 @@ function [] = test_open_reference_idx( varargin )
     t.add_reference(d2);
     t.add_reference(d3);
 
-    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(0).name, d1.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(1).name, d2.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(2).name, d3.name));
+    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(1).name, d1.name));
+    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(2).name, d2.name));
+    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(3).name, d3.name));
 end
 
 %% Test: Set metadata
@@ -582,7 +582,7 @@ function [] = test_retrieve_data_idx( varargin )
         assert(~isempty(strfind(ME.message, 'out of bounds')), 'Invalid index failed');
     end
 
-    retData = t.retrieve_data_idx(0);
+    retData = t.retrieve_data_idx(1);
     assert(size(retData, 2) == t.extent, 'Extent check failed');
     assert(retData(1) == raw(t.position + 1), 'Position check failed');
 end
@@ -650,14 +650,14 @@ function [] = test_retrieve_feature_data_idx( varargin )
     df = b.create_data_array_from_data('testUntagged', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Untagged);
-    retData = t.retrieve_feature_data_idx(0);
+    retData = t.retrieve_feature_data_idx(1);
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data 
     df = b.create_data_array_from_data('testTagged', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Tagged);
-    retData = t.retrieve_feature_data_idx(1);
+    retData = t.retrieve_feature_data_idx(2);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
 
@@ -665,7 +665,7 @@ function [] = test_retrieve_feature_data_idx( varargin )
     df = b.create_data_array_from_data('testIndexed', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Indexed);
-    retData = t.retrieve_feature_data_idx(2);
+    retData = t.retrieve_feature_data_idx(3);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
 
     try

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -371,9 +371,9 @@ function [] = test_open_source_idx( varargin )
     t.add_source(s2);
     t.add_source(s3);
 
-    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(0).name, s1.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(1).name, s2.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(2).name, s3.name));
+    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(3).name, s3.name));
 end
 
 %% Test: nix.Tag has nix.Source by ID or entity


### PR DESCRIPTION
This PR refactors all Indexes on the Matlab-side to Matlab-style 1-based index; closes #150.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).