### PR TITLE
Refactor and Cleanup, part III: Renaming

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -37,7 +37,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         function r = createGroup(obj, name, nixtype)
             fname = strcat(obj.alias, '::createGroup');
-            h = nix_mx(fname, obj.nix_handle, name, nixtype);
+            h = nix_mx(fname, obj.nixhandle, name, nixtype);
             r = nix.Utils.createEntity(h, @nix.Group);
         end
 
@@ -97,7 +97,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 error(err);
             else
                 fname = strcat(obj.alias, '::createDataArray');
-                h = nix_mx(fname, obj.nix_handle, name, nixtype, lower(datatype.char), shape);
+                h = nix_mx(fname, obj.nixhandle, name, nixtype, lower(datatype.char), shape);
                 r = nix.Utils.createEntity(h, @nix.DataArray);
             end
         end
@@ -151,7 +151,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         function r = createSource(obj, name, type)
             fname = strcat(obj.alias, '::createSource');
-            h = nix_mx(fname, obj.nix_handle, name, type);
+            h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Source);
         end
 
@@ -209,7 +209,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         function r = createTag(obj, name, type, position)
             fname = strcat(obj.alias, '::createTag');
-            h = nix_mx(fname, obj.nix_handle, name, type, position);
+            h = nix_mx(fname, obj.nixhandle, name, type, position);
             r = nix.Utils.createEntity(h, @nix.Tag);
         end
 
@@ -246,7 +246,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function r = createMultiTag(obj, name, type, refDataArray)
             fname = strcat(obj.alias, '::createMultiTag');
             id = nix.Utils.parseEntityId(refDataArray, 'nix.DataArray');
-            h = nix_mx(fname, obj.nix_handle, name, type, id);
+            h = nix_mx(fname, obj.nixhandle, name, type, id);
             r = nix.Utils.createEntity(h, @nix.MultiTag);
         end
 

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -126,7 +126,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             end
 
             r = obj.createDataArray(name, nixtype, dtype, shape);
-            r.write_all(data);
+            r.writeAllData(data);
         end
 
         function r = hasDataArray(obj, idName)

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -178,7 +178,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
         % maxdepth is an index
         function r = findSources(obj, maxDepth)
-            r = obj.filterFindSources(maxDepth, nix.Filter.accept_all, '');
+            r = obj.filterFindSources(maxDepth, nix.Filter.acceptall, '');
         end
 
         % maxdepth is an index

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -46,16 +46,16 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = openGroup(obj, idName)
-            r = nix.Utils.open_entity(obj, 'getGroup', idName, @nix.Group);
+            r = nix.Utils.openEntity(obj, 'getGroup', idName, @nix.Group);
         end
 
         function r = openGroupIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openGroupIdx', idx, @nix.Group);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openGroupIdx', idx, @nix.Group);
         end
 
         function r = deleteGroup(obj, idNameEntity)
-            r = nix.Utils.delete_entity(obj, 'deleteGroup', idNameEntity, 'nix.Group');
+            r = nix.Utils.deleteEntity(obj, 'deleteGroup', idNameEntity, 'nix.Group');
         end
 
         function r = filterGroups(obj, filter, val)
@@ -71,12 +71,12 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = openDataArray(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openDataArray', idName, @nix.DataArray);
+            r = nix.Utils.openEntity(obj, 'openDataArray', idName, @nix.DataArray);
         end
 
         function r = openDataArrayIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
         function r = createDataArray(obj, name, nixtype, datatype, shape)
@@ -134,7 +134,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = deleteDataArray(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteDataArray', del, 'nix.DataArray');
+            r = nix.Utils.deleteEntity(obj, 'deleteDataArray', del, 'nix.DataArray');
         end
 
         function r = filterDataArrays(obj, filter, val)
@@ -160,16 +160,16 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = deleteSource(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteSource', del, 'nix.Source');
+            r = nix.Utils.deleteEntity(obj, 'deleteSource', del, 'nix.Source');
         end
 
         function r = openSource(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openSource', idName, @nix.Source);
+            r = nix.Utils.openEntity(obj, 'openSource', idName, @nix.Source);
         end
 
         function r = openSourceIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = filterSources(obj, filter, val)
@@ -199,12 +199,12 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = openTag(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openTag', idName, @nix.Tag);
+            r = nix.Utils.openEntity(obj, 'openTag', idName, @nix.Tag);
         end
 
         function r = openTagIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
         function r = createTag(obj, name, type, position)
@@ -214,7 +214,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = deleteTag(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteTag', del, 'nix.Tag');
+            r = nix.Utils.deleteEntity(obj, 'deleteTag', del, 'nix.Tag');
         end
 
         function r = filterTags(obj, filter, val)
@@ -234,12 +234,12 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = openMultiTag(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openMultiTag', idName, @nix.MultiTag);
+            r = nix.Utils.openEntity(obj, 'openMultiTag', idName, @nix.MultiTag);
         end
 
         function r = openMultiTagIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
         %-- Creating a multitag requires an already existing data array
@@ -251,7 +251,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = deleteMultiTag(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteMultiTag', del, 'nix.MultiTag');
+            r = nix.Utils.deleteEntity(obj, 'deleteMultiTag', del, 'nix.MultiTag');
         end
 
         function r = filterMultiTags(obj, filter, val)

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -20,11 +20,11 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             obj@nix.MetadataMixIn();
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'groups', @nix.Group);
-            nix.Dynamic.add_dyn_relation(obj, 'dataArrays', @nix.DataArray);
-            nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
-            nix.Dynamic.add_dyn_relation(obj, 'tags', @nix.Tag);
-            nix.Dynamic.add_dyn_relation(obj, 'multiTags', @nix.MultiTag);
+            nix.Dynamic.addGetChildEntities(obj, 'groups', @nix.Group);
+            nix.Dynamic.addGetChildEntities(obj, 'dataArrays', @nix.DataArray);
+            nix.Dynamic.addGetChildEntities(obj, 'sources', @nix.Source);
+            nix.Dynamic.addGetChildEntities(obj, 'tags', @nix.Tag);
+            nix.Dynamic.addGetChildEntities(obj, 'multiTags', @nix.MultiTag);
         end
 
         % -----------------

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -31,34 +31,34 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % Group methods
         % -----------------
 
-        function r = group_count(obj)
+        function r = groupCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'groupCount');
         end
 
-        function r = create_group(obj, name, nixtype)
+        function r = createGroup(obj, name, nixtype)
             fname = strcat(obj.alias, '::createGroup');
             h = nix_mx(fname, obj.nix_handle, name, nixtype);
             r = nix.Utils.createEntity(h, @nix.Group);
         end
 
-        function r = has_group(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasGroup', id_or_name);
+        function r = hasGroup(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasGroup', idName);
         end
 
-        function r = get_group(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'getGroup', id_or_name, @nix.Group);
+        function r = openGroup(obj, idName)
+            r = nix.Utils.open_entity(obj, 'getGroup', idName, @nix.Group);
         end
 
-        function r = open_group_idx(obj, index)
+        function r = openGroupIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openGroupIdx', idx, @nix.Group);
         end
 
-        function r = delete_group(obj, idNameEntity)
+        function r = deleteGroup(obj, idNameEntity)
             r = nix.Utils.delete_entity(obj, 'deleteGroup', idNameEntity, 'nix.Group');
         end
 
-        function r = filter_groups(obj, filter, val)
+        function r = filterGroups(obj, filter, val)
             r = nix.Utils.filter(obj, 'groupsFiltered', filter, val, @nix.Group);
         end
 
@@ -66,20 +66,20 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % DataArray methods
         % -----------------
 
-        function r = data_array_count(obj)
+        function r = dataArrayCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'dataArrayCount');
         end
 
-        function r = data_array(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openDataArray', id_or_name, @nix.DataArray);
+        function r = openDataArray(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openDataArray', idName, @nix.DataArray);
         end
 
-        function r = open_data_array_idx(obj, index)
+        function r = openDataArrayIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
-        function r = create_data_array(obj, name, nixtype, datatype, shape)
+        function r = createDataArray(obj, name, nixtype, datatype, shape)
             %-- Quick fix to enable alias range dimension with
             %-- 1D data arrays created with this function.
             %-- e.g. size([1 2 3]) returns shape [1 3], which would not
@@ -102,7 +102,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             end
         end
 
-        function r = create_data_array_from_data(obj, name, nixtype, data)
+        function r = createDataArrayFromData(obj, name, nixtype, data)
             shape = size(data);
             %-- Quick fix to enable alias range dimension with
             %-- 1D data arrays created with this function.
@@ -125,19 +125,19 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 error(err);
             end
 
-            r = obj.create_data_array(name, nixtype, dtype, shape);
+            r = obj.createDataArray(name, nixtype, dtype, shape);
             r.write_all(data);
         end
 
-        function r = has_data_array(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', id_or_name);
+        function r = hasDataArray(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', idName);
         end
 
-        function r = delete_data_array(obj, del)
+        function r = deleteDataArray(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteDataArray', del, 'nix.DataArray');
         end
 
-        function r = filter_data_arrays(obj, filter, val)
+        function r = filterDataArrays(obj, filter, val)
             r = nix.Utils.filter(obj, 'dataArraysFiltered', filter, val, @nix.DataArray);
         end
 
@@ -145,79 +145,79 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % Sources methods
         % -----------------
 
-        function r = source_count(obj)
+        function r = sourceCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
-        function r = create_source(obj, name, type)
+        function r = createSource(obj, name, type)
             fname = strcat(obj.alias, '::createSource');
             h = nix_mx(fname, obj.nix_handle, name, type);
             r = nix.Utils.createEntity(h, @nix.Source);
         end
 
-        function r = has_source(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasSource', id_or_name);
+        function r = hasSource(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasSource', idName);
         end
 
-        function r = delete_source(obj, del)
+        function r = deleteSource(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteSource', del, 'nix.Source');
         end
 
-        function r = open_source(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
+        function r = openSource(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openSource', idName, @nix.Source);
         end
 
-        function r = open_source_idx(obj, index)
+        function r = openSourceIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
-        function r = filter_sources(obj, filter, val)
+        function r = filterSources(obj, filter, val)
             r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
 
         % maxdepth is an index
-        function r = find_sources(obj, max_depth)
-            r = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
+        function r = findSources(obj, maxDepth)
+            r = obj.filterFindSources(maxDepth, nix.Filter.accept_all, '');
         end
 
         % maxdepth is an index
-        function r = find_filtered_sources(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, 'findSources', max_depth, filter, val, @nix.Source);
+        function r = filterFindSources(obj, maxDepth, filter, val)
+            r = nix.Utils.find(obj, 'findSources', maxDepth, filter, val, @nix.Source);
         end
 
         % -----------------
         % Tags methods
         % -----------------
 
-        function r = tag_count(obj)
+        function r = tagCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'tagCount');
         end
 
-        function r = has_tag(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasTag', id_or_name);
+        function r = hasTag(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasTag', idName);
         end
 
-        function r = open_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openTag', id_or_name, @nix.Tag);
+        function r = openTag(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openTag', idName, @nix.Tag);
         end
 
-        function r = open_tag_idx(obj, index)
+        function r = openTagIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
-        function r = create_tag(obj, name, type, position)
+        function r = createTag(obj, name, type, position)
             fname = strcat(obj.alias, '::createTag');
             h = nix_mx(fname, obj.nix_handle, name, type, position);
             r = nix.Utils.createEntity(h, @nix.Tag);
         end
 
-        function r = delete_tag(obj, del)
+        function r = deleteTag(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteTag', del, 'nix.Tag');
         end
 
-        function r = filter_tags(obj, filter, val)
+        function r = filterTags(obj, filter, val)
             r = nix.Utils.filter(obj, 'tagsFiltered', filter, val, @nix.Tag);
         end
 
@@ -225,36 +225,36 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % MultiTag methods
         % -----------------
 
-        function r = multi_tag_count(obj)
+        function r = multiTagCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'multiTagCount');
         end
 
-        function r = has_multi_tag(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', id_or_name);
+        function r = hasMultiTag(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', idName);
         end
 
-        function r = open_multi_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openMultiTag', id_or_name, @nix.MultiTag);
+        function r = openMultiTag(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openMultiTag', idName, @nix.MultiTag);
         end
 
-        function r = open_multi_tag_idx(obj, index)
+        function r = openMultiTagIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
         %-- Creating a multitag requires an already existing data array
-        function r = create_multi_tag(obj, name, type, add_data_array)
+        function r = createMultiTag(obj, name, type, refDataArray)
             fname = strcat(obj.alias, '::createMultiTag');
-            id = nix.Utils.parseEntityId(add_data_array, 'nix.DataArray');
+            id = nix.Utils.parseEntityId(refDataArray, 'nix.DataArray');
             h = nix_mx(fname, obj.nix_handle, name, type, id);
             r = nix.Utils.createEntity(h, @nix.MultiTag);
         end
 
-        function r = delete_multi_tag(obj, del)
+        function r = deleteMultiTag(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteMultiTag', del, 'nix.MultiTag');
         end
 
-        function r = filter_multi_tags(obj, filter, val)
+        function r = filterMultiTags(obj, filter, val)
             r = nix.Utils.filter(obj, 'multiTagsFiltered', filter, val, @nix.MultiTag);
         end
     end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -39,7 +39,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function dimensions = get.dimensions(obj)
             dimensions = {};
             fname = strcat(obj.alias, '::dimensions');
-            currList = nix_mx(fname, obj.nix_handle);
+            currList = nix_mx(fname, obj.nixhandle);
             for i = 1:length(currList)
                 switch currList(i).dtype
                     case 'set'
@@ -59,25 +59,25 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = appendSetDimension(obj)
             fname = strcat(obj.alias, '::appendSetDimension');
-            h = nix_mx(fname, obj.nix_handle);
+            h = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.createEntity(h, @nix.SetDimension);
         end
 
         function r = appendSampledDimension(obj, interval)
             fname = strcat(obj.alias, '::appendSampledDimension');
-            h = nix_mx(fname, obj.nix_handle, interval);
+            h = nix_mx(fname, obj.nixhandle, interval);
             r = nix.Utils.createEntity(h, @nix.SampledDimension);
         end
 
         function r = appendRangeDimension(obj, ticks)
             fname = strcat(obj.alias, '::appendRangeDimension');
-            h = nix_mx(fname, obj.nix_handle, ticks);
+            h = nix_mx(fname, obj.nixhandle, ticks);
             r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
         function r = appendAliasRangeDimension(obj)
             fname = strcat(obj.alias, '::appendAliasRangeDimension');
-            h = nix_mx(fname, obj.nix_handle);
+            h = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
@@ -85,7 +85,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Getting the dimension by index starts with 1
         % instead of 0 compared to all other index functions.
             fname = strcat(obj.alias, '::openDimensionIdx');
-            dim = nix_mx(fname, obj.nix_handle, idx);
+            dim = nix_mx(fname, obj.nixhandle, idx);
             switch (dim.dimension_type)
                 case 'set'
                     r = nix.Utils.createEntity(dim.handle, @nix.SetDimension);
@@ -98,7 +98,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = deleteDimensions(obj)
             fname = strcat(obj.alias, '::deleteDimensions');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = dimensionCount(obj)
@@ -111,7 +111,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = readAllData(obj)
             fname = strcat(obj.alias, '::readAll');
-            data = nix_mx(fname, obj.nix_handle);
+            data = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.transposeArray(data);
         end
 
@@ -143,12 +143,12 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             end
 
             fname = strcat(obj.alias, '::writeAll');
-            nix_mx(fname, obj.nix_handle, nix.Utils.transposeArray(data));
+            nix_mx(fname, obj.nixhandle, nix.Utils.transposeArray(data));
         end
 
         function r = datatype(obj)
             fname = strcat(obj.alias, '::dataType');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         % Set data extent enables to increase the original size 
@@ -162,7 +162,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % will be lost!
         function [] = setDataExtent(obj, extent)
             fname = strcat(obj.alias, '::setDataExtent');
-            nix_mx(fname, obj.nix_handle, extent);
+            nix_mx(fname, obj.nixhandle, extent);
         end
     end
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -86,7 +86,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % instead of 0 compared to all other index functions.
             fname = strcat(obj.alias, '::openDimensionIdx');
             dim = nix_mx(fname, obj.nixhandle, idx);
-            switch (dim.dimension_type)
+            switch (dim.dimensionType)
                 case 'set'
                     r = nix.Utils.createEntity(dim.handle, @nix.SetDimension);
                 case 'sampled'

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -25,11 +25,11 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj@nix.SourcesMixIn();
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'label', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'expansionOrigin', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'polynomCoefficients', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'dataExtent', 'rw');
+            nix.Dynamic.addProperty(obj, 'label', 'rw');
+            nix.Dynamic.addProperty(obj, 'unit', 'rw');
+            nix.Dynamic.addProperty(obj, 'expansionOrigin', 'rw');
+            nix.Dynamic.addProperty(obj, 'polynomCoefficients', 'rw');
+            nix.Dynamic.addProperty(obj, 'dataExtent', 'rw');
         end
 
         % -----------------

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -112,7 +112,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = readAllData(obj)
             fname = strcat(obj.alias, '::readAll');
             data = nix_mx(fname, obj.nix_handle);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         %-- TODO add (optional) offset
@@ -143,7 +143,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             end
 
             fname = strcat(obj.alias, '::writeAll');
-            nix_mx(fname, obj.nix_handle, nix.Utils.transpose_array(data));
+            nix_mx(fname, obj.nix_handle, nix.Utils.transposeArray(data));
         end
 
         function r = datatype(obj)

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -57,31 +57,31 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             end
         end
 
-        function r = append_set_dimension(obj)
+        function r = appendSetDimension(obj)
             fname = strcat(obj.alias, '::appendSetDimension');
             h = nix_mx(fname, obj.nix_handle);
             r = nix.Utils.createEntity(h, @nix.SetDimension);
         end
 
-        function r = append_sampled_dimension(obj, interval)
+        function r = appendSampledDimension(obj, interval)
             fname = strcat(obj.alias, '::appendSampledDimension');
             h = nix_mx(fname, obj.nix_handle, interval);
             r = nix.Utils.createEntity(h, @nix.SampledDimension);
         end
 
-        function r = append_range_dimension(obj, ticks)
+        function r = appendRangeDimension(obj, ticks)
             fname = strcat(obj.alias, '::appendRangeDimension');
             h = nix_mx(fname, obj.nix_handle, ticks);
             r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
-        function r = append_alias_range_dimension(obj)
+        function r = appendAliasRangeDimension(obj)
             fname = strcat(obj.alias, '::appendAliasRangeDimension');
             h = nix_mx(fname, obj.nix_handle);
             r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
-        function r = open_dimension_idx(obj, idx)
+        function r = openDimensionIdx(obj, idx)
         % Getting the dimension by index starts with 1
         % instead of 0 compared to all other index functions.
             fname = strcat(obj.alias, '::openDimensionIdx');
@@ -96,12 +96,12 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             end
         end
 
-        function r = delete_dimensions(obj)
+        function r = deleteDimensions(obj)
             fname = strcat(obj.alias, '::deleteDimensions');
             r = nix_mx(fname, obj.nix_handle);
         end
 
-        function r = dimension_count(obj)
+        function r = dimensionCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'dimensionCount');
         end
 
@@ -109,7 +109,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Data access methods
         % -----------------
 
-        function r = read_all(obj)
+        function r = readAllData(obj)
             fname = strcat(obj.alias, '::readAll');
             data = nix_mx(fname, obj.nix_handle);
             r = nix.Utils.transpose_array(data);
@@ -118,18 +118,19 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         %-- TODO add (optional) offset
         %-- If a DataArray has been created as boolean or numeric,
         %-- provide that only values of the proper DataType can be written.
-        function [] = write_all(obj, data)
-            if (isinteger(obj.read_all) && isfloat(data))
+        function [] = writeAllData(obj, data)
+            if (isinteger(obj.readAllData) && isfloat(data))
                 disp('Warning: Writing Float data to an Integer DataArray');
             end
 
             err.identifier = 'NIXMX:improperDataType';
-            if (islogical(obj.read_all) && ~islogical(data))
+            if (islogical(obj.readAllData) && ~islogical(data))
                 m = sprintf('Trying to write %s to a logical DataArray', class(data));
                 err.message = m;
                 error(err);
-            elseif (isnumeric(obj.read_all) && ~isnumeric(data))
-                m = sprintf('Trying to write %s to a %s DataArray', class(data), class(obj.read_all));
+            elseif (isnumeric(obj.readAllData) && ~isnumeric(data))
+                m = sprintf('Trying to write %s to a %s DataArray', ...
+                    class(data), class(obj.readAllData));
                 err.message = m;
                 error(err);
             elseif (ischar(data))
@@ -159,7 +160,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % or remodels the size of an array to a completely different
         % shape, existing data that does not fit into the new shape
         % will be lost!
-        function [] = set_data_extent(obj, extent)
+        function [] = setDataExtent(obj, extent)
             fname = strcat(obj.alias, '::setDataExtent');
             nix_mx(fname, obj.nix_handle, extent);
         end

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -32,7 +32,7 @@ classdef Dynamic
 
                 if (isempty(val))
                     fname = strcat(obj.alias, '::setNone', upper(prop(1)), prop(2:end));
-                    nix_mx(fname, obj.nix_handle, 0);
+                    nix_mx(fname, obj.nixhandle, 0);
                 elseif ((strcmp(prop, 'units') || strcmp(prop, 'labels')) && (~iscell(val)))
                 %-- BUGFIX: Matlab crashes, if units in Tags and MultiTags
                 %-- or labels of SetDimension are set using anything else than a cell.
@@ -41,7 +41,7 @@ classdef Dynamic
                     throwAsCaller(ME);
                 else
                     fname = strcat(obj.alias, '::set', upper(prop(1)), prop(2:end));
-                    nix_mx(fname, obj.nix_handle, val);
+                    nix_mx(fname, obj.nixhandle, val);
                 end
             end
 

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -11,7 +11,7 @@ classdef Dynamic
     % implements methods to dynamically assigns properties 
 
     methods (Static)
-        function add_dyn_attr(obj, prop, mode)
+        function addProperty(obj, prop, mode)
             if (nargin < 3)
                 mode = 'r'; 
             end
@@ -20,10 +20,10 @@ classdef Dynamic
             p = addprop(obj, prop);
 
             % define property accessor methods
-            p.GetMethod = @get_method;
-            p.SetMethod = @set_method;
+            p.GetMethod = @getMethod;
+            p.SetMethod = @setMethod;
 
-            function set_method(obj, val)
+            function setMethod(obj, val)
                 if (strcmp(mode, 'r'))
                     msg = 'You cannot set the read-only property ''%s'' of %s';
                     ME = MException('MATLAB:class:SetProhibited', msg, prop, class(obj));
@@ -45,12 +45,12 @@ classdef Dynamic
                 end
             end
 
-            function val = get_method(obj)
+            function val = getMethod(obj)
                 val = obj.info.(prop);
             end
         end
 
-        function add_dyn_relation(obj, name, constructor)
+        function addGetChildEntities(obj, name, constructor)
             dataAttr = strcat(name, 'Data');
             data = addprop(obj, dataAttr);
             data.Hidden = true;
@@ -58,25 +58,11 @@ classdef Dynamic
 
             % adds a proxy property
             rel = addprop(obj, name);
-            rel.GetMethod = @get_method;
+            rel.GetMethod = @getMethod;
 
-            % same property but returns Map 
-            rel_map = addprop(obj, strcat(name, 'Map'));
-            rel_map.GetMethod = @get_as_map;
-            rel_map.Hidden = true;
-
-            function val = get_method(obj)
+            function val = getMethod(obj)
                 obj.(dataAttr) = nix.Utils.fetchObjList(obj, name, constructor);
                 val = obj.(dataAttr);
-            end
-
-            function val = get_as_map(obj)
-                val = containers.Map();
-                props = obj.(name);
-
-                for i = 1:length(props)
-                    val(props{i}.name) = cell2mat(props{i}.values);
-                end
             end
         end
     end

--- a/+nix/Entity.m
+++ b/+nix/Entity.m
@@ -11,7 +11,7 @@ classdef Entity < dynamicprops
     %   handles object lifetime
 
     properties (Hidden)
-        nix_handle
+        nixhandle
     end
 
     properties (SetAccess=private, GetAccess=public, Hidden)
@@ -24,20 +24,20 @@ classdef Entity < dynamicprops
 
     methods
         function obj = Entity(h)
-            obj.nix_handle = h;
+            obj.nixhandle = h;
         end
 
         function [] = delete(obj)
-            nix_mx('Entity::destroy', obj.nix_handle);
+            nix_mx('Entity::destroy', obj.nixhandle);
         end
 
         function r = updatedAt(obj)
-            r = nix_mx('Entity::updatedAt', obj.nix_handle);
+            r = nix_mx('Entity::updatedAt', obj.nixhandle);
         end
 
         function r = get.info(obj)
             fname = strcat(obj.alias, '::describe');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
     end
 

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -30,24 +30,24 @@ classdef Feature < nix.Entity
 
         function r = get.linkType(obj)
             fname = strcat(obj.alias, '::getLinkType');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         function [] = set.linkType(obj, linkType)
             fname = strcat(obj.alias, '::setLinkType');
-            nix_mx(fname, obj.nix_handle, linkType);
+            nix_mx(fname, obj.nixhandle, linkType);
         end
 
         function r = openData(obj)
             fname = strcat(obj.alias, '::openData');
-            h = nix_mx(fname, obj.nix_handle);
+            h = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.createEntity(h, @nix.DataArray);
         end
 
         function [] = setData(obj, data)
             id = nix.Utils.parseEntityId(data, 'nix.DataArray');
             fname = strcat(obj.alias, '::setData');
-            nix_mx(fname, obj.nix_handle, id);
+            nix_mx(fname, obj.nixhandle, id);
         end
     end
 

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -38,14 +38,14 @@ classdef Feature < nix.Entity
             nix_mx(fname, obj.nix_handle, linkType);
         end
 
-        function r = open_data(obj)
+        function r = openData(obj)
             fname = strcat(obj.alias, '::openData');
             h = nix_mx(fname, obj.nix_handle);
             r = nix.Utils.createEntity(h, @nix.DataArray);
         end
 
-        function [] = set_data(obj, setData)
-            id = nix.Utils.parseEntityId(setData, 'nix.DataArray');
+        function [] = setData(obj, data)
+            id = nix.Utils.parseEntityId(data, 'nix.DataArray');
             fname = strcat(obj.alias, '::setData');
             nix_mx(fname, obj.nix_handle, id);
         end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -23,8 +23,8 @@ classdef File < nix.Entity
             obj@nix.Entity(h);
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'blocks', @nix.Block);
-            nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
+            nix.Dynamic.addGetChildEntities(obj, 'blocks', @nix.Block);
+            nix.Dynamic.addGetChildEntities(obj, 'sections', @nix.Section);
         end
 
         % braindead...

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -30,17 +30,17 @@ classdef File < nix.Entity
         % braindead...
         function r = isOpen(obj)
             fname = strcat(obj.alias, '::isOpen');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = fileMode(obj)
             fname = strcat(obj.alias, '::fileMode');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = validate(obj)
             fname = strcat(obj.alias, '::validate');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         % ----------------
@@ -49,7 +49,7 @@ classdef File < nix.Entity
 
         function r = createBlock(obj, name, type)
             fname = strcat(obj.alias, '::createBlock');
-            h = nix_mx(fname, obj.nix_handle, name, type);
+            h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Block);
         end
 
@@ -84,7 +84,7 @@ classdef File < nix.Entity
 
         function r = createSection(obj, name, type)
             fname = strcat(obj.alias, '::createSection');
-            h = nix_mx(fname, obj.nix_handle, name, type);
+            h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Section);
         end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -57,12 +57,12 @@ classdef File < nix.Entity
             r = nix.Utils.fetchEntityCount(obj, 'blockCount');
         end
 
-        function r = hasBlock(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasBlock', id_or_name);
+        function r = hasBlock(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasBlock', idName);
         end
 
-        function r = openBlock(obj, id_or_name)
-            r = nix.Utils.openEntity(obj, 'openBlock', id_or_name, @nix.Block);
+        function r = openBlock(obj, idName)
+            r = nix.Utils.openEntity(obj, 'openBlock', idName, @nix.Block);
         end
 
         function r = openBlockIdx(obj, index)
@@ -92,12 +92,12 @@ classdef File < nix.Entity
             r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
-        function r = hasSection(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasSection', id_or_name);
+        function r = hasSection(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasSection', idName);
         end
 
-        function r = openSection(obj, id_or_name)
-            r = nix.Utils.openEntity(obj, 'openSection', id_or_name, @nix.Section);
+        function r = openSection(obj, idName)
+            r = nix.Utils.openEntity(obj, 'openSection', idName, @nix.Section);
         end
 
         function r = openSectionIdx(obj, index)
@@ -114,13 +114,13 @@ classdef File < nix.Entity
         end
 
         % maxdepth is an index
-        function r = findSections(obj, max_depth)
-            r = obj.filterFindSections(max_depth, nix.Filter.accept_all, '');
+        function r = findSections(obj, maxDepth)
+            r = obj.filterFindSections(maxDepth, nix.Filter.acceptall, '');
         end
 
         % maxdepth is an index
-        function r = filterFindSections(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, 'findSections', max_depth, filter, val, @nix.Section);
+        function r = filterFindSections(obj, maxDepth, filter, val)
+            r = nix.Utils.find(obj, 'findSections', maxDepth, filter, val, @nix.Section);
         end
     end
 

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -28,12 +28,12 @@ classdef File < nix.Entity
         end
 
         % braindead...
-        function r = is_open(obj)
+        function r = isOpen(obj)
             fname = strcat(obj.alias, '::isOpen');
             r = nix_mx(fname, obj.nix_handle);
         end
 
-        function r = file_mode(obj)
+        function r = fileMode(obj)
             fname = strcat(obj.alias, '::fileMode');
             r = nix_mx(fname, obj.nix_handle);
         end
@@ -47,34 +47,34 @@ classdef File < nix.Entity
         % Block methods
         % ----------------
 
-        function r = create_block(obj, name, type)
+        function r = createBlock(obj, name, type)
             fname = strcat(obj.alias, '::createBlock');
             h = nix_mx(fname, obj.nix_handle, name, type);
             r = nix.Utils.createEntity(h, @nix.Block);
         end
 
-        function r = block_count(obj)
+        function r = blockCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'blockCount');
         end
 
-        function r = has_block(obj, id_or_name)
+        function r = hasBlock(obj, id_or_name)
             r = nix.Utils.fetchHasEntity(obj, 'hasBlock', id_or_name);
         end
 
-        function r = open_block(obj, id_or_name)
+        function r = openBlock(obj, id_or_name)
             r = nix.Utils.open_entity(obj, 'openBlock', id_or_name, @nix.Block);
         end
 
-        function r = open_block_idx(obj, index)
+        function r = openBlockIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openBlockIdx', idx, @nix.Block);
         end
 
-        function r = delete_block(obj, del)
+        function r = deleteBlock(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteBlock', del, 'nix.Block');
         end
 
-        function r = filter_blocks(obj, filter, val)
+        function r = filterBlocks(obj, filter, val)
             r = nix.Utils.filter(obj, 'blocksFiltered', filter, val, @nix.Block);
         end
 
@@ -82,44 +82,44 @@ classdef File < nix.Entity
         % Section methods
         % ----------------
 
-        function r = create_section(obj, name, type)
+        function r = createSection(obj, name, type)
             fname = strcat(obj.alias, '::createSection');
             h = nix_mx(fname, obj.nix_handle, name, type);
             r = nix.Utils.createEntity(h, @nix.Section);
         end
 
-        function r = section_count(obj)
+        function r = sectionCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
-        function r = has_section(obj, id_or_name)
+        function r = hasSection(obj, id_or_name)
             r = nix.Utils.fetchHasEntity(obj, 'hasSection', id_or_name);
         end
 
-        function r = open_section(obj, id_or_name)
+        function r = openSection(obj, id_or_name)
             r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
         end
 
-        function r = open_section_idx(obj, index)
+        function r = openSectionIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
-        function r = delete_section(obj, del)
+        function r = deleteSection(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteSection', del, 'nix.Section');
         end
 
-        function r = filter_sections(obj, filter, val)
+        function r = filterSections(obj, filter, val)
             r = nix.Utils.filter(obj, 'sectionsFiltered', filter, val, @nix.Section);
         end
 
         % maxdepth is an index
-        function r = find_sections(obj, max_depth)
-            r = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
+        function r = findSections(obj, max_depth)
+            r = obj.filterFindSections(max_depth, nix.Filter.accept_all, '');
         end
 
         % maxdepth is an index
-        function r = find_filtered_sections(obj, max_depth, filter, val)
+        function r = filterFindSections(obj, max_depth, filter, val)
             r = nix.Utils.find(obj, 'findSections', max_depth, filter, val, @nix.Section);
         end
     end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -62,16 +62,16 @@ classdef File < nix.Entity
         end
 
         function r = openBlock(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openBlock', id_or_name, @nix.Block);
+            r = nix.Utils.openEntity(obj, 'openBlock', id_or_name, @nix.Block);
         end
 
         function r = openBlockIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openBlockIdx', idx, @nix.Block);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openBlockIdx', idx, @nix.Block);
         end
 
         function r = deleteBlock(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteBlock', del, 'nix.Block');
+            r = nix.Utils.deleteEntity(obj, 'deleteBlock', del, 'nix.Block');
         end
 
         function r = filterBlocks(obj, filter, val)
@@ -97,16 +97,16 @@ classdef File < nix.Entity
         end
 
         function r = openSection(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
+            r = nix.Utils.openEntity(obj, 'openSection', id_or_name, @nix.Section);
         end
 
         function r = openSectionIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
         function r = deleteSection(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteSection', del, 'nix.Section');
+            r = nix.Utils.deleteEntity(obj, 'deleteSection', del, 'nix.Section');
         end
 
         function r = filterSections(obj, filter, val)

--- a/+nix/Filter.m
+++ b/+nix/Filter.m
@@ -2,7 +2,7 @@ classdef Filter < uint8
     % FILTER available nix custom filters
 
     enumeration
-        accept_all (0); % requires an empty value
+        acceptall (0); % requires an empty value
         id (1);
         ids (2); % requires a cell array
         type (3);

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -39,24 +39,24 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = getDataArray(obj, idName)
-            r = nix.Utils.open_entity(obj, 'getDataArray', idName, @nix.DataArray);
+            r = nix.Utils.openEntity(obj, 'getDataArray', idName, @nix.DataArray);
         end
 
         function r = openDataArrayIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
         function [] = addDataArray(obj, entity)
-            nix.Utils.add_entity(obj, 'addDataArray', entity, 'nix.DataArray');
+            nix.Utils.addEntity(obj, 'addDataArray', entity, 'nix.DataArray');
         end
 
         function [] = addDataArrays(obj, entityArray)
-            nix.Utils.add_entity_array(obj, 'addDataArrays', entityArray, 'nix.DataArray');
+            nix.Utils.addEntityArray(obj, 'addDataArrays', entityArray, 'nix.DataArray');
         end
 
         function r = removeDataArray(obj, del)
-            r = nix.Utils.delete_entity(obj, 'removeDataArray', del, 'nix.DataArray');
+            r = nix.Utils.deleteEntity(obj, 'removeDataArray', del, 'nix.DataArray');
         end
 
         function r = filterDataArrays(obj, filter, val)
@@ -68,11 +68,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = addTag(obj, entity)
-            nix.Utils.add_entity(obj, 'addTag', entity, 'nix.Tag');
+            nix.Utils.addEntity(obj, 'addTag', entity, 'nix.Tag');
         end
 
         function [] = addTags(obj, entityArray)
-            nix.Utils.add_entity_array(obj, 'addTags', entityArray, 'nix.Tag');
+            nix.Utils.addEntityArray(obj, 'addTags', entityArray, 'nix.Tag');
         end
 
         function r = hasTag(obj, idName)
@@ -80,16 +80,16 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = getTag(obj, idName)
-            r = nix.Utils.open_entity(obj, 'getTag', idName, @nix.Tag);
+            r = nix.Utils.openEntity(obj, 'getTag', idName, @nix.Tag);
         end
 
         function r = openTagIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
         function r = removeTag(obj, del)
-            r = nix.Utils.delete_entity(obj, 'removeTag', del, 'nix.Tag');
+            r = nix.Utils.deleteEntity(obj, 'removeTag', del, 'nix.Tag');
         end
 
         function r = tagCount(obj)
@@ -105,11 +105,11 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function [] = addMultiTag(obj, entity)
-            nix.Utils.add_entity(obj, 'addMultiTag', entity, 'nix.MultiTag');
+            nix.Utils.addEntity(obj, 'addMultiTag', entity, 'nix.MultiTag');
         end
 
         function [] = addMultiTags(obj, entityArray)
-            nix.Utils.add_entity_array(obj, 'addMultiTags', entityArray, 'nix.MultiTag');
+            nix.Utils.addEntityArray(obj, 'addMultiTags', entityArray, 'nix.MultiTag');
         end
 
         function r = hasMultiTag(obj, idName)
@@ -117,16 +117,16 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = getMultiTag(obj, idName)
-            r = nix.Utils.open_entity(obj, 'getMultiTag', idName, @nix.MultiTag);
+            r = nix.Utils.openEntity(obj, 'getMultiTag', idName, @nix.MultiTag);
         end
 
         function r = openMultiTagIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
         function r = removeMultiTag(obj, del)
-            r = nix.Utils.delete_entity(obj, 'removeMultiTag', del, 'nix.MultiTag');
+            r = nix.Utils.deleteEntity(obj, 'removeMultiTag', del, 'nix.MultiTag');
         end
 
         function r = multiTagCount(obj)

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -21,9 +21,9 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj@nix.SourcesMixIn();
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'dataArrays', @nix.DataArray);
-            nix.Dynamic.add_dyn_relation(obj, 'tags', @nix.Tag);
-            nix.Dynamic.add_dyn_relation(obj, 'multiTags', @nix.MultiTag);
+            nix.Dynamic.addGetChildEntities(obj, 'dataArrays', @nix.DataArray);
+            nix.Dynamic.addGetChildEntities(obj, 'tags', @nix.Tag);
+            nix.Dynamic.addGetChildEntities(obj, 'multiTags', @nix.MultiTag);
         end
 
         % -----------------

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -30,36 +30,36 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % DataArray methods
         % -----------------
 
-        function r = data_array_count(obj)
+        function r = dataArrayCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'dataArrayCount');
         end
 
-        function r = has_data_array(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', id_or_name);
+        function r = hasDataArray(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', idName);
         end
 
-        function r = get_data_array(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'getDataArray', id_or_name, @nix.DataArray);
+        function r = getDataArray(obj, idName)
+            r = nix.Utils.open_entity(obj, 'getDataArray', idName, @nix.DataArray);
         end
 
-        function r = open_data_array_idx(obj, index)
+        function r = openDataArrayIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
-        function [] = add_data_array(obj, add_this)
-            nix.Utils.add_entity(obj, 'addDataArray', add_this, 'nix.DataArray');
+        function [] = addDataArray(obj, entity)
+            nix.Utils.add_entity(obj, 'addDataArray', entity, 'nix.DataArray');
         end
 
-        function [] = add_data_arrays(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, 'addDataArrays', add_cell_array, 'nix.DataArray');
+        function [] = addDataArrays(obj, entityArray)
+            nix.Utils.add_entity_array(obj, 'addDataArrays', entityArray, 'nix.DataArray');
         end
 
-        function r = remove_data_array(obj, del)
+        function r = removeDataArray(obj, del)
             r = nix.Utils.delete_entity(obj, 'removeDataArray', del, 'nix.DataArray');
         end
 
-        function r = filter_data_arrays(obj, filter, val)
+        function r = filterDataArrays(obj, filter, val)
             r = nix.Utils.filter(obj, 'dataArraysFiltered', filter, val, @nix.DataArray);
         end
 
@@ -67,36 +67,36 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Tags methods
         % -----------------
 
-        function [] = add_tag(obj, add_this)
-            nix.Utils.add_entity(obj, 'addTag', add_this, 'nix.Tag');
+        function [] = addTag(obj, entity)
+            nix.Utils.add_entity(obj, 'addTag', entity, 'nix.Tag');
         end
 
-        function [] = add_tags(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, 'addTags', add_cell_array, 'nix.Tag');
+        function [] = addTags(obj, entityArray)
+            nix.Utils.add_entity_array(obj, 'addTags', entityArray, 'nix.Tag');
         end
 
-        function r = has_tag(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasTag', id_or_name);
+        function r = hasTag(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasTag', idName);
         end
 
-        function r = get_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'getTag', id_or_name, @nix.Tag);
+        function r = getTag(obj, idName)
+            r = nix.Utils.open_entity(obj, 'getTag', idName, @nix.Tag);
         end
 
-        function r = open_tag_idx(obj, index)
+        function r = openTagIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
-        function r = remove_tag(obj, del)
+        function r = removeTag(obj, del)
             r = nix.Utils.delete_entity(obj, 'removeTag', del, 'nix.Tag');
         end
 
-        function r = tag_count(obj)
+        function r = tagCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'tagCount');
         end
 
-        function r = filter_tags(obj, filter, val)
+        function r = filterTags(obj, filter, val)
             r = nix.Utils.filter(obj, 'tagsFiltered', filter, val, @nix.Tag);
         end
 
@@ -104,36 +104,36 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % MultiTag methods
         % -----------------
 
-        function [] = add_multi_tag(obj, add_this)
-            nix.Utils.add_entity(obj, 'addMultiTag', add_this, 'nix.MultiTag');
+        function [] = addMultiTag(obj, entity)
+            nix.Utils.add_entity(obj, 'addMultiTag', entity, 'nix.MultiTag');
         end
 
-        function [] = add_multi_tags(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, 'addMultiTags', add_cell_array, 'nix.MultiTag');
+        function [] = addMultiTags(obj, entityArray)
+            nix.Utils.add_entity_array(obj, 'addMultiTags', entityArray, 'nix.MultiTag');
         end
 
-        function r = has_multi_tag(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', id_or_name);
+        function r = hasMultiTag(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', idName);
         end
 
-        function r = get_multi_tag(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'getMultiTag', id_or_name, @nix.MultiTag);
+        function r = getMultiTag(obj, idName)
+            r = nix.Utils.open_entity(obj, 'getMultiTag', idName, @nix.MultiTag);
         end
 
-        function r = open_multi_tag_idx(obj, index)
+        function r = openMultiTagIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
-        function r = remove_multi_tag(obj, del)
+        function r = removeMultiTag(obj, del)
             r = nix.Utils.delete_entity(obj, 'removeMultiTag', del, 'nix.MultiTag');
         end
 
-        function r = multi_tag_count(obj)
+        function r = multiTagCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'multiTagCount');
         end
 
-        function r = filter_multi_tags(obj, filter, val)
+        function r = filterMultiTags(obj, filter, val)
             r = nix.Utils.filter(obj, 'multiTagsFiltered', filter, val, @nix.MultiTag);
         end
     end

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -26,7 +26,7 @@ classdef MetadataMixIn < handle
                 fname = strcat(obj.alias, '::setNoneMetadata');
                 nix_mx(fname, obj.nix_handle, val);
             else
-                nix.Utils.add_entity(obj, 'setMetadata', val, 'nix.Section');
+                nix.Utils.addEntity(obj, 'setMetadata', val, 'nix.Section');
             end
         end
     end

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -17,11 +17,11 @@ classdef MetadataMixIn < handle
     end
 
     methods
-        function r = open_metadata(obj)
+        function r = openMetadata(obj)
             r = nix.Utils.fetchObj(obj, 'openMetadataSection', @nix.Section);
         end
 
-        function [] = set_metadata(obj, val)
+        function [] = setMetadata(obj, val)
             if (isempty(val))
                 fname = strcat(obj.alias, '::setNoneMetadata');
                 nix_mx(fname, obj.nix_handle, val);

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -24,7 +24,7 @@ classdef MetadataMixIn < handle
         function [] = setMetadata(obj, val)
             if (isempty(val))
                 fname = strcat(obj.alias, '::setNoneMetadata');
-                nix_mx(fname, obj.nix_handle, val);
+                nix_mx(fname, obj.nixhandle, val);
             else
                 nix.Utils.addEntity(obj, 'setMetadata', val, 'nix.Section');
             end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -60,7 +60,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = retrieveData(obj, positionIdx, idName)
             posIdx = nix.Utils.handleIndex(positionIdx);
             fname = strcat(obj.alias, '::retrieveData');
-            data = nix_mx(fname, obj.nix_handle, posIdx, idName);
+            data = nix_mx(fname, obj.nixhandle, posIdx, idName);
             r = nix.Utils.transposeArray(data);
         end
 
@@ -68,7 +68,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             posIdx = nix.Utils.handleIndex(positionIdx);
             refIdx = nix.Utils.handleIndex(referenceIdx);
             fname = strcat(obj.alias, '::retrieveDataIdx');
-            data = nix_mx(fname, obj.nix_handle, posIdx, refIdx);
+            data = nix_mx(fname, obj.nixhandle, posIdx, refIdx);
             r = nix.Utils.transposeArray(data);
         end
 
@@ -87,7 +87,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = addFeature(obj, entity, linkType)
             addId = nix.Utils.parseEntityId(entity, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nix_handle, addId, linkType);
+            h = nix_mx(fname, obj.nixhandle, addId, linkType);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
@@ -111,7 +111,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = retrieveFeatureData(obj, positionIdx, idName)
             posIdx = nix.Utils.handleIndex(positionIdx);
             fname = strcat(obj.alias, '::featureRetrieveData');
-            data = nix_mx(fname, obj.nix_handle, posIdx, idName);
+            data = nix_mx(fname, obj.nixhandle, posIdx, idName);
             r = nix.Utils.transposeArray(data);
         end
 
@@ -119,7 +119,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             posIdx = nix.Utils.handleIndex(positionIdx);
             featIdx = nix.Utils.handleIndex(featureIdx);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
-            data = nix_mx(fname, obj.nix_handle, posIdx, featIdx);
+            data = nix_mx(fname, obj.nixhandle, posIdx, featIdx);
             r = nix.Utils.transposeArray(data);
         end
 
@@ -137,7 +137,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = hasPositions(obj)
             fname = strcat(obj.alias, '::hasPositions');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = openPositions(obj)
@@ -159,7 +159,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function [] = setExtents(obj, entity)
             if (isempty(entity))
                 fname = strcat(obj.alias, '::setNoneExtents');
-                nix_mx(fname, obj.nix_handle, 0);
+                nix_mx(fname, obj.nixhandle, 0);
             else
                 nix.Utils.addEntity(obj, 'setExtents', entity, 'nix.DataArray');
             end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -33,11 +33,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function [] = addReference(obj, entity)
-            nix.Utils.add_entity(obj, 'addReference', entity, 'nix.DataArray');
+            nix.Utils.addEntity(obj, 'addReference', entity, 'nix.DataArray');
         end
 
         function [] = addReferences(obj, entityArray)
-            nix.Utils.add_entity_array(obj, 'addReferences', entityArray, 'nix.DataArray');
+            nix.Utils.addEntityArray(obj, 'addReferences', entityArray, 'nix.DataArray');
         end
 
         function r = hasReference(obj, idName)
@@ -45,31 +45,31 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = removeReference(obj, del)
-            r = nix.Utils.delete_entity(obj, 'removeReference', del, 'nix.DataArray');
+            r = nix.Utils.deleteEntity(obj, 'removeReference', del, 'nix.DataArray');
         end
 
         function r = openReference(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openReferences', idName, @nix.DataArray);
+            r = nix.Utils.openEntity(obj, 'openReferences', idName, @nix.DataArray);
         end
 
         function r = openReferenceIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
         function r = retrieveData(obj, positionIdx, idName)
-            posIdx = nix.Utils.handle_index(positionIdx);
+            posIdx = nix.Utils.handleIndex(positionIdx);
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nix_handle, posIdx, idName);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveDataIdx(obj, positionIdx, referenceIdx)
-            posIdx = nix.Utils.handle_index(positionIdx);
-            refIdx = nix.Utils.handle_index(referenceIdx);
+            posIdx = nix.Utils.handleIndex(positionIdx);
+            refIdx = nix.Utils.handleIndex(referenceIdx);
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, posIdx, refIdx);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = referenceCount(obj)
@@ -96,31 +96,31 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = removeFeature(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteFeature', del, 'nix.Feature');
+            r = nix.Utils.deleteEntity(obj, 'deleteFeature', del, 'nix.Feature');
         end
 
         function r = openFeature(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openFeature', idName, @nix.Feature);
+            r = nix.Utils.openEntity(obj, 'openFeature', idName, @nix.Feature);
         end
 
         function r = openFeatureIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
         function r = retrieveFeatureData(obj, positionIdx, idName)
-            posIdx = nix.Utils.handle_index(positionIdx);
+            posIdx = nix.Utils.handleIndex(positionIdx);
             fname = strcat(obj.alias, '::featureRetrieveData');
             data = nix_mx(fname, obj.nix_handle, posIdx, idName);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveFeatureDataIdx(obj, positionIdx, featureIdx)
-            posIdx = nix.Utils.handle_index(positionIdx);
-            featIdx = nix.Utils.handle_index(featureIdx);
+            posIdx = nix.Utils.handleIndex(positionIdx);
+            featIdx = nix.Utils.handleIndex(featureIdx);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, posIdx, featIdx);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = featureCount(obj)
@@ -145,7 +145,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function [] = addPositions(obj, entity)
-            nix.Utils.add_entity(obj, 'addPositions', entity, 'nix.DataArray');
+            nix.Utils.addEntity(obj, 'addPositions', entity, 'nix.DataArray');
         end
 
         % ------------------
@@ -161,7 +161,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
                 fname = strcat(obj.alias, '::setNoneExtents');
                 nix_mx(fname, obj.nix_handle, 0);
             else
-                nix.Utils.add_entity(obj, 'setExtents', entity, 'nix.DataArray');
+                nix.Utils.addEntity(obj, 'setExtents', entity, 'nix.DataArray');
             end
         end
     end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -21,11 +21,11 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj@nix.SourcesMixIn();
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'units', 'rw');
+            nix.Dynamic.addProperty(obj, 'units', 'rw');
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'references', @nix.DataArray);
-            nix.Dynamic.add_dyn_relation(obj, 'features', @nix.Feature);
+            nix.Dynamic.addGetChildEntities(obj, 'references', @nix.DataArray);
+            nix.Dynamic.addGetChildEntities(obj, 'features', @nix.Feature);
         end
 
         % ------------------

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -32,51 +32,51 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % References methods
         % ------------------
 
-        function [] = add_reference(obj, add_this)
-            nix.Utils.add_entity(obj, 'addReference', add_this, 'nix.DataArray');
+        function [] = addReference(obj, entity)
+            nix.Utils.add_entity(obj, 'addReference', entity, 'nix.DataArray');
         end
 
-        function [] = add_references(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, 'addReferences', add_cell_array, 'nix.DataArray');
+        function [] = addReferences(obj, entityArray)
+            nix.Utils.add_entity_array(obj, 'addReferences', entityArray, 'nix.DataArray');
         end
 
-        function r = has_reference(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasReference', id_or_name);
+        function r = hasReference(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasReference', idName);
         end
 
-        function r = remove_reference(obj, del)
+        function r = removeReference(obj, del)
             r = nix.Utils.delete_entity(obj, 'removeReference', del, 'nix.DataArray');
         end
 
-        function r = open_reference(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openReferences', id_or_name, @nix.DataArray);
+        function r = openReference(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openReferences', idName, @nix.DataArray);
         end
 
-        function r = open_reference_idx(obj, index)
+        function r = openReferenceIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
-        function r = retrieve_data(obj, position_idx, id_or_name)
-            pos_idx = nix.Utils.handle_index(position_idx);
+        function r = retrieveData(obj, positionIdx, idName)
+            posIdx = nix.Utils.handle_index(positionIdx);
             fname = strcat(obj.alias, '::retrieveData');
-            data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
+            data = nix_mx(fname, obj.nix_handle, posIdx, idName);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_data_idx(obj, position_idx, reference_idx)
-            pos_idx = nix.Utils.handle_index(position_idx);
-            ref_idx = nix.Utils.handle_index(reference_idx);
+        function r = retrieveDataIdx(obj, positionIdx, referenceIdx)
+            posIdx = nix.Utils.handle_index(positionIdx);
+            refIdx = nix.Utils.handle_index(referenceIdx);
             fname = strcat(obj.alias, '::retrieveDataIdx');
-            data = nix_mx(fname, obj.nix_handle, pos_idx, ref_idx);
+            data = nix_mx(fname, obj.nix_handle, posIdx, refIdx);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = reference_count(obj)
+        function r = referenceCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'referenceCount');
         end
 
-        function r = filter_references(obj, filter, val)
+        function r = filterReferences(obj, filter, val)
             r = nix.Utils.filter(obj, 'referencesFiltered', filter, val, @nix.DataArray);
         end
 
@@ -84,50 +84,50 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Features methods
         % ------------------
 
-        function r = add_feature(obj, add_this, link_type)
-            addId = nix.Utils.parseEntityId(add_this, 'nix.DataArray');
+        function r = addFeature(obj, entity, linkType)
+            addId = nix.Utils.parseEntityId(entity, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nix_handle, addId, link_type);
+            h = nix_mx(fname, obj.nix_handle, addId, linkType);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
-        function r = has_feature(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', id_or_name);
+        function r = hasFeature(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', idName);
         end
 
-        function r = remove_feature(obj, del)
+        function r = removeFeature(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteFeature', del, 'nix.Feature');
         end
 
-        function r = open_feature(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openFeature', id_or_name, @nix.Feature);
+        function r = openFeature(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openFeature', idName, @nix.Feature);
         end
 
-        function r = open_feature_idx(obj, index)
+        function r = openFeatureIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
-        function r = retrieve_feature_data(obj, position_idx, id_or_name)
-            pos_idx = nix.Utils.handle_index(position_idx);
+        function r = retrieveFeatureData(obj, positionIdx, idName)
+            posIdx = nix.Utils.handle_index(positionIdx);
             fname = strcat(obj.alias, '::featureRetrieveData');
-            data = nix_mx(fname, obj.nix_handle, pos_idx, id_or_name);
+            data = nix_mx(fname, obj.nix_handle, posIdx, idName);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_feature_data_idx(obj, position_idx, feature_idx)
-            pos_idx = nix.Utils.handle_index(position_idx);
-            feat_idx = nix.Utils.handle_index(feature_idx);
+        function r = retrieveFeatureDataIdx(obj, positionIdx, featureIdx)
+            posIdx = nix.Utils.handle_index(positionIdx);
+            featIdx = nix.Utils.handle_index(featureIdx);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
-            data = nix_mx(fname, obj.nix_handle, pos_idx, feat_idx);
+            data = nix_mx(fname, obj.nix_handle, posIdx, featIdx);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = feature_count(obj)
+        function r = featureCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'featureCount');
         end
 
-        function r = filter_features(obj, filter, val)
+        function r = filterFeatures(obj, filter, val)
             r = nix.Utils.filter(obj, 'featuresFiltered', filter, val, @nix.Feature);
         end
 
@@ -135,33 +135,33 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Positions methods
         % ------------------
 
-        function r = has_positions(obj)
+        function r = hasPositions(obj)
             fname = strcat(obj.alias, '::hasPositions');
             r = nix_mx(fname, obj.nix_handle);
         end
 
-        function r = open_positions(obj)
+        function r = openPositions(obj)
             r = nix.Utils.fetchObj(obj, 'openPositions', @nix.DataArray);
         end
 
-        function [] = add_positions(obj, add_this)
-            nix.Utils.add_entity(obj, 'addPositions', add_this, 'nix.DataArray');
+        function [] = addPositions(obj, entity)
+            nix.Utils.add_entity(obj, 'addPositions', entity, 'nix.DataArray');
         end
 
         % ------------------
         % Extents methods
         % ------------------
 
-        function r = open_extents(obj)
+        function r = openExtents(obj)
             r = nix.Utils.fetchObj(obj, 'openExtents', @nix.DataArray);
         end
 
-        function [] = set_extents(obj, add_this)
-            if (isempty(add_this))
+        function [] = setExtents(obj, entity)
+            if (isempty(entity))
                 fname = strcat(obj.alias, '::setNoneExtents');
                 nix_mx(fname, obj.nix_handle, 0);
             else
-                nix.Utils.add_entity(obj, 'setExtents', add_this, 'nix.DataArray');
+                nix.Utils.add_entity(obj, 'setExtents', entity, 'nix.DataArray');
             end
         end
     end

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -15,10 +15,10 @@ classdef NamedEntity < nix.Entity
             obj = obj@nix.Entity(h);
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'id', 'r');
-            nix.Dynamic.add_dyn_attr(obj, 'name', 'r');
-            nix.Dynamic.add_dyn_attr(obj, 'type', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'definition', 'rw');
+            nix.Dynamic.addProperty(obj, 'id', 'r');
+            nix.Dynamic.addProperty(obj, 'name', 'r');
+            nix.Dynamic.addProperty(obj, 'type', 'rw');
+            nix.Dynamic.addProperty(obj, 'definition', 'rw');
         end
 
         function r = compare(obj, entity)

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -30,7 +30,7 @@ classdef NamedEntity < nix.Entity
                 error(err);
             end
             fname = strcat(obj.alias, '::compare');
-            r = nix_mx(fname, obj.nix_handle, entity.nix_handle);
+            r = nix_mx(fname, obj.nixhandle, entity.nixhandle);
         end
     end
 

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -57,11 +57,11 @@ classdef Property < nix.NamedEntity
             nix_mx(fname, obj.nix_handle, values);
         end
 
-        function r = value_count(obj)
+        function r = valueCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'valueCount');
         end
 
-        function [] = values_delete(obj)
+        function [] = deleteValues(obj)
             fname = strcat(obj.alias, '::deleteValues');
             nix_mx(fname, obj.nix_handle);
         end

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -30,7 +30,7 @@ classdef Property < nix.NamedEntity
 
         function r = get.values(obj)
             fname = strcat(obj.alias, '::values');
-            r = nix_mx(fname, obj.nix_handle);
+            r = nix_mx(fname, obj.nixhandle);
         end
 
         function [] = set.values(obj, val)
@@ -54,7 +54,7 @@ classdef Property < nix.NamedEntity
             end
 
             fname = strcat(obj.alias, '::updateValues');
-            nix_mx(fname, obj.nix_handle, values);
+            nix_mx(fname, obj.nixhandle, values);
         end
 
         function r = valueCount(obj)
@@ -63,7 +63,7 @@ classdef Property < nix.NamedEntity
 
         function [] = deleteValues(obj)
             fname = strcat(obj.alias, '::deleteValues');
-            nix_mx(fname, obj.nix_handle);
+            nix_mx(fname, obj.nixhandle);
         end
     end
 

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -24,8 +24,8 @@ classdef Property < nix.NamedEntity
             obj@nix.NamedEntity(h);
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'datatype', 'r');
+            nix.Dynamic.addProperty(obj, 'unit', 'rw');
+            nix.Dynamic.addProperty(obj, 'datatype', 'r');
         end
 
         function r = get.values(obj)

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -19,11 +19,11 @@ classdef RangeDimension < nix.Entity
             obj@nix.Entity(h);
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
-            nix.Dynamic.add_dyn_attr(obj, 'isAlias', 'r');
-            nix.Dynamic.add_dyn_attr(obj, 'label', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'ticks', 'rw');
+            nix.Dynamic.addProperty(obj, 'dimensionType', 'r');
+            nix.Dynamic.addProperty(obj, 'isAlias', 'r');
+            nix.Dynamic.addProperty(obj, 'label', 'rw');
+            nix.Dynamic.addProperty(obj, 'unit', 'rw');
+            nix.Dynamic.addProperty(obj, 'ticks', 'rw');
         end
 
         function r = tickAt(obj, index)

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -27,7 +27,7 @@ classdef RangeDimension < nix.Entity
         end
 
         function r = tickAt(obj, index)
-            index = nix.Utils.handle_index(index);
+            index = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::tickAt');
             r = nix_mx(fname, obj.nix_handle, index);
         end
@@ -42,7 +42,7 @@ classdef RangeDimension < nix.Entity
                 startIndex = 1;
             end
 
-            startIndex = nix.Utils.handle_index(startIndex);
+            startIndex = nix.Utils.handleIndex(startIndex);
 
             fname = strcat(obj.alias, '::axis');
             r = nix_mx(fname, obj.nix_handle, count, startIndex);

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -29,12 +29,12 @@ classdef RangeDimension < nix.Entity
         function r = tickAt(obj, index)
             index = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::tickAt');
-            r = nix_mx(fname, obj.nix_handle, index);
+            r = nix_mx(fname, obj.nixhandle, index);
         end
 
         function r = indexOf(obj, position)
             fname = strcat(obj.alias, '::indexOf');
-            r = nix_mx(fname, obj.nix_handle, position);
+            r = nix_mx(fname, obj.nixhandle, position);
         end
 
         function r = axis(obj, count, startIndex)
@@ -45,7 +45,7 @@ classdef RangeDimension < nix.Entity
             startIndex = nix.Utils.handleIndex(startIndex);
 
             fname = strcat(obj.alias, '::axis');
-            r = nix_mx(fname, obj.nix_handle, count, startIndex);
+            r = nix_mx(fname, obj.nixhandle, count, startIndex);
         end
     end
 

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -26,13 +26,13 @@ classdef RangeDimension < nix.Entity
             nix.Dynamic.add_dyn_attr(obj, 'ticks', 'rw');
         end
 
-        function r = tick_at(obj, index)
+        function r = tickAt(obj, index)
             index = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::tickAt');
             r = nix_mx(fname, obj.nix_handle, index);
         end
 
-        function r = index_of(obj, position)
+        function r = indexOf(obj, position)
             fname = strcat(obj.alias, '::indexOf');
             r = nix_mx(fname, obj.nix_handle, position);
         end

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -32,7 +32,7 @@ classdef SampledDimension < nix.Entity
         end
 
         function r = positionAt(obj, index)
-            index = nix.Utils.handle_index(index);
+            index = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::positionAt');
             r = nix_mx(fname, obj.nix_handle, index);
         end
@@ -42,7 +42,7 @@ classdef SampledDimension < nix.Entity
                 startIndex = 1;
             end
 
-            startIndex = nix.Utils.handle_index(startIndex);
+            startIndex = nix.Utils.handleIndex(startIndex);
             fname = strcat(obj.alias, '::axis');
             r = nix_mx(fname, obj.nix_handle, count, startIndex);
         end

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -28,13 +28,13 @@ classdef SampledDimension < nix.Entity
 
         function r = indexOf(obj, position)
             fname = strcat(obj.alias, '::indexOf');
-            r = nix_mx(fname, obj.nix_handle, position);
+            r = nix_mx(fname, obj.nixhandle, position);
         end
 
         function r = positionAt(obj, index)
             index = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::positionAt');
-            r = nix_mx(fname, obj.nix_handle, index);
+            r = nix_mx(fname, obj.nixhandle, index);
         end
 
         function r = axis(obj, count, startIndex)
@@ -44,7 +44,7 @@ classdef SampledDimension < nix.Entity
 
             startIndex = nix.Utils.handleIndex(startIndex);
             fname = strcat(obj.alias, '::axis');
-            r = nix_mx(fname, obj.nix_handle, count, startIndex);
+            r = nix_mx(fname, obj.nixhandle, count, startIndex);
         end
     end
 

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -19,11 +19,11 @@ classdef SampledDimension < nix.Entity
             obj@nix.Entity(h);
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
-            nix.Dynamic.add_dyn_attr(obj, 'label', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'unit', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'samplingInterval', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'offset', 'rw');
+            nix.Dynamic.addProperty(obj, 'dimensionType', 'r');
+            nix.Dynamic.addProperty(obj, 'label', 'rw');
+            nix.Dynamic.addProperty(obj, 'unit', 'rw');
+            nix.Dynamic.addProperty(obj, 'samplingInterval', 'rw');
+            nix.Dynamic.addProperty(obj, 'offset', 'rw');
         end
 
         function r = indexOf(obj, position)

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -26,12 +26,12 @@ classdef SampledDimension < nix.Entity
             nix.Dynamic.add_dyn_attr(obj, 'offset', 'rw');
         end
 
-        function r = index_of(obj, position)
+        function r = indexOf(obj, position)
             fname = strcat(obj.alias, '::indexOf');
             r = nix_mx(fname, obj.nix_handle, position);
         end
 
-        function r = position_at(obj, index)
+        function r = positionAt(obj, index)
             index = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::positionAt');
             r = nix_mx(fname, obj.nix_handle, index);

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -20,11 +20,11 @@ classdef Section < nix.NamedEntity
             obj@nix.NamedEntity(h);
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'repository', 'rw');
+            nix.Dynamic.addProperty(obj, 'repository', 'rw');
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'sections', @nix.Section);
-            nix.Dynamic.add_dyn_relation(obj, 'properties', @nix.Property);
+            nix.Dynamic.addGetChildEntities(obj, 'sections', @nix.Section);
+            nix.Dynamic.addGetChildEntities(obj, 'properties', @nix.Property);
         end
 
         function r = parent(obj)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -97,11 +97,11 @@ classdef Section < nix.NamedEntity
 
         % maxDepth is handled like an index
         function r = findSections(obj, maxDepth)
-            r = obj.FilterFindSections(maxDepth, nix.Filter.acceptall, '');
+            r = obj.filterFindSections(maxDepth, nix.Filter.acceptall, '');
         end
 
         % maxDepth is handled like an index
-        function r = FilterFindSections(obj, maxDepth, filter, val)
+        function r = filterFindSections(obj, maxDepth, filter, val)
             r = nix.Utils.find(obj, 'findSections', maxDepth, filter, val, @nix.Section);
         end
 

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -97,7 +97,7 @@ classdef Section < nix.NamedEntity
 
         % maxDepth is handled like an index
         function r = findSections(obj, maxDepth)
-            r = obj.FilterFindSections(maxDepth, nix.Filter.accept_all, '');
+            r = obj.FilterFindSections(maxDepth, nix.Filter.acceptall, '');
         end
 
         % maxDepth is handled like an index

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -40,7 +40,7 @@ classdef Section < nix.NamedEntity
                 fname = strcat(obj.alias, '::setNoneLink');
                 nix_mx(fname, obj.nix_handle);
             else
-                nix.Utils.add_entity(obj, 'setLink', val, 'nix.Section');
+                nix.Utils.addEntity(obj, 'setLink', val, 'nix.Section');
             end
         end
 
@@ -63,16 +63,16 @@ classdef Section < nix.NamedEntity
         end
 
         function r = deleteSection(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteSection', del, 'nix.Section');
+            r = nix.Utils.deleteEntity(obj, 'deleteSection', del, 'nix.Section');
         end
 
         function r = openSection(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openSection', idName, @nix.Section);
+            r = nix.Utils.openEntity(obj, 'openSection', idName, @nix.Section);
         end
 
         function r = openSectionIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
         function r = hasSection(obj, idName)
@@ -142,12 +142,12 @@ classdef Section < nix.NamedEntity
         end
 
         function r = openProperty(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openProperty', idName, @nix.Property);
+            r = nix.Utils.openEntity(obj, 'openProperty', idName, @nix.Property);
         end
 
         function r = openPropertyIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openPropertyIdx', idx, @nix.Property);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openPropertyIdx', idx, @nix.Property);
         end
 
         function r = propertyCount(obj)

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -35,7 +35,7 @@ classdef Section < nix.NamedEntity
         % Link methods
         % ----------------
 
-        function [] = set_link(obj, val)
+        function [] = setLink(obj, val)
             if (isempty(val))
                 fname = strcat(obj.alias, '::setNoneLink');
                 nix_mx(fname, obj.nix_handle);
@@ -48,7 +48,7 @@ classdef Section < nix.NamedEntity
             r = nix.Utils.fetchObj(obj, 'openLink', @nix.Section);
         end
 
-        function r = inherited_properties(obj)
+        function r = inheritedProperties(obj)
             r = nix.Utils.fetchObjList(obj, 'inheritedProperties', @nix.Property);
         end
 
@@ -56,60 +56,60 @@ classdef Section < nix.NamedEntity
         % Section methods
         % ----------------
 
-        function r = create_section(obj, name, type)
+        function r = createSection(obj, name, type)
             fname = strcat(obj.alias, '::createSection');
             h = nix_mx(fname, obj.nix_handle, name, type);
             r = nix.Utils.createEntity(h, @nix.Section);
         end
 
-        function r = delete_section(obj, del)
+        function r = deleteSection(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteSection', del, 'nix.Section');
         end
 
-        function r = open_section(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openSection', id_or_name, @nix.Section);
+        function r = openSection(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openSection', idName, @nix.Section);
         end
 
-        function r = open_section_idx(obj, index)
+        function r = openSectionIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
-        function r = has_section(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasSection', id_or_name);
+        function r = hasSection(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasSection', idName);
         end
 
-        function r = section_count(obj)
+        function r = sectionCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
-        function r = filter_sections(obj, filter, val)
+        function r = filterSections(obj, filter, val)
             r = nix.Utils.filter(obj, 'sectionsFiltered', filter, val, @nix.Section);
         end
 
-        % find_related returns the nearest occurrence downstream of a
+        % findRelated returns the nearest occurrence downstream of a
         % nix.Section matching the filter.
         % If no section can be found downstream, it will look for the
         % nearest occurrence upstream of a nix.Section matching the filter.
-        function r = find_related(obj, filter, val)
+        function r = findRelated(obj, filter, val)
             r = nix.Utils.filter(obj, 'findRelated', filter, val, @nix.Section);
         end
 
-        % maxdepth is handled like an index
-        function r = find_sections(obj, max_depth)
-            r = obj.find_filtered_sections(max_depth, nix.Filter.accept_all, '');
+        % maxDepth is handled like an index
+        function r = findSections(obj, maxDepth)
+            r = obj.FilterFindSections(maxDepth, nix.Filter.accept_all, '');
         end
 
-        % maxdepth is handled like an index
-        function r = find_filtered_sections(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, 'findSections', max_depth, filter, val, @nix.Section);
+        % maxDepth is handled like an index
+        function r = FilterFindSections(obj, maxDepth, filter, val)
+            r = nix.Utils.find(obj, 'findSections', maxDepth, filter, val, @nix.Section);
         end
 
         % ----------------
         % Property methods
         % ----------------
 
-        function r = create_property(obj, name, datatype)
+        function r = createProperty(obj, name, datatype)
             if (~isa(datatype, 'nix.DataType'))
                 err.identifier = 'NIXMX:InvalidArgument';
                 err.message = 'Please provide a valid nix.DataType';
@@ -121,7 +121,7 @@ classdef Section < nix.NamedEntity
             end
         end
 
-        function r = create_property_with_value(obj, name, val)
+        function r = createPropertyWithValue(obj, name, val)
             if (~iscell(val))
                 val = num2cell(val);
             end
@@ -130,7 +130,7 @@ classdef Section < nix.NamedEntity
             r = nix.Utils.createEntity(h, @nix.Property);
         end
 
-        function r = delete_property(obj, del)
+        function r = deleteProperty(obj, del)
             if (isstruct(del) && isfield(del, 'id'))
                 id = del.id;
             else
@@ -141,20 +141,20 @@ classdef Section < nix.NamedEntity
             r = nix_mx(fname, obj.nix_handle, id);
         end
 
-        function r = open_property(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openProperty', id_or_name, @nix.Property);
+        function r = openProperty(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openProperty', idName, @nix.Property);
         end
 
-        function r = open_property_idx(obj, index)
+        function r = openPropertyIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openPropertyIdx', idx, @nix.Property);
         end
 
-        function r = property_count(obj)
+        function r = propertyCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'propertyCount');
         end
 
-        function r = filter_properties(obj, filter, val)
+        function r = filterProperties(obj, filter, val)
             r = nix.Utils.filter(obj, 'propertiesFiltered', filter, val, @nix.Property);
         end
 
@@ -162,23 +162,23 @@ classdef Section < nix.NamedEntity
         % Referring entity methods
         % ----------------
 
-        function r = referring_data_arrays(obj, varargin)
-            r = obj.referring_util(@nix.DataArray, 'DataArrays', varargin{:});
+        function r = referringDataArrays(obj, varargin)
+            r = obj.referringUtil(@nix.DataArray, 'DataArrays', varargin{:});
         end
 
-        function r = referring_tags(obj, varargin)
-            r = obj.referring_util(@nix.Tag, 'Tags', varargin{:});
+        function r = referringTags(obj, varargin)
+            r = obj.referringUtil(@nix.Tag, 'Tags', varargin{:});
         end
 
-        function r = referring_multi_tags(obj, varargin)
-            r = obj.referring_util(@nix.MultiTag, 'MultiTags', varargin{:});
+        function r = referringMultiTags(obj, varargin)
+            r = obj.referringUtil(@nix.MultiTag, 'MultiTags', varargin{:});
         end
 
-        function r = referring_sources(obj, varargin)
-            r = obj.referring_util(@nix.Source, 'Sources', varargin{:});
+        function r = referringSources(obj, varargin)
+            r = obj.referringUtil(@nix.Source, 'Sources', varargin{:});
         end
 
-        function r = referring_blocks(obj)
+        function r = referringBlocks(obj)
             r = nix.Utils.fetchObjList(obj, 'referringBlocks', @nix.Block);
         end
     end
@@ -188,10 +188,10 @@ classdef Section < nix.NamedEntity
     % ----------------
 
     methods (Access=protected)
-        % referring_util receives a nix entityConstructor, part of a function
+        % referringUtil receives a nix entityConstructor, part of a function
         % name and varargin to provide abstract access to nix.Section
         % referringXXX and referringXXX(Block) methods.
-        function r = referring_util(obj, entityConstructor, fsuffix, varargin)
+        function r = referringUtil(obj, entityConstructor, fsuffix, varargin)
             if (isempty(varargin))
                 fname = strcat('referring', fsuffix);
                 r = nix.Utils.fetchObjList(obj, fname, entityConstructor);

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -38,7 +38,7 @@ classdef Section < nix.NamedEntity
         function [] = setLink(obj, val)
             if (isempty(val))
                 fname = strcat(obj.alias, '::setNoneLink');
-                nix_mx(fname, obj.nix_handle);
+                nix_mx(fname, obj.nixhandle);
             else
                 nix.Utils.addEntity(obj, 'setLink', val, 'nix.Section');
             end
@@ -58,7 +58,7 @@ classdef Section < nix.NamedEntity
 
         function r = createSection(obj, name, type)
             fname = strcat(obj.alias, '::createSection');
-            h = nix_mx(fname, obj.nix_handle, name, type);
+            h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Section);
         end
 
@@ -116,7 +116,7 @@ classdef Section < nix.NamedEntity
                 error(err);
             else
                 fname = strcat(obj.alias, '::createProperty');
-                h = nix_mx(fname, obj.nix_handle, name, lower(datatype.char));
+                h = nix_mx(fname, obj.nixhandle, name, lower(datatype.char));
                 r = nix.Utils.createEntity(h, @nix.Property);
             end
         end
@@ -126,7 +126,7 @@ classdef Section < nix.NamedEntity
                 val = num2cell(val);
             end
             fname = strcat(obj.alias, '::createPropertyWithValue');
-            h = nix_mx(fname, obj.nix_handle, name, val);
+            h = nix_mx(fname, obj.nixhandle, name, val);
             r = nix.Utils.createEntity(h, @nix.Property);
         end
 
@@ -138,7 +138,7 @@ classdef Section < nix.NamedEntity
             end
 
             fname = strcat(obj.alias, '::deleteProperty');
-            r = nix_mx(fname, obj.nix_handle, id);
+            r = nix_mx(fname, obj.nixhandle, id);
         end
 
         function r = openProperty(obj, idName)
@@ -202,7 +202,7 @@ classdef Section < nix.NamedEntity
             else
                 fname = strcat('referringBlock', fsuffix);
                 r = nix.Utils.fetchObjListByEntity(obj, fname, ...
-                                            varargin{1}.nix_handle, entityConstructor);
+                                            varargin{1}.nixhandle, entityConstructor);
             end
         end
     end

--- a/+nix/SetDimension.m
+++ b/+nix/SetDimension.m
@@ -19,8 +19,8 @@ classdef SetDimension < nix.Entity
             obj@nix.Entity(h);
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'dimensionType', 'r');
-            nix.Dynamic.add_dyn_attr(obj, 'labels', 'rw');
+            nix.Dynamic.addProperty(obj, 'dimensionType', 'r');
+            nix.Dynamic.addProperty(obj, 'labels', 'rw');
         end
     end
 

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -20,7 +20,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             obj@nix.MetadataMixIn();
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
+            nix.Dynamic.addGetChildEntities(obj, 'sources', @nix.Source);
         end
 
         % ------------------

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -27,61 +27,61 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         % Sources methods
         % ------------------
 
-        function r = source_count(obj)
+        function r = sourceCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
-        function r = create_source(obj, name, type)
+        function r = createSource(obj, name, type)
             fname = strcat(obj.alias, '::createSource');
             h = nix_mx(fname, obj.nix_handle, name, type);
             r = nix.Utils.createEntity(h, @nix.Source);
         end
 
-        function r = has_source(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasSource', id_or_name);
+        function r = hasSource(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasSource', idName);
         end
 
-        function r = delete_source(obj, del)
+        function r = deleteSource(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteSource', del, 'nix.Source');
         end
 
-        function r = open_source(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
+        function r = openSource(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openSource', idName, @nix.Source);
         end
 
-        function r = open_source_idx(obj, index)
+        function r = openSourceIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
-        function r = parent_source(obj)
+        function r = parentSource(obj)
             r = nix.Utils.fetchObj(obj, 'parentSource', @nix.Source);
         end
 
-        function r = referring_data_arrays(obj)
+        function r = referringDataArrays(obj)
             r = nix.Utils.fetchObjList(obj, 'referringDataArrays', @nix.DataArray);
         end
 
-        function r = referring_tags(obj)
+        function r = referringTags(obj)
             r = nix.Utils.fetchObjList(obj, 'referringTags', @nix.Tag);
         end
 
-        function r = referring_multi_tags(obj)
+        function r = referringMultiTags(obj)
             r = nix.Utils.fetchObjList(obj, 'referringMultiTags', @nix.MultiTag);
         end
 
-        function r = filter_sources(obj, filter, val)
+        function r = filterSources(obj, filter, val)
             r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
 
         % maxdepth is an index where idx = 0 corresponds to the calling source
-        function r = find_sources(obj, max_depth)
-            r = obj.find_filtered_sources(max_depth, nix.Filter.accept_all, '');
+        function r = findSources(obj, maxDepth)
+            r = obj.filterFindSources(maxDepth, nix.Filter.accept_all, '');
         end
 
         % maxdepth is an index where idx = 0 corresponds to the calling source
-        function r = find_filtered_sources(obj, max_depth, filter, val)
-            r = nix.Utils.find(obj, 'findSources', max_depth, filter, val, @nix.Source);
+        function r = filterFindSources(obj, maxDepth, filter, val)
+            r = nix.Utils.find(obj, 'findSources', maxDepth, filter, val, @nix.Source);
         end
     end
 

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -76,7 +76,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
 
         % maxdepth is an index where idx = 0 corresponds to the calling source
         function r = findSources(obj, maxDepth)
-            r = obj.filterFindSources(maxDepth, nix.Filter.accept_all, '');
+            r = obj.filterFindSources(maxDepth, nix.Filter.acceptall, '');
         end
 
         % maxdepth is an index where idx = 0 corresponds to the calling source

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -42,16 +42,16 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = deleteSource(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteSource', del, 'nix.Source');
+            r = nix.Utils.deleteEntity(obj, 'deleteSource', del, 'nix.Source');
         end
 
         function r = openSource(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openSource', idName, @nix.Source);
+            r = nix.Utils.openEntity(obj, 'openSource', idName, @nix.Source);
         end
 
         function r = openSourceIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = parentSource(obj)

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -33,7 +33,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
 
         function r = createSource(obj, name, type)
             fname = strcat(obj.alias, '::createSource');
-            h = nix_mx(fname, obj.nix_handle, name, type);
+            h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Source);
         end
 

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -19,38 +19,38 @@ classdef SourcesMixIn < handle
             nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
         end
 
-        function r = source_count(obj)
+        function r = sourceCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
-        % has_source supports only check by id, not by name
-        function r = has_source(obj, id_or_entity)
-            has = nix.Utils.parseEntityId(id_or_entity, 'nix.Source');
+        % hasSource supports only check by id, not by name
+        function r = hasSource(obj, idEntity)
+            has = nix.Utils.parseEntityId(idEntity, 'nix.Source');
             r = nix.Utils.fetchHasEntity(obj, 'hasSource', has);
         end
 
-        function [] = add_source(obj, add_this)
-            nix.Utils.add_entity(obj, 'addSource', add_this, 'nix.Source');
+        function [] = addSource(obj, entity)
+            nix.Utils.add_entity(obj, 'addSource', entity, 'nix.Source');
         end
 
-        function [] = add_sources(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, 'addSources', add_cell_array, 'nix.Source');
+        function [] = addSources(obj, entityArray)
+            nix.Utils.add_entity_array(obj, 'addSources', entityArray, 'nix.Source');
         end
 
-        function r = remove_source(obj, del)
+        function r = removeSource(obj, del)
             r = nix.Utils.delete_entity(obj, 'removeSource', del, 'nix.Source');
         end
 
-        function r = open_source(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openSource', id_or_name, @nix.Source);
+        function r = openSource(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openSource', idName, @nix.Source);
         end
 
-        function r = open_source_idx(obj, index)
+        function r = openSourceIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
-        function r = filter_sources(obj, filter, val)
+        function r = filterSources(obj, filter, val)
             r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
     end

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -30,24 +30,24 @@ classdef SourcesMixIn < handle
         end
 
         function [] = addSource(obj, entity)
-            nix.Utils.add_entity(obj, 'addSource', entity, 'nix.Source');
+            nix.Utils.addEntity(obj, 'addSource', entity, 'nix.Source');
         end
 
         function [] = addSources(obj, entityArray)
-            nix.Utils.add_entity_array(obj, 'addSources', entityArray, 'nix.Source');
+            nix.Utils.addEntityArray(obj, 'addSources', entityArray, 'nix.Source');
         end
 
         function r = removeSource(obj, del)
-            r = nix.Utils.delete_entity(obj, 'removeSource', del, 'nix.Source');
+            r = nix.Utils.deleteEntity(obj, 'removeSource', del, 'nix.Source');
         end
 
         function r = openSource(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openSource', idName, @nix.Source);
+            r = nix.Utils.openEntity(obj, 'openSource', idName, @nix.Source);
         end
 
         function r = openSourceIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openSourceIdx', idx, @nix.Source);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = filterSources(obj, filter, val)

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -16,7 +16,7 @@ classdef SourcesMixIn < handle
 
     methods
         function obj = SourcesMixIn()
-            nix.Dynamic.add_dyn_relation(obj, 'sources', @nix.Source);
+            nix.Dynamic.addGetChildEntities(obj, 'sources', @nix.Source);
         end
 
         function r = sourceCount(obj)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -61,14 +61,14 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = retrieveData(obj, idName)
             fname = strcat(obj.alias, '::retrieveData');
-            data = nix_mx(fname, obj.nix_handle, idName);
+            data = nix_mx(fname, obj.nixhandle, idName);
             r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveDataIdx(obj, index)
             idx = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::retrieveDataIdx');
-            data = nix_mx(fname, obj.nix_handle, idx);
+            data = nix_mx(fname, obj.nixhandle, idx);
             r = nix.Utils.transposeArray(data);
         end
 
@@ -87,7 +87,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         function r = addFeature(obj, entity, linkType)
             id = nix.Utils.parseEntityId(entity, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nix_handle, id, linkType);
+            h = nix_mx(fname, obj.nixhandle, id, linkType);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
@@ -110,14 +110,14 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
         function r = retrieveFeatureData(obj, idName)
             fname = strcat(obj.alias, '::featureRetrieveData');
-            data = nix_mx(fname, obj.nix_handle, idName);
+            data = nix_mx(fname, obj.nixhandle, idName);
             r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveFeatureDataIdx(obj, index)
             idx = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
-            data = nix_mx(fname, obj.nix_handle, idx);
+            data = nix_mx(fname, obj.nixhandle, idx);
             r = nix.Utils.transposeArray(data);
         end
 

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -21,13 +21,13 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj@nix.SourcesMixIn();
 
             % assign dynamic properties
-            nix.Dynamic.add_dyn_attr(obj, 'position', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'extent', 'rw');
-            nix.Dynamic.add_dyn_attr(obj, 'units', 'rw');
+            nix.Dynamic.addProperty(obj, 'position', 'rw');
+            nix.Dynamic.addProperty(obj, 'extent', 'rw');
+            nix.Dynamic.addProperty(obj, 'units', 'rw');
 
             % assign relations
-            nix.Dynamic.add_dyn_relation(obj, 'references', @nix.DataArray);
-            nix.Dynamic.add_dyn_relation(obj, 'features', @nix.Feature);
+            nix.Dynamic.addGetChildEntities(obj, 'references', @nix.DataArray);
+            nix.Dynamic.addGetChildEntities(obj, 'features', @nix.Feature);
         end
 
         % ------------------

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -35,11 +35,11 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function [] = addReference(obj, entity)
-            nix.Utils.add_entity(obj, 'addReference', entity, 'nix.DataArray');
+            nix.Utils.addEntity(obj, 'addReference', entity, 'nix.DataArray');
         end
 
         function [] = addReferences(obj, entityArray)
-            nix.Utils.add_entity_array(obj, 'addReferences', entityArray, 'nix.DataArray');
+            nix.Utils.addEntityArray(obj, 'addReferences', entityArray, 'nix.DataArray');
         end
 
         function r = hasReference(obj, idName)
@@ -47,29 +47,29 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = removeReference(obj, del)
-            r = nix.Utils.delete_entity(obj, 'removeReference', del, 'nix.DataArray');
+            r = nix.Utils.deleteEntity(obj, 'removeReference', del, 'nix.DataArray');
         end
 
         function r = openReference(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openReferenceDataArray', idName, @nix.DataArray);
+            r = nix.Utils.openEntity(obj, 'openReferenceDataArray', idName, @nix.DataArray);
         end
 
         function r = openReferenceIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
         function r = retrieveData(obj, idName)
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nix_handle, idName);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveDataIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
+            idx = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = referenceCount(obj)
@@ -96,29 +96,29 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = removeFeature(obj, del)
-            r = nix.Utils.delete_entity(obj, 'deleteFeature', del, 'nix.Feature');
+            r = nix.Utils.deleteEntity(obj, 'deleteFeature', del, 'nix.Feature');
         end
 
         function r = openFeature(obj, idName)
-            r = nix.Utils.open_entity(obj, 'openFeature', idName, @nix.Feature);
+            r = nix.Utils.openEntity(obj, 'openFeature', idName, @nix.Feature);
         end
 
         function r = openFeatureIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
-            r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
+            idx = nix.Utils.handleIndex(index);
+            r = nix.Utils.openEntity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
         function r = retrieveFeatureData(obj, idName)
             fname = strcat(obj.alias, '::featureRetrieveData');
             data = nix_mx(fname, obj.nix_handle, idName);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveFeatureDataIdx(obj, index)
-            idx = nix.Utils.handle_index(index);
+            idx = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
-            r = nix.Utils.transpose_array(data);
+            r = nix.Utils.transposeArray(data);
         end
 
         function r = featureCount(obj)

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -34,49 +34,49 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % References methods
         % ------------------
 
-        function [] = add_reference(obj, add_this)
-            nix.Utils.add_entity(obj, 'addReference', add_this, 'nix.DataArray');
+        function [] = addReference(obj, entity)
+            nix.Utils.add_entity(obj, 'addReference', entity, 'nix.DataArray');
         end
 
-        function [] = add_references(obj, add_cell_array)
-            nix.Utils.add_entity_array(obj, 'addReferences', add_cell_array, 'nix.DataArray');
+        function [] = addReferences(obj, entityArray)
+            nix.Utils.add_entity_array(obj, 'addReferences', entityArray, 'nix.DataArray');
         end
 
-        function r = has_reference(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasReference', id_or_name);
+        function r = hasReference(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasReference', idName);
         end
 
-        function r = remove_reference(obj, del)
+        function r = removeReference(obj, del)
             r = nix.Utils.delete_entity(obj, 'removeReference', del, 'nix.DataArray');
         end
 
-        function r = open_reference(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openReferenceDataArray', id_or_name, @nix.DataArray);
+        function r = openReference(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openReferenceDataArray', idName, @nix.DataArray);
         end
 
-        function r = open_reference_idx(obj, index)
+        function r = openReferenceIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
-        function r = retrieve_data(obj, id_or_name)
+        function r = retrieveData(obj, idName)
             fname = strcat(obj.alias, '::retrieveData');
-            data = nix_mx(fname, obj.nix_handle, id_or_name);
+            data = nix_mx(fname, obj.nix_handle, idName);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_data_idx(obj, index)
+        function r = retrieveDataIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = reference_count(obj)
+        function r = referenceCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'referenceCount');
         end
 
-        function r = filter_references(obj, filter, val)
+        function r = filterReferences(obj, filter, val)
             r = nix.Utils.filter(obj, 'referencesFiltered', filter, val, @nix.DataArray);
         end
 
@@ -84,48 +84,48 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Features methods
         % ------------------
 
-        function r = add_feature(obj, add_this, link_type)
-            id = nix.Utils.parseEntityId(add_this, 'nix.DataArray');
+        function r = addFeature(obj, entity, linkType)
+            id = nix.Utils.parseEntityId(entity, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nix_handle, id, link_type);
+            h = nix_mx(fname, obj.nix_handle, id, linkType);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
-        function r = has_feature(obj, id_or_name)
-            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', id_or_name);
+        function r = hasFeature(obj, idName)
+            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', idName);
         end
 
-        function r = remove_feature(obj, del)
+        function r = removeFeature(obj, del)
             r = nix.Utils.delete_entity(obj, 'deleteFeature', del, 'nix.Feature');
         end
 
-        function r = open_feature(obj, id_or_name)
-            r = nix.Utils.open_entity(obj, 'openFeature', id_or_name, @nix.Feature);
+        function r = openFeature(obj, idName)
+            r = nix.Utils.open_entity(obj, 'openFeature', idName, @nix.Feature);
         end
 
-        function r = open_feature_idx(obj, index)
+        function r = openFeatureIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             r = nix.Utils.open_entity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
-        function r = retrieve_feature_data(obj, id_or_name)
+        function r = retrieveFeatureData(obj, idName)
             fname = strcat(obj.alias, '::featureRetrieveData');
-            data = nix_mx(fname, obj.nix_handle, id_or_name);
+            data = nix_mx(fname, obj.nix_handle, idName);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = retrieve_feature_data_idx(obj, index)
+        function r = retrieveFeatureDataIdx(obj, index)
             idx = nix.Utils.handle_index(index);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nix_handle, idx);
             r = nix.Utils.transpose_array(data);
         end
 
-        function r = feature_count(obj)
+        function r = featureCount(obj)
             r = nix.Utils.fetchEntityCount(obj, 'featureCount');
         end
 
-        function r = filter_features(obj, filter, val)
+        function r = filterFeatures(obj, filter, val)
             r = nix.Utils.filter(obj, 'featuresFiltered', filter, val, @nix.Feature);
         end
     end

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -38,17 +38,17 @@ classdef Utils
 
         function r = fetchEntityCount(obj, mxMethodName)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            r = nix_mx(mxMethod, obj.nix_handle);
+            r = nix_mx(mxMethod, obj.nixhandle);
         end
 
         function r = fetchHasEntity(obj, mxMethodName, identifier)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            r = nix_mx(mxMethod, obj.nix_handle, identifier);
+            r = nix_mx(mxMethod, obj.nixhandle, identifier);
         end
 
         function r = fetchObjList(obj, mxMethodName, objConstructor)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            list = nix_mx(mxMethod, obj.nix_handle);
+            list = nix_mx(mxMethod, obj.nixhandle);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
@@ -59,20 +59,20 @@ classdef Utils
         % returned nix Entities.
         function r = fetchObjListByEntity(obj, mxMethodName, relatedHandle, objConstructor)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            list = nix_mx(mxMethod, obj.nix_handle, relatedHandle);
+            list = nix_mx(mxMethod, obj.nixhandle, relatedHandle);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
         function r = fetchObj(obj, mxMethodName, objConstructor)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            h = nix_mx(mxMethod, obj.nix_handle);
+            h = nix_mx(mxMethod, obj.nixhandle);
             r = nix.Utils.createEntity(h, objConstructor);
         end
 
         function [] = addEntity(obj, mxMethodName, idNameEntity, nixEntity)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
-            nix_mx(mxMethod, obj.nix_handle, id);
+            nix_mx(mxMethod, obj.nixhandle, id);
         end
 
         function [] = addEntityArray(obj, mxMethodName, entityArray, nixEntity)
@@ -89,11 +89,11 @@ classdef Utils
                     err.message = sprintf('Element #%s is not a %s.', num2str(i), nixEntity);
                     error(err);
                 end
-                handleArray{i} = entityArray{i}.nix_handle;
+                handleArray{i} = entityArray{i}.nixhandle;
             end
 
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            nix_mx(mxMethod, obj.nix_handle, handleArray);
+            nix_mx(mxMethod, obj.nixhandle, handleArray);
         end
 
         % Function can be used for both nix delete and remove methods.
@@ -102,12 +102,12 @@ classdef Utils
         function r = deleteEntity(obj, mxMethodName, idNameEntity, nixEntity)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
-            r = nix_mx(mxMethod, obj.nix_handle, id);
+            r = nix_mx(mxMethod, obj.nixhandle, id);
         end
 
         function r = openEntity(obj, mxMethodName, idName, objConstructor)
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            h = nix_mx(mxMethod, obj.nix_handle, idName);
+            h = nix_mx(mxMethod, obj.nixhandle, idName);
             r = nix.Utils.createEntity(h, objConstructor);
         end
 
@@ -135,7 +135,7 @@ classdef Utils
             nix.Utils.validFilter(filter, val);
 
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            list = nix_mx(mxMethod, obj.nix_handle, uint8(filter), val);
+            list = nix_mx(mxMethod, obj.nixhandle, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
@@ -156,7 +156,7 @@ classdef Utils
             md = nix.Utils.handleIndex(maxDepth);
 
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            list = nix_mx(mxMethod, obj.nix_handle, md, uint8(filter), val);
+            list = nix_mx(mxMethod, obj.nixhandle, md, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Please try to avoid duplicates of issues. If you encounter duplicated issues, pl
 one, reference the closed issues in the one that is left open and add missing information from the closed issues
 (if necessary) to the remaining issue.
 
-Assign meaningful tags to newly crated issues and if possible assign them to milestones.
+Assign meaningful tags to newly crated issues and if possible assign them to a milestone.
 
 
 Reviewing pull requests
@@ -64,7 +64,8 @@ Testing
 Style guide
 -----------
 
-Adhere to the MATLAB Style Guidelines 2.0 as suggested by Richard Johnson.
+Adhere to the [MATLAB Style Guidelines 2.0](https://de.mathworks.com/matlabcentral/fileexchange/46056-matlab-style-guidelines-2-0) 
+as suggested by Richard Johnson.
 
 Furthermore, adhere to these additional guidelines for the nix-mx project:
 - Keep line length at a maximum of 90 characters.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,9 @@ Style guide
 Adhere to the MATLAB Style Guidelines 2.0 as suggested by Richard Johnson.
 
 Furthermore, adhere to these additional guidelines for the nix-mx project:
-
-- keep line length at 90 max.
-- use `r` as return variable name of simple (2-3 line) functions.
-- always use ';' to terminate proper statements, never for terminating control structures.
+- Keep line length at a maximum of 90 characters.
+- Use `r` as return variable name of simple (2-3 line) functions.
+- Always terminate proper statements with a semicolon.
+- Never terminate control structures with a semicolon.
 - Structure names should start with a capital letter.
 - Structure field names should be camel case and start with a lower case letter.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+How to contribute to nix-mx
+===========================
+
+This document gives some information about how to contribute to the nix-mx project.
+
+
+Contributing
+------------
+
+If you want to contribute to the project please first create a fork of the repository on GitHub.
+When you are done with implementing a new feature or with fixing a bug, please send
+us a pull request.
+
+If you contribute to the project regularly, it would be very much appreciated if you
+would stick to the following development workflow:
+
+1. Select an *issue* from the issue tracker that you want to work on and assign the issue to your account.
+   If the *issue* is about a relatively complex matter or requires larger API changes the description of the
+   *issue* or its respective discussion should contain a brief concept about how the solution will look like.
+
+2. During the implementation of the feature or bug-fix add your changes in small atomic commits.
+   Commit messages should be short but expressive.
+   The first line of the message should not exceed **50** characters and the 2nd line should be empty.
+   If you want to add further text you can do so from the 3rd line on without limitations.
+   If possible reference fixed issues in the commit message (e.g. "fixes #101").
+
+3. When done with the implementation, compile and test the code.
+   If your work includes a new function or class please write a small unit test for it.
+
+4. Send us a pull request with your changes.
+   The pull request message should explain the changes and reference the *issue* addressed by your code.
+   Your pull request will be reviewed by one of our team members.
+   Pull requests should never be merged by the author of the contribution, but by another team member.
+
+
+The issue tracker
+-----------------
+
+Please try to avoid duplicates of issues. If you encounter duplicated issues, please close all of them except
+one, reference the closed issues in the one that is left open and add missing information from the closed issues
+(if necessary) to the remaining issue.
+
+Assign meaningful tags to newly crated issues and if possible assign them to milestones.
+
+
+Reviewing pull requests
+-----------------------
+
+Every code (even small contributions from core developers) should be added to the project via pull requests.
+Each pull request that passes all builds and tests should be reviewed by at least one of the core developers.
+If a contribution is rather complex or leads to significant API changes, the respective pull request should be
+reviewed by two other developers.
+In such cases the first reviewer or the contributor should request a second review in a comment.
+
+
+Testing
+-------
+
+- Unit test can be found in the `tests` sub directory.
+- Provide a unit test for every class, method or function.
+- Please make sure that all tests pass before merging/sending pull requests.
+
+
+Style guide
+-----------
+
+Adhere to the MATLAB Style Guidelines 2.0 as suggested by Richard Johnson.
+
+Furthermore, adhere to these additional guidelines for the nix-mx project:
+
+- keep line length at 90 max.
+- use `r` as return variable name of simple (2-3 line) functions.
+- always use ';' to terminate proper statements, never for terminating control structures.
+- Structure names should start with a capital letter.
+- Structure field names should be camel case and start with a lower case letter.

--- a/examples/Primer.m
+++ b/examples/Primer.m
@@ -24,8 +24,8 @@ for i = 1:length(f.blocks)
     b = f.blocks{i};
     
     % fetch trial indexes of a certain type = 'nix.trial'
-    trial_idx = cellfun(@(x) strcmp(x.type, 'nix.trial'), b.tags);
-    disp([10 b.name ': ' num2str(length(nonzeros(trial_idx))) ' trials']);
+    trialIdx = cellfun(@(x) strcmp(x.type, 'nix.trial'), b.tags);
+    disp([10 b.name ': ' num2str(length(nonzeros(trialIdx))) ' trials']);
     
     % display source names
     for j = 1:length(b.sources)
@@ -53,7 +53,7 @@ selection2 = b.dataArrays(idx);
 
 % get actual data
 d1 = selection2{1};
-dataset = d1.read_all();
+dataset = d1.readAllData();
 
 % understand dimensions
 dim1 = d1.dimensions{1};
@@ -79,5 +79,5 @@ cellfun(@(x) disp(x), sec.properties);
 value = sec.properties{1}.values{1};
 
 % or by name
-value = sec.open_property('Name').values{1}.value;
+value = sec.openProperty('Name').values{1}.value;
 

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -151,7 +151,7 @@ namespace nixdataarray {
 
         nix::Dimension d = currObj.getDimension(idx);
 
-        struct_builder sb({ 1 }, { "dimension_type", "handle" });
+        struct_builder sb({ 1 }, { "dimensionType", "handle" });
 
         switch (d.dimensionType()) {
         case nix::DimensionType::Set:

--- a/tests/RunTests.m
+++ b/tests/RunTests.m
@@ -20,24 +20,24 @@ disp([10 'starting tests']);
 %--     id: 7b59c0b9-b200-4b53-951d-6851dbd1cdc8
 %--     name: joe097
 
-all_tests = {};
-all_tests{end+1} = struct('name', 'FILE', 'tests', {TestFile()});
-all_tests{end+1} = struct('name', 'BLOCK', 'tests', {TestBlock()});
-all_tests{end+1} = struct('name', 'GROUP', 'tests', {TestGroup()});
-all_tests{end+1} = struct('name', 'SOURCE', 'tests', {TestSource()});
-all_tests{end+1} = struct('name', 'DATAARRAY', 'tests', {TestDataArray()});
-all_tests{end+1} = struct('name', 'TAG', 'tests', {TestTag()});
-all_tests{end+1} = struct('name', 'MULTITAG', 'tests', {TestMultiTag()});
-all_tests{end+1} = struct('name', 'SECTION', 'tests', {TestSection()});
-all_tests{end+1} = struct('name', 'FEATURE', 'tests', {TestFeature()});
-all_tests{end+1} = struct('name', 'PROPERTY', 'tests', {TestProperty()});
-all_tests{end+1} = struct('name', 'DIMENSIONS', 'tests', {TestDimensions()});
+all = {};
+all{end+1} = struct('name', 'FILE', 'tests', {TestFile()});
+all{end+1} = struct('name', 'BLOCK', 'tests', {TestBlock()});
+all{end+1} = struct('name', 'GROUP', 'tests', {TestGroup()});
+all{end+1} = struct('name', 'SOURCE', 'tests', {TestSource()});
+all{end+1} = struct('name', 'DATAARRAY', 'tests', {TestDataArray()});
+all{end+1} = struct('name', 'TAG', 'tests', {TestTag()});
+all{end+1} = struct('name', 'MULTITAG', 'tests', {TestMultiTag()});
+all{end+1} = struct('name', 'SECTION', 'tests', {TestSection()});
+all{end+1} = struct('name', 'FEATURE', 'tests', {TestFeature()});
+all{end+1} = struct('name', 'PROPERTY', 'tests', {TestProperty()});
+all{end+1} = struct('name', 'DIMENSIONS', 'tests', {TestDimensions()});
 
-for i = 1:length(all_tests)
-    fprintf([10 'Execute ' all_tests{i}.name ' tests:\n\n']);
+for i = 1:length(all)
+    fprintf([10 'Execute ' all{i}.name ' tests:\n\n']);
     
-    for j = 1:length(all_tests{i}.tests)
-        stats = wrapper(all_tests{i}.tests{j}, stats);
+    for j = 1:length(all{i}.tests)
+        stats = wrapper(all{i}.tests{j}, stats);
     end
 end;
 

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -92,7 +92,7 @@ function [] = testCreateDataArray( varargin )
     da = b.createDataArray(doubleName, dtype, nix.DataType.Double, [2 3]);
     assert(strcmp(da.name, doubleName));
     assert(strcmp(da.type, dtype));
-    tmp = da.read_all();
+    tmp = da.readAllData();
     assert(all(tmp(:) == 0));
 
     try
@@ -138,7 +138,7 @@ function [] = testCreateDataArrayFromData( varargin )
     assert(strcmp(da.name, numName));
     assert(strcmp(da.type, daType));
     
-    tmp = da.read_all();
+    tmp = da.readAllData();
     assert(strcmp(class(tmp), class(numData)));
     assert(isequal(size(tmp), size(numData)));
     assert(isequal(tmp, numData));
@@ -146,9 +146,9 @@ function [] = testCreateDataArrayFromData( varargin )
     logName = 'logicalDataArray';
     logData = logical([1 0 1; 0 1 0; 1 0 1]);
     da = b.createDataArrayFromData(logName, daType, logData);
-    assert(islogical(da.read_all));
-    assert(isequal(size(da.read_all), size(logData)));
-    assert(isequal(da.read_all, logData));
+    assert(islogical(da.readAllData));
+    assert(isequal(size(da.readAllData), size(logData)));
+    assert(isequal(da.readAllData, logData));
     
     try
         b.createDataArrayFromData('stringDataArray', daType, ['a' 'b']);

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -7,8 +7,7 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestBlock
-%TESTFILE Tests for the nix.Block object
-%   Detailed explanation goes here
+% TESTBLOCK Tests for the nix.Block object
 
     funcs = {};
     funcs{end+1} = @testAttributes;
@@ -887,7 +886,7 @@ function [] = testFilterGroup( varargin )
     mainEntity = b.createGroup(mainName, 'nixGroup');
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    mainEntity.add_source(s);
+    mainEntity.addSource(s);
     subID = s.id;
 
     % filter works only for ID, not for name
@@ -952,7 +951,7 @@ function [] = testFilterTag( varargin )
     mainEntity = b.createTag(mainName, 'nixTag', [12 3]);
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    mainEntity.add_source(s);
+    mainEntity.addSource(s);
     subID = s.id;
 
     % filter works only for ID, not for name
@@ -1018,7 +1017,7 @@ function [] = testFilterMultiTag( varargin )
     mainEntity = b.createMultiTag(mainName, 'nixMultiTag', d);
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    mainEntity.add_source(s);
+    mainEntity.addSource(s);
     subID = s.id;
 
     % filter works only for ID, not for name
@@ -1089,7 +1088,7 @@ function [] = testFilterDataArray( varargin )
     mainEntity = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    mainEntity.add_source(s);
+    mainEntity.addSource(s);
     subID = s.id;
 
     % filter works only for ID, not for name

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -62,7 +62,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'test nixBlock');
+    b = f.createBlock('tagtest', 'test nixBlock');
 
     assert(~isempty(b.id));
     assert(strcmp(b.name, 'tagtest'));
@@ -83,7 +83,7 @@ end
 function [] = test_create_data_array( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('arraytest', 'nixblock');
+    b = f.createBlock('arraytest', 'nixblock');
     
     assert(isempty(b.dataArrays));
     
@@ -128,7 +128,7 @@ function [] = test_create_data_array_from_data( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('arraytest', 'nixblock');
+    b = f.createBlock('arraytest', 'nixblock');
     
     assert(isempty(b.dataArrays));
     
@@ -168,7 +168,7 @@ end
 %% Test: delete dataArray by entity and id
 function [] = test_delete_data_array( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('arraytest', 'nixBlock');
+    b = f.createBlock('arraytest', 'nixBlock');
     tmp = b.create_data_array('dataArrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('dataArrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
@@ -183,7 +183,7 @@ end
 function [] = test_create_tag( varargin )
 %% Test: Create Tag
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'nixblock');
+    b = f.createBlock('tagtest', 'nixblock');
     
     assert(isempty(b.tags));
 
@@ -199,7 +199,7 @@ end
 %% Test: delete tag by entity and id
 function [] = test_delete_tag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'nixBlock');
+    b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
     tmp = b.create_tag('tagtest1', 'nixTag', position);
     tmp = b.create_tag('tagtest2', 'nixTag', position);
@@ -216,7 +216,7 @@ end
 function [] = test_create_multi_tag( varargin )
 %% Test: Create multitag by data_array entity and data_array id
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('mTagTestBlock', 'nixBlock');
+    b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     assert(isempty(b.multiTags));
@@ -235,7 +235,7 @@ end
 %% Test: delete multitag by entity and id
 function [] = test_delete_multi_tag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('mTagTestBlock', 'nixBlock');
+    b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
     tmp = b.create_multi_tag('mTagTest2', 'nixMultiTag2', b.dataArrays{1});
@@ -253,7 +253,7 @@ end
 %% Test: create source
 function [] = test_create_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('sourcetest', 'nixblock');
+    getBlock = test_file.createBlock('sourcetest', 'nixblock');
     assert(isempty(getBlock.sources));
 
     createSource = getBlock.create_source('sourcetest','nixsource');
@@ -265,7 +265,7 @@ end
 %% Test: delete source by entity and id
 function [] = test_delete_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('sourcetest', 'nixblock');
+    getBlock = test_file.createBlock('sourcetest', 'nixblock');
     tmp = getBlock.create_source('sourcetest1','nixsource');
     tmp = getBlock.create_source('sourcetest2','nixsource');
     tmp = getBlock.create_source('sourcetest3','nixsource');
@@ -282,7 +282,7 @@ end
 function [] = test_list_arrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('arraytest', 'nixBlock');
+    b = f.createBlock('arraytest', 'nixBlock');
 
     assert(isempty(b.dataArrays));
     tmp = b.create_data_array('arrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -299,7 +299,7 @@ end
 function [] = test_list_sources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('sourcetest', 'nixBlock');
+    b = f.createBlock('sourcetest', 'nixBlock');
 
     assert(isempty(b.sources));
     tmp = b.create_source('sourcetest1','nixSource');
@@ -318,7 +318,7 @@ end
 function [] = test_list_tags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'nixBlock');
+    b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
 
     assert(isempty(b.tags));
@@ -338,7 +338,7 @@ end
 function [] = test_list_multitags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('mTagTestBlock', 'nixBlock');
+    b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(b.multiTags));
@@ -357,7 +357,7 @@ end
 function [] = test_open_array( varargin )
 %% Test: Open data array by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('arraytest', 'nixBlock');
+    b = f.createBlock('arraytest', 'nixBlock');
     daName = 'arrayTest1';
     
     assert(isempty(b.dataArrays));
@@ -377,7 +377,7 @@ end
 function [] = test_open_tag( varargin )
 %% Test: Open tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'nixBlock');
+    b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
     tagName = 'tagtest1';
     tmp = b.create_tag(tagName, 'nixTag', position);
@@ -396,7 +396,7 @@ end
 function [] = test_open_multitag( varargin )
 %% Test: Open multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('mTagTestBlock', 'nixBlock');
+    b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTagName = 'mTagTest1';
     tmp = b.create_multi_tag(mTagName, 'nixMultiTag', b.dataArrays{1});
@@ -415,7 +415,7 @@ end
 function [] = test_open_source( varargin )
 %% Test: Open source by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('sourcetest', 'nixBlock');
+    b = f.createBlock('sourcetest', 'nixBlock');
     sName = 'sourcetest1';
     tmp = b.create_source(sName, 'nixSource');
     
@@ -433,7 +433,7 @@ end
 function [] = test_open_group_idx( varargin )
 %% Test Open Group by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g1 = b.create_group('testGroup1', 'nixGroup');
     g2 = b.create_group('testGroup2', 'nixGroup');
     g3 = b.create_group('testGroup3', 'nixGroup');
@@ -446,7 +446,7 @@ end
 function [] = test_open_data_array_idx( varargin )
 %% Test Open DataArray by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d1 = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
     d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
     d3 = b.create_data_array('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
@@ -459,7 +459,7 @@ end
 function [] = test_open_tag_idx( varargin )
 %% Test Open Tag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t1 = b.create_tag('testTag1', 'nixTag', [1 2]);
     t2 = b.create_tag('testTag2', 'nixTag', [1 2]);
     t3 = b.create_tag('testTag3', 'nixTag', [1 2]);
@@ -472,7 +472,7 @@ end
 function [] = test_open_multi_tag_idx( varargin )
 %% Test Open MultiTag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
     t1 = b.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
     t2 = b.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
@@ -486,7 +486,7 @@ end
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s1 = b.create_source('testSource1', 'nixSource');
     s2 = b.create_source('testSource2', 'nixSource');
     s3 = b.create_source('testSource3', 'nixSource');
@@ -499,7 +499,7 @@ end
 function [] = test_has_multitag( varargin )
 %% Test: Block has multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('mTagTestBlock', 'nixBlock');
+    b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
 
@@ -512,7 +512,7 @@ end
 function [] = test_has_tag( varargin )
 %% Test: Block has tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'nixBlock');
+    b = f.createBlock('tagtest', 'nixBlock');
     tmp = b.create_tag('tagtest1', 'nixTag', [1.0 1.2 1.3 15.9]);
 
     assert(b.has_tag(b.tags{1,1}.id));
@@ -527,9 +527,9 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.create_section(secName1, 'nixSection');
-    tmp = f.create_section(secName2, 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection(secName1, 'nixSection');
+    tmp = f.createSection(secName2, 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     
     assert(isempty(b.open_metadata));
     assert(isempty(f.blocks{1}.open_metadata));
@@ -554,8 +554,8 @@ end
 function [] = test_open_metadata( varargin )
 %% Test: Open metadata
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     b.set_metadata(f.sections{1});
 
     assert(strcmp(b.open_metadata.name, 'testSection'));
@@ -566,7 +566,7 @@ function [] = test_has_data_array( varargin )
     fileName = 'testRW.h5';
     daName = 'hasDataArrayTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     daID = da.id;
     
@@ -583,7 +583,7 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     s = b.create_source(sName, 'nixSource');
     sID = s.id;
 
@@ -602,7 +602,7 @@ function [] = test_create_group( varargin )
     groupType = 'nixGroup';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('grouptest', 'nixBlock');
+    b = f.createBlock('grouptest', 'nixBlock');
 
     assert(isempty(b.groups));
 
@@ -621,7 +621,7 @@ end
 function [] = test_has_group( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('grouptest', 'nixBlock');
+    b = f.createBlock('grouptest', 'nixBlock');
 
     assert(~b.has_group('I do not exist'));
     
@@ -637,7 +637,7 @@ end
 function [] = test_get_group( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('grouptest', 'nixBlock');
+    b = f.createBlock('grouptest', 'nixBlock');
     g = b.create_group(groupName, 'nixGroup');
     gID = g.id;
 
@@ -653,7 +653,7 @@ function [] = test_delete_group( varargin )
     groupType = 'nixGroup';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('grouptest', 'nixBlock');
+    b = f.createBlock('grouptest', 'nixBlock');
     g1 = b.create_group('testGroup1', groupType);
     g2 = b.create_group('testGroup2', groupType);
 
@@ -674,7 +674,7 @@ end
 function [] = test_group_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     assert(b.group_count() == 0);
     g = b.create_group('testGroup', 'nixGroup');
     assert(b.group_count() == 1);
@@ -689,7 +689,7 @@ end
 function [] = test_data_array_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     assert(b.data_array_count() == 0);
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -705,7 +705,7 @@ end
 function [] = test_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     assert(b.tag_count() == 0);
     t = b.create_tag('testTag1', 'nixTag', [1.0 1.2 1.3 15.9]);
@@ -721,7 +721,7 @@ end
 function [] = test_multi_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(b.multi_tag_count() == 0);
@@ -738,7 +738,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     assert(b.source_count() == 0);
     s = b.create_source('testSource1', 'nixSource');
@@ -753,8 +753,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare block entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
 
     assert(b1.compare(b2) < 0);
     assert(b1.compare(b1) == 0);
@@ -766,7 +766,7 @@ function [] = test_filter_source( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source(filterName, 'nixSource');
     filterID = s.id;
 	s = b.create_source('testSource1', filterType);
@@ -803,7 +803,7 @@ function [] = test_filter_source( varargin )
     mainName = 'testSubSection';
     mainSource = b.create_source(mainName, 'nixSource');
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
@@ -836,7 +836,7 @@ function [] = test_filter_group( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group(filterName, 'nixGroup');
     filterID = g.id;
 	g = b.create_group('testGroup1', filterType);
@@ -873,7 +873,7 @@ function [] = test_filter_group( varargin )
     mainName = 'testSubSection';
     mainEntity = b.create_group(mainName, 'nixGroup');
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
@@ -901,7 +901,7 @@ function [] = test_filter_tag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag(filterName, 'nixTag', [1 2 3]);
     filterID = t.id;
 	t = b.create_tag('testTag1', filterType, [1 2 3 4]);
@@ -938,7 +938,7 @@ function [] = test_filter_tag( varargin )
     mainName = 'testSubSection';
     mainEntity = b.create_tag(mainName, 'nixTag', [1 8]);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
@@ -966,7 +966,7 @@ function [] = test_filter_multi_tag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 9]);
     t = b.create_multi_tag(filterName, 'nixMultiTag', d);
     filterID = t.id;
@@ -1004,7 +1004,7 @@ function [] = test_filter_multi_tag( varargin )
     mainName = 'testSubSection';
     mainEntity = b.create_multi_tag(mainName, 'nixMultiTag', d);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
@@ -1027,7 +1027,7 @@ function [] = test_filter_multi_tag( varargin )
     assert(strcmp(filtered{1}.name, mainName));
     
     % test filters work only within blocks, not between them
-    b = f.create_block('testBlock2', 'nixBlock');
+    b = f.createBlock('testBlock2', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 9]);
     t = b.create_multi_tag(filterName, 'nixMultiTag', d);
     assert(size( b.filter_multi_tags(nix.Filter.name, filterName), 1) == 1);
@@ -1038,7 +1038,7 @@ function [] = test_filter_data_array( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     filterID = d.id;
     d = b.create_data_array('testDataArray1', filterType, nix.DataType.Bool, [2 9]);
@@ -1075,7 +1075,7 @@ function [] = test_filter_data_array( varargin )
     mainName = 'testSubSection';
     mainEntity = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
@@ -1101,7 +1101,7 @@ end
 %% Test: Find source w/o filter
 function [] = test_find_source
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     sl1 = b.create_source('sourceLvl1', 'nixSource');
 
     sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
@@ -1149,7 +1149,7 @@ end
 function [] = test_find_source_filtered
     findSource = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     sl1 = b.create_source('sourceLvl1', 'nixSource');
 
     sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
@@ -1193,7 +1193,7 @@ function [] = test_find_source_filtered
     assert(strcmp(filtered{1}.type, findSource));
 
     % test nix.Filter.metadata
-    sec = f.create_section('testSection', 'nixSection');
+    sec = f.createSection('testSection', 'nixSection');
     sl43.set_metadata(sec);
     filtered = b.find_filtered_sources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -776,8 +776,8 @@ function [] = testFilterSource( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filterSources(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.filterSources(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -846,8 +846,8 @@ function [] = testFilterGroup( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.filterGroups(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filterGroups(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.filterGroups(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -911,8 +911,8 @@ function [] = testFilterTag( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.filterTags(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filterTags(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.filterTags(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -977,8 +977,8 @@ function [] = testFilterMultiTag( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.filterMultiTags(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filterMultiTags(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
@@ -1048,8 +1048,8 @@ function [] = testFilterDataArray( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.filterDataArrays(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filterDataArrays(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -530,24 +530,25 @@ function [] = testSetMetadata ( varargin )
     tmp = f.createSection(secName2, 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
     
-    assert(isempty(b.open_metadata));
-    assert(isempty(f.blocks{1}.open_metadata));
+    assert(isempty(b.openMetadata));
+    assert(isempty(f.blocks{1}.openMetadata));
 
-    b.set_metadata(f.sections{1});
-    assert(strcmp(b.open_metadata.name, secName1));
-    assert(strcmp(f.blocks{1}.open_metadata.name, secName1));
+    b.setMetadata(f.sections{1});
+    assert(strcmp(b.openMetadata.name, secName1));
+    assert(strcmp(f.blocks{1}.openMetadata.name, secName1));
 
-    b.set_metadata(f.sections{2});
-    assert(strcmp(b.open_metadata.name, secName2));
-    assert(strcmp(f.blocks{1}.open_metadata.name, secName2));
-    b.set_metadata('');
-    assert(isempty(b.open_metadata));
-    assert(isempty(f.blocks{1}.open_metadata));
+    b.setMetadata(f.sections{2});
+    assert(strcmp(b.openMetadata.name, secName2));
+    assert(strcmp(f.blocks{1}.openMetadata.name, secName2));
+    b.setMetadata('');
+    assert(isempty(b.openMetadata));
+    assert(isempty(f.blocks{1}.openMetadata));
 
-    b.set_metadata(f.sections{2});
+    b.setMetadata(f.sections{2});
+
     clear tmp b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-	assert(strcmp(f.blocks{1}.open_metadata.name, secName2));
+	assert(strcmp(f.blocks{1}.openMetadata.name, secName2));
 end
 
 function [] = testOpenMetadata( varargin )
@@ -555,9 +556,9 @@ function [] = testOpenMetadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    b.set_metadata(f.sections{1});
+    b.setMetadata(f.sections{1});
 
-    assert(strcmp(b.open_metadata.name, 'testSection'));
+    assert(strcmp(b.openMetadata.name, 'testSection'));
 end
 
 %% Test: nix.Block has nix.DataArray by ID or name
@@ -803,7 +804,7 @@ function [] = testFilterSource( varargin )
     mainSource = b.createSource(mainName, 'nixSource');
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainSource.set_metadata(s);
+    mainSource.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
@@ -873,7 +874,7 @@ function [] = testFilterGroup( varargin )
     mainEntity = b.createGroup(mainName, 'nixGroup');
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainEntity.set_metadata(s);
+    mainEntity.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.filterGroups(nix.Filter.metadata, 'Do not exist')));
@@ -938,7 +939,7 @@ function [] = testFilterTag( varargin )
     mainEntity = b.createTag(mainName, 'nixTag', [1 8]);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainEntity.set_metadata(s);
+    mainEntity.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.filterTags(nix.Filter.metadata, 'Do not exist')));
@@ -1004,7 +1005,7 @@ function [] = testFilterMultiTag( varargin )
     mainEntity = b.createMultiTag(mainName, 'nixMultiTag', d);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainEntity.set_metadata(s);
+    mainEntity.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.filterMultiTags(nix.Filter.metadata, 'Do not exist')));
@@ -1075,7 +1076,7 @@ function [] = testFilterDataArray( varargin )
     mainEntity = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainEntity.set_metadata(s);
+    mainEntity.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.filterMultiTags(nix.Filter.metadata, 'Do not exist')));
@@ -1193,7 +1194,7 @@ function [] = testFindSourceFiltered
 
     % test nix.Filter.metadata
     sec = f.createSection('testSection', 'nixSection');
-    sl43.set_metadata(sec);
+    sl43.setMetadata(sec);
     filtered = b.filterFindSources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));
     filtered = b.filterFindSources(4, nix.Filter.metadata, sec.id);

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -817,7 +817,7 @@ function [] = testFilterSource( varargin )
     mainSource = b.createSource(mainName, 'nixSource');
     mainID = mainSource.id;
     subName = 'testSubSource1';
-    s = mainSource.create_source(subName, 'nixSource');
+    s = mainSource.createSource(subName, 'nixSource');
     subID = s.id;
 
     assert(isempty(f.blocks{1}.filterSources(nix.Filter.source, 'Do not exist')));
@@ -1104,17 +1104,17 @@ function [] = testFindSource
     b = f.createBlock('testBlock', 'nixBlock');
     sl1 = b.createSource('sourceLvl1', 'nixSource');
 
-    sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
-    sl22 = sl1.create_source('sourceLvl2_2', 'nixSource');
+    sl21 = sl1.createSource('sourceLvl2_1', 'nixSource');
+    sl22 = sl1.createSource('sourceLvl2_2', 'nixSource');
 
-    sl31 = sl21.create_source('sourceLvl3_1', 'nixSource');
-    sl32 = sl21.create_source('sourceLvl3_2', 'nixSource');
-    sl33 = sl21.create_source('sourceLvl3_3', 'nixSource');
+    sl31 = sl21.createSource('sourceLvl3_1', 'nixSource');
+    sl32 = sl21.createSource('sourceLvl3_2', 'nixSource');
+    sl33 = sl21.createSource('sourceLvl3_3', 'nixSource');
 
-    sl41 = sl31.create_source('sourceLvl4_1', 'nixSource');
-    sl42 = sl31.create_source('sourceLvl4_2', 'nixSource');
-    sl43 = sl31.create_source('sourceLvl4_3', 'nixSource');
-    sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
+    sl41 = sl31.createSource('sourceLvl4_1', 'nixSource');
+    sl42 = sl31.createSource('sourceLvl4_2', 'nixSource');
+    sl43 = sl31.createSource('sourceLvl4_3', 'nixSource');
+    sl44 = sl31.createSource('sourceLvl4_4', 'nixSource');
 
     % Check invalid entry
     err = 'Provide a valid search depth';
@@ -1152,17 +1152,17 @@ function [] = testFindSourceFiltered
     b = f.createBlock('testBlock', 'nixBlock');
     sl1 = b.createSource('sourceLvl1', 'nixSource');
 
-    sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
-    sl22 = sl1.create_source('sourceLvl2_2', findSource);
+    sl21 = sl1.createSource('sourceLvl2_1', 'nixSource');
+    sl22 = sl1.createSource('sourceLvl2_2', findSource);
 
-    sl31 = sl21.create_source('sourceLvl3_1', findSource);
-    sl32 = sl21.create_source('sourceLvl3_2', 'nixSource');
-    sl33 = sl21.create_source('sourceLvl3_3', 'nixSource');
+    sl31 = sl21.createSource('sourceLvl3_1', findSource);
+    sl32 = sl21.createSource('sourceLvl3_2', 'nixSource');
+    sl33 = sl21.createSource('sourceLvl3_3', 'nixSource');
 
-    sl41 = sl31.create_source('sourceLvl4_1', findSource);
-    sl42 = sl31.create_source('sourceLvl4_2', 'nixSource');
-    sl43 = sl31.create_source('sourceLvl4_3', 'nixSource');
-    sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
+    sl41 = sl31.createSource('sourceLvl4_1', findSource);
+    sl42 = sl31.createSource('sourceLvl4_2', 'nixSource');
+    sl43 = sl31.createSource('sourceLvl4_3', 'nixSource');
+    sl44 = sl31.createSource('sourceLvl4_4', 'nixSource');
 
     % test find by id
     filtered = b.filterFindSources(2, nix.Filter.id, sl41.id);

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -11,55 +11,55 @@ function funcs = TestBlock
 %   Detailed explanation goes here
 
     funcs = {};
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_create_data_array;
-    funcs{end+1} = @test_create_data_array_from_data;
-    funcs{end+1} = @test_delete_data_array;
-    funcs{end+1} = @test_create_tag;
-    funcs{end+1} = @test_delete_tag;
-    funcs{end+1} = @test_create_multi_tag;
-    funcs{end+1} = @test_delete_multi_tag;
-    funcs{end+1} = @test_create_source;
-    funcs{end+1} = @test_delete_source;
-    funcs{end+1} = @test_list_arrays;
-    funcs{end+1} = @test_list_sources;
-    funcs{end+1} = @test_list_tags;
-    funcs{end+1} = @test_list_multitags;
-    funcs{end+1} = @test_open_array;
-    funcs{end+1} = @test_open_tag;
-    funcs{end+1} = @test_open_multitag;
-    funcs{end+1} = @test_open_source;
-    funcs{end+1} = @test_open_group_idx;
-    funcs{end+1} = @test_open_data_array_idx;
-    funcs{end+1} = @test_open_tag_idx;
-    funcs{end+1} = @test_open_multi_tag_idx;
-    funcs{end+1} = @test_open_source_idx;
-    funcs{end+1} = @test_has_data_array;
-    funcs{end+1} = @test_has_source;
-    funcs{end+1} = @test_has_multitag;
-    funcs{end+1} = @test_has_tag;
-    funcs{end+1} = @test_set_metadata;
-    funcs{end+1} = @test_open_metadata;
-    funcs{end+1} = @test_create_group;
-    funcs{end+1} = @test_has_group;
-    funcs{end+1} = @test_get_group;
-    funcs{end+1} = @test_delete_group;
-    funcs{end+1} = @test_group_count;
-    funcs{end+1} = @test_data_array_count;
-    funcs{end+1} = @test_tag_count;
-    funcs{end+1} = @test_multi_tag_count;
-    funcs{end+1} = @test_source_count;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_source;
-    funcs{end+1} = @test_filter_group;
-    funcs{end+1} = @test_filter_tag;
-    funcs{end+1} = @test_filter_multi_tag;
-    funcs{end+1} = @test_filter_data_array;
-    funcs{end+1} = @test_find_source;
-    funcs{end+1} = @test_find_source_filtered;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testCreateDataArray;
+    funcs{end+1} = @testCreateDataArrayFromData;
+    funcs{end+1} = @testDeleteDataArray;
+    funcs{end+1} = @testCreateTag;
+    funcs{end+1} = @testDeleteTag;
+    funcs{end+1} = @testCreateMultiTag;
+    funcs{end+1} = @testDeleteMultiTag;
+    funcs{end+1} = @testCreateSource;
+    funcs{end+1} = @testDeleteSource;
+    funcs{end+1} = @testListArrays;
+    funcs{end+1} = @testListSources;
+    funcs{end+1} = @testListTags;
+    funcs{end+1} = @testListMultiTags;
+    funcs{end+1} = @testOpenDataArray;
+    funcs{end+1} = @testOpenTag;
+    funcs{end+1} = @testOpenMultiTag;
+    funcs{end+1} = @testOpenSource;
+    funcs{end+1} = @testOpenGroupIdx;
+    funcs{end+1} = @testOpenDataArrayIdx;
+    funcs{end+1} = @testOpenTagIdx;
+    funcs{end+1} = @testOpenMultiTagIdx;
+    funcs{end+1} = @testOpenSourceIdx;
+    funcs{end+1} = @testHasDataArray;
+    funcs{end+1} = @testHasSource;
+    funcs{end+1} = @testHasMultiTag;
+    funcs{end+1} = @testHasTag;
+    funcs{end+1} = @testSetMetadata;
+    funcs{end+1} = @testOpenMetadata;
+    funcs{end+1} = @testCreateGroup;
+    funcs{end+1} = @testHasGroup;
+    funcs{end+1} = @testOpenGroup;
+    funcs{end+1} = @testDeleteGroup;
+    funcs{end+1} = @testGroupCount;
+    funcs{end+1} = @testDataArrayCount;
+    funcs{end+1} = @testTagCount;
+    funcs{end+1} = @testMultiTagCount;
+    funcs{end+1} = @testSourceCount;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSource;
+    funcs{end+1} = @testFilterGroup;
+    funcs{end+1} = @testFilterTag;
+    funcs{end+1} = @testFilterMultiTag;
+    funcs{end+1} = @testFilterDataArray;
+    funcs{end+1} = @testFindSource;
+    funcs{end+1} = @testFindSourceFiltered;
 end
 
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'test nixBlock');
@@ -80,7 +80,7 @@ function [] = test_attrs( varargin )
 end
 
 %% Test: Create Data Array
-function [] = test_create_data_array( varargin )
+function [] = testCreateDataArray( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixblock');
@@ -89,34 +89,34 @@ function [] = test_create_data_array( varargin )
     
     dtype = 'nix.DataArray';
     doubleName = 'doubleDataArray';
-    da = b.create_data_array(doubleName, dtype, nix.DataType.Double, [2 3]);
+    da = b.createDataArray(doubleName, dtype, nix.DataType.Double, [2 3]);
     assert(strcmp(da.name, doubleName));
     assert(strcmp(da.type, dtype));
     tmp = da.read_all();
     assert(all(tmp(:) == 0));
 
     try
-        b.create_data_array('stringDataArray', dtype, nix.DataType.String, [1 5]);
+        b.createDataArray('stringDataArray', dtype, nix.DataType.String, [1 5]);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
     
     try
-        b.create_data_array('I will crash and burn', dtype, 'Thou shalt not work!', [1 5]);
+        b.createDataArray('I will crash and burn', dtype, 'Thou shalt not work!', [1 5]);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
 
-    da = b.create_data_array('floatDataArray', dtype, nix.DataType.Float, [3 3]);
-    da = b.create_data_array('Int8DataArray', dtype, nix.DataType.Int8, [3 3]);
-    da = b.create_data_array('Int16DataArray', dtype, nix.DataType.Int16, [3 3]);
-    da = b.create_data_array('Int32DataArray', dtype, nix.DataType.Int32, [3 3]);
-    da = b.create_data_array('Int64DataArray', dtype, nix.DataType.Int64, [3 3]);
-    da = b.create_data_array('UInt8DataArray', dtype, nix.DataType.UInt8, [3 3]);
-    da = b.create_data_array('UInt16DataArray', dtype, nix.DataType.UInt16, [3 3]);
-    da = b.create_data_array('UInt32DataArray', dtype, nix.DataType.UInt32, [3 3]);
-    da = b.create_data_array('UInt64DataArray', dtype, nix.DataType.UInt64, [3 3]);
-    da = b.create_data_array('logicalArray', dtype, nix.DataType.Bool, [3 3]);
+    da = b.createDataArray('floatDataArray', dtype, nix.DataType.Float, [3 3]);
+    da = b.createDataArray('Int8DataArray', dtype, nix.DataType.Int8, [3 3]);
+    da = b.createDataArray('Int16DataArray', dtype, nix.DataType.Int16, [3 3]);
+    da = b.createDataArray('Int32DataArray', dtype, nix.DataType.Int32, [3 3]);
+    da = b.createDataArray('Int64DataArray', dtype, nix.DataType.Int64, [3 3]);
+    da = b.createDataArray('UInt8DataArray', dtype, nix.DataType.UInt8, [3 3]);
+    da = b.createDataArray('UInt16DataArray', dtype, nix.DataType.UInt16, [3 3]);
+    da = b.createDataArray('UInt32DataArray', dtype, nix.DataType.UInt32, [3 3]);
+    da = b.createDataArray('UInt64DataArray', dtype, nix.DataType.UInt64, [3 3]);
+    da = b.createDataArray('logicalArray', dtype, nix.DataType.Bool, [3 3]);
     
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
@@ -124,7 +124,7 @@ function [] = test_create_data_array( varargin )
 end
 
 %% Test: Create Data Array from data
-function [] = test_create_data_array_from_data( varargin )
+function [] = testCreateDataArrayFromData( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -134,7 +134,7 @@ function [] = test_create_data_array_from_data( varargin )
     
     numName = 'numDataArray';
     numData = [1, 2, 3; 4, 5, 6];
-    da = b.create_data_array_from_data(numName, daType, numData);
+    da = b.createDataArrayFromData(numName, daType, numData);
     assert(strcmp(da.name, numName));
     assert(strcmp(da.type, daType));
     
@@ -145,19 +145,19 @@ function [] = test_create_data_array_from_data( varargin )
     
     logName = 'logicalDataArray';
     logData = logical([1 0 1; 0 1 0; 1 0 1]);
-    da = b.create_data_array_from_data(logName, daType, logData);
+    da = b.createDataArrayFromData(logName, daType, logData);
     assert(islogical(da.read_all));
     assert(isequal(size(da.read_all), size(logData)));
     assert(isequal(da.read_all, logData));
     
     try
-        b.create_data_array_from_data('stringDataArray', daType, ['a' 'b']);
+        b.createDataArrayFromData('stringDataArray', daType, ['a' 'b']);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
     
     try
-        b.create_data_array_from_data('I will crash and burn', daType, {1 2 3});
+        b.createDataArrayFromData('I will crash and burn', daType, {1 2 3});
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:UnsupportedDataType'));
     end;
@@ -166,21 +166,21 @@ function [] = test_create_data_array_from_data( varargin )
 end
 
 %% Test: delete dataArray by entity and id
-function [] = test_delete_data_array( varargin )
+function [] = testDeleteDataArray( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixBlock');
-    tmp = b.create_data_array('dataArrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('dataArrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('dataArrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('dataArrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     assert(size(b.dataArrays, 1) == 2);
-    assert(b.delete_data_array(b.dataArrays{2}.id));
+    assert(b.deleteDataArray(b.dataArrays{2}.id));
     assert(size(b.dataArrays, 1) == 1);
-    assert(b.delete_data_array(b.dataArrays{1}));
+    assert(b.deleteDataArray(b.dataArrays{1}));
     assert(isempty(b.dataArrays));
-    assert(~b.delete_data_array('I do not exist'));
+    assert(~b.deleteDataArray('I do not exist'));
 end
 
-function [] = test_create_tag( varargin )
+function [] = testCreateTag( varargin )
 %% Test: Create Tag
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixblock');
@@ -188,7 +188,7 @@ function [] = test_create_tag( varargin )
     assert(isempty(b.tags));
 
     position = [1.0 1.2 1.3 15.9];
-    t1 = b.create_tag('foo', 'bar', position);
+    t1 = b.createTag('foo', 'bar', position);
     assert(strcmp(t1.name, 'foo'));
     assert(strcmp(t1.type, 'bar'));
     assert(isequal(t1.position, position));
@@ -197,96 +197,96 @@ function [] = test_create_tag( varargin )
 end
 
 %% Test: delete tag by entity and id
-function [] = test_delete_tag( varargin )
+function [] = testDeleteTag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
-    tmp = b.create_tag('tagtest1', 'nixTag', position);
-    tmp = b.create_tag('tagtest2', 'nixTag', position);
+    tmp = b.createTag('tagtest1', 'nixTag', position);
+    tmp = b.createTag('tagtest2', 'nixTag', position);
     
     assert(size(b.tags, 1) == 2);
-    assert(b.delete_tag(b.tags{2}.id));
+    assert(b.deleteTag(b.tags{2}.id));
     assert(size(b.tags, 1) == 1);
-    assert(b.delete_tag(b.tags{1}));
+    assert(b.deleteTag(b.tags{1}));
     assert(isempty(b.tags));
 
-    assert(~b.delete_tag('I do not exist'));
+    assert(~b.deleteTag('I do not exist'));
 end
 
-function [] = test_create_multi_tag( varargin )
-%% Test: Create multitag by data_array entity and data_array id
+function [] = testCreateMultiTag( varargin )
+%% Test: Create multitag by DataArray entity and DataArray id
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     assert(isempty(b.multiTags));
 
-    %-- create by data_array entity
-    tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
+    %-- create by DataArray entity
+    tmp = b.createMultiTag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
     assert(~isempty(b.multiTags));
     assert(strcmp(b.multiTags{1}.name, 'mTagTest1'));
 
-    %-- create by data_array id
-    tmp = b.create_multi_tag('mTagTest2', 'nixMultiTag2', b.dataArrays{2}.id);
+    %-- create by DataArray id
+    tmp = b.createMultiTag('mTagTest2', 'nixMultiTag2', b.dataArrays{2}.id);
     assert(size(b.multiTags, 1) == 2);
     assert(strcmp(b.multiTags{2}.type, 'nixMultiTag2'));
 end
 
 %% Test: delete multitag by entity and id
-function [] = test_delete_multi_tag( varargin )
+function [] = testDeleteMultiTag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
-    tmp = b.create_multi_tag('mTagTest2', 'nixMultiTag2', b.dataArrays{1});
+    tmp = b.createDataArray('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createMultiTag('mTagTest1', 'nixMultiTag1', b.dataArrays{1});
+    tmp = b.createMultiTag('mTagTest2', 'nixMultiTag2', b.dataArrays{1});
 
     assert(size(b.multiTags, 1) == 2);
-    assert(b.delete_multi_tag(b.multiTags{2}.id));
+    assert(b.deleteMultiTag(b.multiTags{2}.id));
     assert(size(b.multiTags, 1) == 1);
-    assert(b.delete_multi_tag(b.multiTags{1}));
+    assert(b.deleteMultiTag(b.multiTags{1}));
     assert(isempty(b.multiTags));
     assert(size(b.dataArrays, 1) == 1);
 
-    assert(~b.delete_multi_tag('I do not exist'));
+    assert(~b.deleteMultiTag('I do not exist'));
 end
 
 %% Test: create source
-function [] = test_create_source ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixblock');
-    assert(isempty(getBlock.sources));
+function [] = testCreateSource ( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourcetest', 'nixblock');
+    assert(isempty(b.sources));
 
-    createSource = getBlock.create_source('sourcetest','nixsource');
-    assert(~isempty(getBlock.sources));
-    assert(strcmp(createSource.name, 'sourcetest'));
-    assert(strcmp(createSource.type, 'nixsource'));
+    s = b.createSource('sourcetest','nixsource');
+    assert(~isempty(b.sources));
+    assert(strcmp(s.name, 'sourcetest'));
+    assert(strcmp(s.type, 'nixsource'));
 end
 
 %% Test: delete source by entity and id
-function [] = test_delete_source( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixblock');
-    tmp = getBlock.create_source('sourcetest1','nixsource');
-    tmp = getBlock.create_source('sourcetest2','nixsource');
-    tmp = getBlock.create_source('sourcetest3','nixsource');
+function [] = testDeleteSource( varargin )
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourcetest', 'nixblock');
+    tmp = b.createSource('sourcetest1','nixsource');
+    tmp = b.createSource('sourcetest2','nixsource');
+    tmp = b.createSource('sourcetest3','nixsource');
 
-    assert(getBlock.delete_source('sourcetest1'));
-    assert(getBlock.delete_source(getBlock.sources{1}.id));
-    assert(getBlock.delete_source(getBlock.sources{1}));
-    assert(isempty(getBlock.sources));
+    assert(b.deleteSource('sourcetest1'));
+    assert(b.deleteSource(b.sources{1}.id));
+    assert(b.deleteSource(b.sources{1}));
+    assert(isempty(b.sources));
     
-    assert(~getBlock.delete_source('I do not exist'));
+    assert(~b.deleteSource('I do not exist'));
 end
 
 %% Test: Fetch nix.DataArrays
-function [] = test_list_arrays( varargin )
+function [] = testListArrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixBlock');
 
     assert(isempty(b.dataArrays));
-    tmp = b.create_data_array('arrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('arrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('arrayTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('arrayTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     assert(size(b.dataArrays, 1) == 2);
     assert(size(f.blocks{1}.dataArrays, 1) == 2);
 
@@ -296,16 +296,16 @@ function [] = test_list_arrays( varargin )
 end
 
 %% Test: Fetch nix.Sources
-function [] = test_list_sources( varargin )
+function [] = testListSources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
 
     assert(isempty(b.sources));
-    tmp = b.create_source('sourcetest1','nixSource');
+    tmp = b.createSource('sourcetest1','nixSource');
     assert(size(b.sources, 1) == 1);
     assert(size(f.blocks{1}.sources, 1) == 1);
-    tmp = b.create_source('sourcetest2','nixSource');
+    tmp = b.createSource('sourcetest2','nixSource');
     assert(size(b.sources, 1) == 2);
     assert(size(f.blocks{1}.sources, 1) == 2);
 
@@ -315,17 +315,17 @@ function [] = test_list_sources( varargin )
 end
 
 %% Test: Fetch nix.Tags
-function [] = test_list_tags( varargin )
+function [] = testListTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
 
     assert(isempty(b.tags));
-    tmp = b.create_tag('tagtest1', 'nixTag', position);
+    tmp = b.createTag('tagtest1', 'nixTag', position);
     assert(size(b.tags, 1) == 1);
     assert(size(f.blocks{1}.tags, 1) == 1);
-    tmp = b.create_tag('tagtest2', 'nixTag', position);
+    tmp = b.createTag('tagtest2', 'nixTag', position);
     assert(size(b.tags, 1) == 2);
     assert(size(f.blocks{1}.tags, 1) == 2);
 
@@ -335,17 +335,17 @@ function [] = test_list_tags( varargin )
 end
 
 %% Test: fetch multitags
-function [] = test_list_multitags( varargin )
+function [] = testListMultiTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(b.multiTags));
-    tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createMultiTag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
     assert(size(b.multiTags, 1) == 1);
     assert(size(f.blocks{1}.multiTags, 1) == 1);
-    tmp = b.create_multi_tag('mTagTest2', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createMultiTag('mTagTest2', 'nixMultiTag', b.dataArrays{1});
     assert(size(b.multiTags, 1) == 2);
     assert(size(f.blocks{1}.multiTags, 1) == 2);
 
@@ -354,175 +354,175 @@ function [] = test_list_multitags( varargin )
     assert(size(f.blocks{1}.multiTags, 1) == 2);
 end
 
-function [] = test_open_array( varargin )
+function [] = testOpenDataArray( varargin )
 %% Test: Open data array by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixBlock');
     daName = 'arrayTest1';
     
     assert(isempty(b.dataArrays));
-    tmp = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    getDataArrayByID = b.data_array(b.dataArrays{1,1}.id);
+    getDataArrayByID = b.openDataArray(b.dataArrays{1,1}.id);
     assert(~isempty(getDataArrayByID));
 
-    getDataArrayByName = b.data_array(daName);
+    getDataArrayByName = b.openDataArray(daName);
     assert(~isempty(getDataArrayByName));
     
     %-- test open non existing dataarray
-    getDataArray = b.data_array('I do not exist');
+    getDataArray = b.openDataArray('I do not exist');
     assert(isempty(getDataArray));
 end
 
-function [] = test_open_tag( varargin )
+function [] = testOpenTag( varargin )
 %% Test: Open tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
     tagName = 'tagtest1';
-    tmp = b.create_tag(tagName, 'nixTag', position);
+    tmp = b.createTag(tagName, 'nixTag', position);
 
-    getTagByID = b.open_tag(b.tags{1,1}.id);
+    getTagByID = b.openTag(b.tags{1,1}.id);
     assert(~isempty(getTagByID));
 
-    getTagByName = b.open_tag(tagName);
+    getTagByName = b.openTag(tagName);
     assert(~isempty(getTagByName));
     
     %-- test open non existing tag
-    getTag = b.open_tag('I do not exist');
+    getTag = b.openTag('I do not exist');
     assert(isempty(getTag));
 end
 
-function [] = test_open_multitag( varargin )
+function [] = testOpenMultiTag( varargin )
 %% Test: Open multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTagName = 'mTagTest1';
-    tmp = b.create_multi_tag(mTagName, 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createMultiTag(mTagName, 'nixMultiTag', b.dataArrays{1});
 
-    getMultiTagByID = b.open_multi_tag(b.multiTags{1,1}.id);
+    getMultiTagByID = b.openMultiTag(b.multiTags{1,1}.id);
     assert(~isempty(getMultiTagByID));
 
-    getMultiTagByName = b.open_multi_tag(mTagName);
+    getMultiTagByName = b.openMultiTag(mTagName);
     assert(~isempty(getMultiTagByName));
     
     %-- test open non existing multitag
-    getMultiTag = b.open_multi_tag('I do not exist');
+    getMultiTag = b.openMultiTag('I do not exist');
     assert(isempty(getMultiTag));
 end
 
-function [] = test_open_source( varargin )
+function [] = testOpenSource( varargin )
 %% Test: Open source by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
     sName = 'sourcetest1';
-    tmp = b.create_source(sName, 'nixSource');
+    tmp = b.createSource(sName, 'nixSource');
     
-    getSourceByID = b.open_source(b.sources{1,1}.id);
+    getSourceByID = b.openSource(b.sources{1,1}.id);
     assert(~isempty(getSourceByID));
 
-    getSourceByName = b.open_source(sName);
+    getSourceByName = b.openSource(sName);
     assert(~isempty(getSourceByName));
     
     %-- test open non existing source
-    getSource = b.open_source('I do not exist');
+    getSource = b.openSource('I do not exist');
     assert(isempty(getSource));
 end
 
-function [] = test_open_group_idx( varargin )
+function [] = testOpenGroupIdx( varargin )
 %% Test Open Group by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g1 = b.create_group('testGroup1', 'nixGroup');
-    g2 = b.create_group('testGroup2', 'nixGroup');
-    g3 = b.create_group('testGroup3', 'nixGroup');
+    g1 = b.createGroup('testGroup1', 'nixGroup');
+    g2 = b.createGroup('testGroup2', 'nixGroup');
+    g3 = b.createGroup('testGroup3', 'nixGroup');
 
-    assert(strcmp(f.blocks{1}.open_group_idx(1).name, g1.name));
-    assert(strcmp(f.blocks{1}.open_group_idx(2).name, g2.name));
-    assert(strcmp(f.blocks{1}.open_group_idx(3).name, g3.name));
+    assert(strcmp(f.blocks{1}.openGroupIdx(1).name, g1.name));
+    assert(strcmp(f.blocks{1}.openGroupIdx(2).name, g2.name));
+    assert(strcmp(f.blocks{1}.openGroupIdx(3).name, g3.name));
 end
 
-function [] = test_open_data_array_idx( varargin )
+function [] = testOpenDataArrayIdx( varargin )
 %% Test Open DataArray by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d1 = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
-    d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
-    d3 = b.create_data_array('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
+    d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
+    d2 = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
+    d3 = b.createDataArray('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
 
-    assert(strcmp(f.blocks{1}.open_data_array_idx(1).name, d1.name));
-    assert(strcmp(f.blocks{1}.open_data_array_idx(2).name, d2.name));
-    assert(strcmp(f.blocks{1}.open_data_array_idx(3).name, d3.name));
+    assert(strcmp(f.blocks{1}.openDataArrayIdx(1).name, d1.name));
+    assert(strcmp(f.blocks{1}.openDataArrayIdx(2).name, d2.name));
+    assert(strcmp(f.blocks{1}.openDataArrayIdx(3).name, d3.name));
 end
 
-function [] = test_open_tag_idx( varargin )
+function [] = testOpenTagIdx( varargin )
 %% Test Open Tag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t1 = b.create_tag('testTag1', 'nixTag', [1 2]);
-    t2 = b.create_tag('testTag2', 'nixTag', [1 2]);
-    t3 = b.create_tag('testTag3', 'nixTag', [1 2]);
+    t1 = b.createTag('testTag1', 'nixTag', [1 2]);
+    t2 = b.createTag('testTag2', 'nixTag', [1 2]);
+    t3 = b.createTag('testTag3', 'nixTag', [1 2]);
 
-    assert(strcmp(f.blocks{1}.open_tag_idx(1).name, t1.name));
-    assert(strcmp(f.blocks{1}.open_tag_idx(2).name, t2.name));
-    assert(strcmp(f.blocks{1}.open_tag_idx(3).name, t3.name));
+    assert(strcmp(f.blocks{1}.openTagIdx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.openTagIdx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.openTagIdx(3).name, t3.name));
 end
 
-function [] = test_open_multi_tag_idx( varargin )
+function [] = testOpenMultiTagIdx( varargin )
 %% Test Open MultiTag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
-    t1 = b.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
-    t2 = b.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
-    t3 = b.create_multi_tag('testMultiTag3', 'nixMultiTag', d);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
+    t1 = b.createMultiTag('testMultiTag1', 'nixMultiTag', d);
+    t2 = b.createMultiTag('testMultiTag2', 'nixMultiTag', d);
+    t3 = b.createMultiTag('testMultiTag3', 'nixMultiTag', d);
 
-    assert(strcmp(f.blocks{1}.open_multi_tag_idx(1).name, t1.name));
-    assert(strcmp(f.blocks{1}.open_multi_tag_idx(2).name, t2.name));
-    assert(strcmp(f.blocks{1}.open_multi_tag_idx(3).name, t3.name));
+    assert(strcmp(f.blocks{1}.openMultiTagIdx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.openMultiTagIdx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.openMultiTagIdx(3).name, t3.name));
 end
 
-function [] = test_open_source_idx( varargin )
+function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s1 = b.create_source('testSource1', 'nixSource');
-    s2 = b.create_source('testSource2', 'nixSource');
-    s3 = b.create_source('testSource3', 'nixSource');
+    s1 = b.createSource('testSource1', 'nixSource');
+    s2 = b.createSource('testSource2', 'nixSource');
+    s3 = b.createSource('testSource3', 'nixSource');
 
-    assert(strcmp(f.blocks{1}.open_source_idx(1).name, s1.name));
-    assert(strcmp(f.blocks{1}.open_source_idx(2).name, s2.name));
-    assert(strcmp(f.blocks{1}.open_source_idx(3).name, s3.name));
+    assert(strcmp(f.blocks{1}.openSourceIdx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.openSourceIdx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.openSourceIdx(3).name, s3.name));
 end
 
-function [] = test_has_multitag( varargin )
+function [] = testHasMultiTag( varargin )
 %% Test: Block has multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
-    tmp = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_multi_tag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createMultiTag('mTagTest1', 'nixMultiTag', b.dataArrays{1});
 
-    assert(b.has_multi_tag(b.multiTags{1,1}.id));
-    assert(b.has_multi_tag(b.multiTags{1,1}.name));
+    assert(b.hasMultiTag(b.multiTags{1,1}.id));
+    assert(b.hasMultiTag(b.multiTags{1,1}.name));
     
-    assert(~b.has_multi_tag('I do not exist'));
+    assert(~b.hasMultiTag('I do not exist'));
 end
 
-function [] = test_has_tag( varargin )
+function [] = testHasTag( varargin )
 %% Test: Block has tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
-    tmp = b.create_tag('tagtest1', 'nixTag', [1.0 1.2 1.3 15.9]);
+    tmp = b.createTag('tagtest1', 'nixTag', [1.0 1.2 1.3 15.9]);
 
-    assert(b.has_tag(b.tags{1,1}.id));
-    assert(b.has_tag(b.tags{1,1}.name));
+    assert(b.hasTag(b.tags{1,1}.id));
+    assert(b.hasTag(b.tags{1,1}.name));
     
-    assert(~b.has_tag('I do not exist'));
+    assert(~b.hasTag('I do not exist'));
 end
 
 %% Test: Set metadata
-function [] = test_set_metadata ( varargin )
+function [] = testSetMetadata ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     secName1 = 'testSection1';
     secName2 = 'testSection2';
@@ -551,7 +551,7 @@ function [] = test_set_metadata ( varargin )
 	assert(strcmp(f.blocks{1}.open_metadata.name, secName2));
 end
 
-function [] = test_open_metadata( varargin )
+function [] = testOpenMetadata( varargin )
 %% Test: Open metadata
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
@@ -562,41 +562,41 @@ function [] = test_open_metadata( varargin )
 end
 
 %% Test: nix.Block has nix.DataArray by ID or name
-function [] = test_has_data_array( varargin )
+function [] = testHasDataArray( varargin )
     fileName = 'testRW.h5';
     daName = 'hasDataArrayTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     daID = da.id;
     
-    assert(~b.has_data_array('I do not exist'));
-    assert(b.has_data_array(daName));
+    assert(~b.hasDataArray('I do not exist'));
+    assert(b.hasDataArray(daName));
 
     clear da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.has_data_array(daID));
+    assert(f.blocks{1}.hasDataArray(daID));
 end
 
 %% Test: nix.Block has nix.Source by ID or name
-function [] = test_has_source( varargin )
+function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.create_source(sName, 'nixSource');
+    s = b.createSource(sName, 'nixSource');
     sID = s.id;
 
-    assert(~b.has_source('I do not exist'));
-    assert(b.has_source(sName));
+    assert(~b.hasSource('I do not exist'));
+    assert(b.hasSource(sName));
 
     clear s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.has_source(sID));
+    assert(f.blocks{1}.hasSource(sID));
 end
 
 %% Test: Create nix.Group
-function [] = test_create_group( varargin )
+function [] = testCreateGroup( varargin )
     fileName = 'testRW.h5';
     groupName = 'testGroup';
     groupType = 'nixGroup';
@@ -606,7 +606,7 @@ function [] = test_create_group( varargin )
 
     assert(isempty(b.groups));
 
-    g = b.create_group(groupName, groupType);
+    g = b.createGroup(groupName, groupType);
     assert(strcmp(g.name, groupName));
     assert(strcmp(g.type, groupType));
     assert(~isempty(b.groups));
@@ -618,52 +618,52 @@ function [] = test_create_group( varargin )
 end
 
 %% Test: nix.Block has nix.Group by name or id
-function [] = test_has_group( varargin )
+function [] = testHasGroup( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('grouptest', 'nixBlock');
 
-    assert(~b.has_group('I do not exist'));
+    assert(~b.hasGroup('I do not exist'));
     
-    g = b.create_group(groupName, 'nixGroup');
-    assert(b.has_group(b.groups{1}.id));
-    assert(b.has_group(groupName));
+    g = b.createGroup(groupName, 'nixGroup');
+    assert(b.hasGroup(b.groups{1}.id));
+    assert(b.hasGroup(groupName));
 
-    b.delete_group(b.groups{1});
-    assert(~b.has_group(g.id));
+    b.deleteGroup(b.groups{1});
+    assert(~b.hasGroup(g.id));
 end
 
 %% Test: Get nix.Group by name or id
-function [] = test_get_group( varargin )
+function [] = testOpenGroup( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('grouptest', 'nixBlock');
-    g = b.create_group(groupName, 'nixGroup');
+    g = b.createGroup(groupName, 'nixGroup');
     gID = g.id;
 
     clear g b f;
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.get_group(gID).name, groupName));
-    assert(strcmp(f.blocks{1}.get_group(groupName).name, groupName));
+    assert(strcmp(f.blocks{1}.openGroup(gID).name, groupName));
+    assert(strcmp(f.blocks{1}.openGroup(groupName).name, groupName));
 end
 
 %% Test: Delete nix.Group by entity and id
-function [] = test_delete_group( varargin )
+function [] = testDeleteGroup( varargin )
     fileName = 'testRW.h5';
     groupType = 'nixGroup';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('grouptest', 'nixBlock');
-    g1 = b.create_group('testGroup1', groupType);
-    g2 = b.create_group('testGroup2', groupType);
+    g1 = b.createGroup('testGroup1', groupType);
+    g2 = b.createGroup('testGroup2', groupType);
 
     assert(size(b.groups, 1) == 2);
-    assert(b.delete_group(b.groups{2}.id));
+    assert(b.deleteGroup(b.groups{2}.id));
     assert(size(b.groups, 1) == 1);
-    assert(b.delete_group(b.groups{1}));
+    assert(b.deleteGroup(b.groups{1}));
     assert(isempty(b.groups));
 
-    assert(~b.delete_group('I do not exist'));
+    assert(~b.deleteGroup('I do not exist'));
 
     clear g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
@@ -671,86 +671,86 @@ function [] = test_delete_group( varargin )
 end
 
 %% Test: Group count
-function [] = test_group_count( varargin )
+function [] = testGroupCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    assert(b.group_count() == 0);
-    g = b.create_group('testGroup', 'nixGroup');
-    assert(b.group_count() == 1);
-    g = b.create_group('testGroup2', 'nixGroup');
+    assert(b.groupCount() == 0);
+    g = b.createGroup('testGroup', 'nixGroup');
+    assert(b.groupCount() == 1);
+    g = b.createGroup('testGroup2', 'nixGroup');
     
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.group_count() == 2);
+    assert(f.blocks{1}.groupCount() == 2);
 end
 
 %% Test: DataArray count
-function [] = test_data_array_count( varargin )
+function [] = testDataArrayCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
-    assert(b.data_array_count() == 0);
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    assert(b.data_array_count() == 1);
-    d = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    assert(b.dataArrayCount() == 0);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    assert(b.dataArrayCount() == 1);
+    d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     clear d b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.data_array_count() == 2);
+    assert(f.blocks{1}.dataArrayCount() == 2);
 end
 
 %% Test: Tag count
-function [] = test_tag_count( varargin )
+function [] = testTagCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
-    assert(b.tag_count() == 0);
-    t = b.create_tag('testTag1', 'nixTag', [1.0 1.2 1.3 15.9]);
-    assert(b.tag_count() == 1);
-    t = b.create_tag('testTag2', 'nixTag', [1.0 1.2 1.3 15.9]);
+    assert(b.tagCount() == 0);
+    t = b.createTag('testTag1', 'nixTag', [1.0 1.2 1.3 15.9]);
+    assert(b.tagCount() == 1);
+    t = b.createTag('testTag2', 'nixTag', [1.0 1.2 1.3 15.9]);
     
     clear t b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tag_count() == 2);
+    assert(f.blocks{1}.tagCount() == 2);
 end
 
 %% Test: MultiTag count
-function [] = test_multi_tag_count( varargin )
+function [] = testMultiTagCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    assert(b.multi_tag_count() == 0);
-    t = b.create_multi_tag('testMultiTag1', 'nixMultiTag', b.dataArrays{1});
-    assert(b.multi_tag_count() == 1);
-    t = b.create_multi_tag('testMultiTag2', 'nixMultiTag', b.dataArrays{1});
+    assert(b.multiTagCount() == 0);
+    t = b.createMultiTag('testMultiTag1', 'nixMultiTag', b.dataArrays{1});
+    assert(b.multiTagCount() == 1);
+    t = b.createMultiTag('testMultiTag2', 'nixMultiTag', b.dataArrays{1});
     
     clear t d b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multi_tag_count() == 2);
+    assert(f.blocks{1}.multiTagCount() == 2);
 end
 
 %% Test: Source count
-function [] = test_source_count( varargin )
+function [] = testSourceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
-    assert(b.source_count() == 0);
-    s = b.create_source('testSource1', 'nixSource');
-    assert(b.source_count() == 1);
-    s = b.create_source('testSource2', 'nixSource');
+    assert(b.sourceCount() == 0);
+    s = b.createSource('testSource1', 'nixSource');
+    assert(b.sourceCount() == 1);
+    s = b.createSource('testSource2', 'nixSource');
     
     clear s b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.source_count() == 2);
+    assert(f.blocks{1}.sourceCount() == 2);
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare block entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -762,347 +762,347 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter sources
-function [] = test_filter_source( varargin )
+function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source(filterName, 'nixSource');
+    s = b.createSource(filterName, 'nixSource');
     filterID = s.id;
-	s = b.create_source('testSource1', filterType);
+	s = b.createSource('testSource1', filterType);
     filterIDs = {filterID, s.id};
-    s = b.create_source('testSource2', filterType);
+    s = b.createSource('testSource2', filterType);
     
     % test empty id filter
-    assert(isempty(f.blocks{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filter_sources(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.filterSources(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.filter_sources(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.filterSources(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.filter_sources(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.filterSources(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.filter_sources(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.filterSources(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.filter_sources(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.filterSources(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filterSources(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     mainID = mainSource.id;
     subName = 'testSubSource1';
     s = mainSource.create_source(subName, 'nixSource');
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.filter_sources(nix.Filter.source, 'Do not exist')));
-    filtered = f.blocks{1}.filter_sources(nix.Filter.source, subName);
+    assert(isempty(f.blocks{1}.filterSources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.filterSources(nix.Filter.source, subName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, mainID));
 
-    filtered = f.blocks{1}.filter_sources(nix.Filter.source, subID);
+    filtered = f.blocks{1}.filterSources(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 
 %% Test: filter groups
-function [] = test_filter_group( varargin )
+function [] = testFilterGroup( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group(filterName, 'nixGroup');
+    g = b.createGroup(filterName, 'nixGroup');
     filterID = g.id;
-	g = b.create_group('testGroup1', filterType);
+	g = b.createGroup('testGroup1', filterType);
     filterIDs = {filterID, g.id};
-    g = b.create_group('testGroup2', filterType);
+    g = b.createGroup('testGroup2', filterType);
     
     % test empty id filter
-    assert(isempty(f.blocks{1}.filter_groups(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.filterGroups(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filter_groups(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.filterGroups(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.filter_groups(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.filterGroups(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.filter_groups(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.filterGroups(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.filter_groups(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.filterGroups(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.filter_groups(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.filterGroups(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainEntity = b.create_group(mainName, 'nixGroup');
+    mainEntity = b.createGroup(mainName, 'nixGroup');
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.filter_groups(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.filter_groups(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.filterGroups(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filterGroups(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    mainEntity = b.create_group(mainName, 'nixGroup');
+    mainEntity = b.createGroup(mainName, 'nixGroup');
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     mainEntity.add_source(s);
     subID = s.id;
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.filter_groups(nix.Filter.source, subID);
+    filtered = f.blocks{1}.filterGroups(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: filter tags
-function [] = test_filter_tag( varargin )
+function [] = testFilterTag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag(filterName, 'nixTag', [1 2 3]);
+    t = b.createTag(filterName, 'nixTag', [1 2 3]);
     filterID = t.id;
-	t = b.create_tag('testTag1', filterType, [1 2 3 4]);
+	t = b.createTag('testTag1', filterType, [1 2 3 4]);
     filterIDs = {filterID, t.id};
-    t = b.create_tag('testTag2', filterType, [1 2]);
+    t = b.createTag('testTag2', filterType, [1 2]);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.filter_tags(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.filterTags(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filter_tags(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.filterTags(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.filter_tags(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.filterTags(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.filter_tags(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.filterTags(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.filter_tags(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.filterTags(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.filter_tags(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.filterTags(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainEntity = b.create_tag(mainName, 'nixTag', [1 8]);
+    mainEntity = b.createTag(mainName, 'nixTag', [1 8]);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.filter_tags(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.filter_tags(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.filterTags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filterTags(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    mainEntity = b.create_tag(mainName, 'nixTag', [12 3]);
+    mainEntity = b.createTag(mainName, 'nixTag', [12 3]);
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     mainEntity.add_source(s);
     subID = s.id;
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.filter_tags(nix.Filter.source, subID);
+    filtered = f.blocks{1}.filterTags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: filter multi tags
-function [] = test_filter_multi_tag( varargin )
+function [] = testFilterMultiTag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 9]);
-    t = b.create_multi_tag(filterName, 'nixMultiTag', d);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 9]);
+    t = b.createMultiTag(filterName, 'nixMultiTag', d);
     filterID = t.id;
-	t = b.create_multi_tag('testMultiTag1', filterType, d);
+	t = b.createMultiTag('testMultiTag1', filterType, d);
     filterIDs = {filterID, t.id};
-    t = b.create_multi_tag('testMultiTag2', filterType, d);
+    t = b.createMultiTag('testMultiTag2', filterType, d);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.filter_multi_tags(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.filterMultiTags(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filter_multi_tags(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.filter_multi_tags(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.filter_multi_tags(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
 
     % test nix.Filter.name
-    filtered  = f.blocks{1}.filter_multi_tags(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.filterMultiTags(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
 
     % test nix.Filter.type
-    filtered = f.blocks{1}.filter_multi_tags(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainEntity = b.create_multi_tag(mainName, 'nixMultiTag', d);
+    mainEntity = b.createMultiTag(mainName, 'nixMultiTag', d);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.filter_multi_tags(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.filter_multi_tags(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.filterMultiTags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    mainEntity = b.create_multi_tag(mainName, 'nixMultiTag', d);
+    mainEntity = b.createMultiTag(mainName, 'nixMultiTag', d);
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     mainEntity.add_source(s);
     subID = s.id;
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.filter_multi_tags(nix.Filter.source, subID);
+    filtered = f.blocks{1}.filterMultiTags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
     
     % test filters work only within blocks, not between them
     b = f.createBlock('testBlock2', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 9]);
-    t = b.create_multi_tag(filterName, 'nixMultiTag', d);
-    assert(size( b.filter_multi_tags(nix.Filter.name, filterName), 1) == 1);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 9]);
+    t = b.createMultiTag(filterName, 'nixMultiTag', d);
+    assert(size( b.filterMultiTags(nix.Filter.name, filterName), 1) == 1);
 end
 
 %% Test: filter data arrays
-function [] = test_filter_data_array( varargin )
+function [] = testFilterDataArray( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Bool, [2 9]);
+    d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     filterID = d.id;
-    d = b.create_data_array('testDataArray1', filterType, nix.DataType.Bool, [2 9]);
+    d = b.createDataArray('testDataArray1', filterType, nix.DataType.Bool, [2 9]);
     filterIDs = {filterID, d.id};
-    d = b.create_data_array('testDataArray2', filterType, nix.DataType.Bool, [2 9]);
+    d = b.createDataArray('testDataArray2', filterType, nix.DataType.Bool, [2 9]);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.filter_data_arrays(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.filterDataArrays(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.filter_data_arrays(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.filter_data_arrays(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.filter_data_arrays(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
 
     % test nix.Filter.name
-    filtered  = f.blocks{1}.filter_data_arrays(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.filterDataArrays(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
 
     % test nix.Filter.type
-    filtered = f.blocks{1}.filter_data_arrays(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainEntity = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
+    mainEntity = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainEntity.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.filter_multi_tags(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.filter_data_arrays(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.filterMultiTags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    mainEntity = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
+    mainEntity = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 9]);
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     mainEntity.add_source(s);
     subID = s.id;
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.filter_data_arrays(nix.Filter.source, subID);
+    filtered = f.blocks{1}.filterDataArrays(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: Find source w/o filter
-function [] = test_find_source
+function [] = testFindSource
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    sl1 = b.create_source('sourceLvl1', 'nixSource');
+    sl1 = b.createSource('sourceLvl1', 'nixSource');
 
     sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
     sl22 = sl1.create_source('sourceLvl2_2', 'nixSource');
@@ -1119,38 +1119,38 @@ function [] = test_find_source
     % Check invalid entry
     err = 'Provide a valid search depth';
     try
-        b.find_sources('hurra');
+        b.findSources('hurra');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % find all
-    filtered = b.find_sources(5);
+    filtered = b.findSources(5);
     assert(size(filtered, 1) == 10);
 
     % find until level 4
-    filtered = b.find_sources(4);
+    filtered = b.findSources(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
-    filtered = b.find_sources(3);
+    filtered = b.findSources(3);
     assert(size(filtered, 1) == 6);
 
     % find until level 2
-    filtered = b.find_sources(2);
+    filtered = b.findSources(2);
     assert(size(filtered, 1) == 3);
 
     % find until level 1
-    filtered = b.find_sources(1);
+    filtered = b.findSources(1);
     assert(size(filtered, 1) == 1);
 end
 
 %% Test: Find sources with filters
-function [] = test_find_source_filtered
+function [] = testFindSourceFiltered
     findSource = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    sl1 = b.create_source('sourceLvl1', 'nixSource');
+    sl1 = b.createSource('sourceLvl1', 'nixSource');
 
     sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
     sl22 = sl1.create_source('sourceLvl2_2', findSource);
@@ -1165,46 +1165,46 @@ function [] = test_find_source_filtered
     sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
 
     % test find by id
-    filtered = b.find_filtered_sources(2, nix.Filter.id, sl41.id);
+    filtered = b.filterFindSources(2, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(5, nix.Filter.id, sl41.id);
+    filtered = b.filterFindSources(5, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = b.find_filtered_sources(1, nix.Filter.ids, filterids);
+    filtered = b.filterFindSources(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = b.find_filtered_sources(4, nix.Filter.ids, filterids);
+    filtered = b.filterFindSources(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = b.find_filtered_sources(1, nix.Filter.name, sl41.name);
+    filtered = b.filterFindSources(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(4, nix.Filter.name, sl41.name);
+    filtered = b.filterFindSources(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = b.find_filtered_sources(1, nix.Filter.type, findSource);
+    filtered = b.filterFindSources(1, nix.Filter.type, findSource);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(4, nix.Filter.type, findSource);
+    filtered = b.filterFindSources(4, nix.Filter.type, findSource);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSource));
 
     % test nix.Filter.metadata
     sec = f.createSection('testSection', 'nixSection');
     sl43.set_metadata(sec);
-    filtered = b.find_filtered_sources(1, nix.Filter.metadata, sec.id);
+    filtered = b.filterFindSources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(4, nix.Filter.metadata, sec.id);
+    filtered = b.filterFindSources(4, nix.Filter.metadata, sec.id);
     assert(size(filtered, 1) == 1);
     strcmp(filtered{1}.id, sl43.id);
 
     % test nix.Filter.source
-    filtered = b.find_filtered_sources(1, nix.Filter.source, sl44.id);
+    filtered = b.filterFindSources(1, nix.Filter.source, sl44.id);
     assert(isempty(filtered));
-    filtered = b.find_filtered_sources(4, nix.Filter.source, sl44.id);
+    filtered = b.filterFindSources(4, nix.Filter.source, sl44.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl31.id));
 end

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -40,7 +40,7 @@ function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(~isempty(da.id));
     assert(strcmp(da.name, 'daTest'));
@@ -93,27 +93,27 @@ function [] = test_open_data( varargin )
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nix.Block');
 
-    da = b.create_data_array('logicalArray', daType, nix.DataType.Bool, [3 3]);
+    da = b.createDataArray('logicalArray', daType, nix.DataType.Bool, [3 3]);
     assert(islogical(da.read_all));
-    da = b.create_data_array('doubleDataArray', daType, nix.DataType.Double, [3 3]);
+    da = b.createDataArray('doubleDataArray', daType, nix.DataType.Double, [3 3]);
     assert(isa(da.read_all, 'double'));
-    da = b.create_data_array('floatDataArray', daType, nix.DataType.Float, [3 3]);
+    da = b.createDataArray('floatDataArray', daType, nix.DataType.Float, [3 3]);
     assert(isfloat(da.read_all));
-    da = b.create_data_array('Int8DataArray', daType, nix.DataType.Int8, [3 3]);
+    da = b.createDataArray('Int8DataArray', daType, nix.DataType.Int8, [3 3]);
     assert(isa(da.read_all, 'int8'));
-    da = b.create_data_array('Int16DataArray', daType, nix.DataType.Int16, [3 3]);
+    da = b.createDataArray('Int16DataArray', daType, nix.DataType.Int16, [3 3]);
     assert(isa(da.read_all, 'int16'));
-    da = b.create_data_array('Int32DataArray', daType, nix.DataType.Int32, [3 3]);
+    da = b.createDataArray('Int32DataArray', daType, nix.DataType.Int32, [3 3]);
     assert(isa(da.read_all, 'int32'));
-    da = b.create_data_array('Int64DataArray', daType, nix.DataType.Int64, [3 3]);
+    da = b.createDataArray('Int64DataArray', daType, nix.DataType.Int64, [3 3]);
     assert(isa(da.read_all, 'int64'));
-    da = b.create_data_array('UInt8DataArray', daType, nix.DataType.UInt8, [3 3]);
+    da = b.createDataArray('UInt8DataArray', daType, nix.DataType.UInt8, [3 3]);
     assert(isa(da.read_all, 'uint8'));
-    da = b.create_data_array('UInt16DataArray', daType, nix.DataType.UInt16, [3 3]);
+    da = b.createDataArray('UInt16DataArray', daType, nix.DataType.UInt16, [3 3]);
     assert(isa(da.read_all, 'uint16'));
-    da = b.create_data_array('UInt32DataArray', daType, nix.DataType.UInt32, [3 3]);
+    da = b.createDataArray('UInt32DataArray', daType, nix.DataType.UInt32, [3 3]);
     assert(isa(da.read_all, 'uint32'));
-    da = b.create_data_array('UInt64DataArray', daType, nix.DataType.UInt64, [3 3]);
+    da = b.createDataArray('UInt64DataArray', daType, nix.DataType.UInt64, [3 3]);
     assert(isa(da.read_all, 'uint64'));
 end
 
@@ -127,7 +127,7 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection(secName2, 'nixSection');
 
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(da.open_metadata));
     assert(isempty(f.blocks{1}.dataArrays{1}.open_metadata));
@@ -155,7 +155,7 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     da.set_metadata(f.sections{1});
 
     assert(strcmp(da.open_metadata.name, 'testSection'));
@@ -183,7 +183,7 @@ function [] = test_write_data_double( varargin )
     charData = ['a' 'b' 'c' 'd' 'e'];
     cellData = {1 2 3 4 5};
     
-    da = b.create_data_array('numericArray', typeDA, nix.DataType.Double, 5);
+    da = b.createDataArray('numericArray', typeDA, nix.DataType.Double, 5);
     da.write_all(numData);
     assert(isequal(da.read_all(), numData));
 
@@ -219,7 +219,7 @@ function [] = test_write_data_logical( varargin )
     numData = [1 2 3 4 5];
     charData = ['a' 'b' 'c' 'd' 'e'];
     
-    da = b.create_data_array('logicalArray', typeDA, nix.DataType.Bool, 5);
+    da = b.createDataArray('logicalArray', typeDA, nix.DataType.Bool, 5);
     da.write_all(logData);
     assert(isequal(da.read_all, logData));
     try
@@ -247,7 +247,7 @@ function [] = test_write_data_float( varargin )
 
     numData = [1.3 2.4143 3.9878 4.1239 5];
     
-    da = b.create_data_array('floatArray', typeDA, nix.DataType.Float, 5);
+    da = b.createDataArray('floatArray', typeDA, nix.DataType.Float, 5);
     da.write_all(numData);
     assert(isequal(da.read_all, single(numData)));
 
@@ -265,28 +265,28 @@ function [] = test_write_data_integer( varargin )
 
     numData = [1 2 3; 4 5 6; 7 8 9];
     
-    da = b.create_data_array('Int8DataArray', typeDA, nix.DataType.Int8, [3 3]);
+    da = b.createDataArray('Int8DataArray', typeDA, nix.DataType.Int8, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('Int16DataArray', typeDA, nix.DataType.Int16, [3 3]);
+    da = b.createDataArray('Int16DataArray', typeDA, nix.DataType.Int16, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('Int32DataArray', typeDA, nix.DataType.Int32, [3 3]);
+    da = b.createDataArray('Int32DataArray', typeDA, nix.DataType.Int32, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('Int64DataArray', typeDA, nix.DataType.Int64, [3 3]);
+    da = b.createDataArray('Int64DataArray', typeDA, nix.DataType.Int64, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('UInt8DataArray', typeDA, nix.DataType.UInt8, [3 3]);
+    da = b.createDataArray('UInt8DataArray', typeDA, nix.DataType.UInt8, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('UInt16DataArray', typeDA, nix.DataType.UInt16, [3 3]);
+    da = b.createDataArray('UInt16DataArray', typeDA, nix.DataType.UInt16, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('UInt32DataArray', typeDA, nix.DataType.UInt32, [3 3]);
+    da = b.createDataArray('UInt32DataArray', typeDA, nix.DataType.UInt32, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
-    da = b.create_data_array('UInt64DataArray', typeDA, nix.DataType.UInt64, [3 3]);
+    da = b.createDataArray('UInt64DataArray', typeDA, nix.DataType.UInt64, [3 3]);
     da.write_all(numData);
     assert(isequal(da.read_all, numData));
 
@@ -306,14 +306,14 @@ end
 function [] = test_add_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    getSource = b.create_source('sourceTest', 'nixSource');
-    tmp = getSource.create_source('nestedSource1', 'nixSource');
-    tmp = getSource.create_source('nestedSource2', 'nixSource');
-    getDataArray = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.createSource('sourceTest', 'nixSource');
+    tmp = s.create_source('nestedSource1', 'nixSource');
+    tmp = s.create_source('nestedSource2', 'nixSource');
+    getDataArray = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(getDataArray.sources));
-    getDataArray.add_source(getSource.sources{1}.id);
-    getDataArray.add_source(getSource.sources{2});
+    getDataArray.add_source(s.sources{1}.id);
+    getDataArray.add_source(s.sources{2});
     assert(size(getDataArray.sources, 1) == 2);
 end
 
@@ -322,10 +322,10 @@ function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_source('testSource1', 'nixSource');
-    tmp = b.create_source('testSource2', 'nixSource');
-    tmp = b.create_source('testSource3', 'nixSource');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createSource('testSource1', 'nixSource');
+    tmp = b.createSource('testSource2', 'nixSource');
+    tmp = b.createSource('testSource3', 'nixSource');
 
     assert(isempty(d.sources));
 
@@ -355,11 +355,11 @@ end
 function [] = test_open_source( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    s = b.create_source('test', 'nixSource');
+    s = b.createSource('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
 
-    d = b.create_data_array('sourceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('sourceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     d.add_source(nSource);
 
     % -- test get source by ID
@@ -376,10 +376,10 @@ function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
-    s1 = b.create_source('testSource1', 'nixSource');
-    s2 = b.create_source('testSource2', 'nixSource');
-    s3 = b.create_source('testSource3', 'nixSource');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
+    s1 = b.createSource('testSource1', 'nixSource');
+    s2 = b.createSource('testSource2', 'nixSource');
+    s3 = b.createSource('testSource3', 'nixSource');
     d.add_source(s1);
     d.add_source(s2);
     d.add_source(s3);
@@ -393,20 +393,20 @@ end
 function [] = test_remove_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    getSource = b.create_source('sourceTest', 'nixSource');
-    tmp = getSource.create_source('nestedSource1', 'nixSource');
-    tmp = getSource.create_source('nestedSource2', 'nixSource');
-    getDataArray = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.createSource('sourceTest', 'nixSource');
+    tmp = s.create_source('nestedSource1', 'nixSource');
+    tmp = s.create_source('nestedSource2', 'nixSource');
+    getDataArray = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    getDataArray.add_source(getSource.sources{1}.id);
-    getDataArray.add_source(getSource.sources{2});
+    getDataArray.add_source(s.sources{1}.id);
+    getDataArray.add_source(s.sources{2});
 
-    assert(getDataArray.remove_source(getSource.sources{2}));
-    assert(getDataArray.remove_source(getSource.sources{1}.id));
+    assert(getDataArray.remove_source(s.sources{2}));
+    assert(getDataArray.remove_source(s.sources{1}.id));
     assert(isempty(getDataArray.sources));
 
     assert(getDataArray.remove_source('I do not exist'));
-    assert(size(getSource.sources, 1) == 2);
+    assert(size(s.sources, 1) == 2);
 end
 
 %% Test: has nix.Source by ID or entity
@@ -414,9 +414,9 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.create_source('sourceTest1', 'nixSource');
+    s = b.createSource('sourceTest1', 'nixSource');
     sID = s.id;
-    d = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     d.add_source(b.sources{1});
 
     assert(~d.has_source('I do not exist'));
@@ -432,12 +432,12 @@ function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(d.source_count() == 0);
-    d.add_source(b.create_source('testSource1', 'nixSource'));
+    d.add_source(b.createSource('testSource1', 'nixSource'));
     assert(d.source_count() == 1);
-    d.add_source(b.create_source('testSource2', 'nixSource'));
+    d.add_source(b.createSource('testSource2', 'nixSource'));
     
     clear d b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -449,7 +449,7 @@ function [] = test_dimensions( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(isempty(da.dimensions));
     assert(isempty(f.blocks{1}.dataArrays{1}.dimensions));
@@ -489,7 +489,7 @@ function [] = test_dimensions( varargin )
         assert(strcmp(ME.identifier, 'nix:arg:inval'));
     end;
     
-    daAlias = b.create_data_array('aliasDimTest', 'nix.DataArray', ...
+    daAlias = b.createDataArray('aliasDimTest', 'nix.DataArray', ...
         nix.DataType.Double, 25);
     daAlias.append_alias_range_dimension();
     assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
@@ -499,16 +499,16 @@ function [] = test_dimensions( varargin )
     assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
     
     %-- Test for the alias dimension shape work around
-    daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWTest1', ...
+    daAliasWa = f.blocks{1}.createDataArrayFromData('aliasDimWTest1', ...
         'nix.DataArray', [1 2 3]);
     daAliasWa.append_alias_range_dimension();
     assert(daAliasWa.dimensions{1}.isAlias);
     
-    daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWATest2', ...
+    daAliasWa = f.blocks{1}.createDataArrayFromData('aliasDimWATest2', ...
         'nix.DataArray', [1; 2; 3]);
     assert(isequal(daAliasWa.dataExtent, [3 1]));
     
-    daAliasWa = f.blocks{1}.create_data_array_from_data('aliasDimWATest3', ...
+    daAliasWa = f.blocks{1}.createDataArrayFromData('aliasDimWATest3', ...
         'nix.DataArray', [1 2 3; 2 4 5; 3 6 7]);
     assert(isequal(daAliasWa.dataExtent, [3 3]));
 end
@@ -518,7 +518,7 @@ function [] = test_open_dimension_idx( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
     da.append_set_dimension();
     da.append_sampled_dimension(200);
@@ -536,7 +536,7 @@ function [] = test_dimension_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(da.dimension_count == 0);
 
@@ -563,10 +563,10 @@ function [] = test_datatype( varargin )
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixblock');
 
-    da = b.create_data_array_from_data('testDataArray1', typeDA, [1 2 3]);
+    da = b.createDataArrayFromData('testDataArray1', typeDA, [1 2 3]);
     assert(strcmp(da.datatype, 'double'));
     
-    da = b.create_data_array('testDataArray2', typeDA, nix.DataType.Bool, 5);
+    da = b.createDataArray('testDataArray2', typeDA, nix.DataType.Bool, 5);
     da.write_all(logical([1 0 1 1 1]));
     assert(strcmp(da.datatype, 'logical'));
 end
@@ -577,7 +577,7 @@ function [] = test_set_data_extent( varargin )
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixblock');
 
-    da = b.create_data_array_from_data('testDataArray1', 'nix.DataArray', [1 2 3; 4 5 6]);
+    da = b.createDataArrayFromData('testDataArray1', 'nix.DataArray', [1 2 3; 4 5 6]);
     extent = [4 6];
     da.set_data_extent(extent);
     assert(da.dataExtent(1) == extent(1) && size(da.read_all, 2) == extent(2));
@@ -588,9 +588,9 @@ function [] = test_compare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    d1 = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Bool, [2 9]);
-    d2 = b1.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Bool, [2 9]);
-    d3 = b2.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Bool, [2 9]);
+    d1 = b1.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Bool, [2 9]);
+    d2 = b1.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Bool, [2 9]);
+    d3 = b2.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Bool, [2 9]);
 
     assert(d1.compare(d2) < 0);
     assert(d1.compare(d1) == 0);
@@ -604,14 +604,14 @@ function [] = test_filter_source( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [3 2 3]);
-    s = b.create_source(filterName, 'nixSource');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [3 2 3]);
+    s = b.createSource(filterName, 'nixSource');
     d.add_source(s);
     filterID = s.id;
-	s = b.create_source('testSource1', filterType);
+	s = b.createSource('testSource1', filterType);
     d.add_source(s);
     filterIDs = {filterID, s.id};
-    s = b.create_source('testSource2', filterType);
+    s = b.createSource('testSource2', filterType);
     d.add_source(s);
 
     % test empty id filter
@@ -642,7 +642,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     d.add_source(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -656,7 +656,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_source(mainName, 'nixSource');
+    main = b.createSource(mainName, 'nixSource');
     d.add_source(main);
     mainID = main.id;
     subName = 'testSubSource1';

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -39,7 +39,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('daTestBlock', 'test nixBlock');
+    b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(~isempty(da.id));
@@ -91,7 +91,7 @@ function [] = test_open_data( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nix.Block');
+    b = f.createBlock('testBlock', 'nix.Block');
 
     da = b.create_data_array('logicalArray', daType, nix.DataType.Bool, [3 3]);
     assert(islogical(da.read_all));
@@ -123,10 +123,10 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.create_section(secName1, 'nixSection');
-    tmp = f.create_section(secName2, 'nixSection');
+    tmp = f.createSection(secName1, 'nixSection');
+    tmp = f.createSection(secName2, 'nixSection');
 
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(da.open_metadata));
@@ -153,8 +153,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     da.set_metadata(f.sections{1});
 
@@ -176,7 +176,7 @@ function [] = test_write_data_double( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testDataArray', 'nixblock');
+    b = f.createBlock('testDataArray', 'nixblock');
 
     numData = [1 2 3 4 5];
     logData = logical([1 0 1 0 1]);
@@ -213,7 +213,7 @@ function [] = test_write_data_logical( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testDataArray', 'nixblock');
+    b = f.createBlock('testDataArray', 'nixblock');
 
     logData = logical([1 0 1 0 1]);
     numData = [1 2 3 4 5];
@@ -243,7 +243,7 @@ function [] = test_write_data_float( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testDataArray', 'nixblock');
+    b = f.createBlock('testDataArray', 'nixblock');
 
     numData = [1.3 2.4143 3.9878 4.1239 5];
     
@@ -261,7 +261,7 @@ function [] = test_write_data_integer( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testDataArray', 'nixblock');
+    b = f.createBlock('testDataArray', 'nixblock');
 
     numData = [1 2 3; 4 5 6; 7 8 9];
     
@@ -305,7 +305,7 @@ end
 %% Test: Add sources by entity and id
 function [] = test_add_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('sourceTest', 'nixBlock');
+    b = f.createBlock('sourceTest', 'nixBlock');
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -321,7 +321,7 @@ end
 function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_source('testSource1', 'nixSource');
     tmp = b.create_source('testSource2', 'nixSource');
@@ -353,8 +353,8 @@ end
 
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('test', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('test', 'nixBlock');
     s = b.create_source('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
@@ -375,7 +375,7 @@ end
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
     s1 = b.create_source('testSource1', 'nixSource');
     s2 = b.create_source('testSource2', 'nixSource');
@@ -392,7 +392,7 @@ end
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('sourceTest', 'nixBlock');
+    b = f.createBlock('sourceTest', 'nixBlock');
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
@@ -413,7 +413,7 @@ end
 function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     s = b.create_source('sourceTest1', 'nixSource');
     sID = s.id;
     d = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -431,7 +431,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(d.source_count() == 0);
@@ -448,7 +448,7 @@ end
 function [] = test_dimensions( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('daTestBlock', 'test nixBlock');
+    b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(isempty(da.dimensions));
@@ -517,7 +517,7 @@ function [] = test_open_dimension_idx( varargin )
 %% Test: Open dimension by index
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('daTestBlock', 'test nixBlock');
+    b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
     da.append_set_dimension();
@@ -535,7 +535,7 @@ end
 function [] = test_dimension_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
     assert(da.dimension_count == 0);
@@ -561,7 +561,7 @@ function [] = test_datatype( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixblock');
+    b = f.createBlock('testBlock', 'nixblock');
 
     da = b.create_data_array_from_data('testDataArray1', typeDA, [1 2 3]);
     assert(strcmp(da.datatype, 'double'));
@@ -575,7 +575,7 @@ end
 function [] = test_set_data_extent( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixblock');
+    b = f.createBlock('testBlock', 'nixblock');
 
     da = b.create_data_array_from_data('testDataArray1', 'nix.DataArray', [1 2 3; 4 5 6]);
     extent = [4 6];
@@ -586,8 +586,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare DataArray entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     d1 = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Bool, [2 9]);
     d2 = b1.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Bool, [2 9]);
     d3 = b2.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Bool, [2 9]);
@@ -603,7 +603,7 @@ function [] = test_filter_source( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [3 2 3]);
     s = b.create_source(filterName, 'nixSource');
     d.add_source(s);
@@ -645,7 +645,7 @@ function [] = test_filter_source( varargin )
     mainSource = b.create_source(mainName, 'nixSource');
     d.add_source(mainSource);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -617,8 +617,8 @@ function [] = testFilterSource( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -128,25 +128,26 @@ function [] = testSetMetadata ( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    assert(isempty(da.open_metadata));
-    assert(isempty(f.blocks{1}.dataArrays{1}.open_metadata));
+    assert(isempty(da.openMetadata));
+    assert(isempty(f.blocks{1}.dataArrays{1}.openMetadata));
 
-    da.set_metadata(f.sections{1});
-    assert(strcmp(da.open_metadata.name, secName1));
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_metadata.name, secName1));
+    da.setMetadata(f.sections{1});
+    assert(strcmp(da.openMetadata.name, secName1));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.openMetadata.name, secName1));
 
-    da.set_metadata(f.sections{2});
-    assert(strcmp(da.open_metadata.name, secName2));
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_metadata.name, secName2));
+    da.setMetadata(f.sections{2});
+    assert(strcmp(da.openMetadata.name, secName2));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.openMetadata.name, secName2));
 
-    da.set_metadata('');
-    assert(isempty(da.open_metadata));
-    assert(isempty(f.blocks{1}.dataArrays{1}.open_metadata));
+    da.setMetadata('');
+    assert(isempty(da.openMetadata));
+    assert(isempty(f.blocks{1}.dataArrays{1}.openMetadata));
     
-    da.set_metadata(f.sections{2});
+    da.setMetadata(f.sections{2});
+
     clear tmp da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_metadata.name, secName2));    
+    assert(strcmp(f.blocks{1}.dataArrays{1}.openMetadata.name, secName2));    
 end
 
 %% Test: Open metadata
@@ -155,9 +156,9 @@ function [] = testOpenMetadata( varargin )
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
     da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    da.set_metadata(f.sections{1});
+    da.setMetadata(f.sections{1});
 
-    assert(strcmp(da.open_metadata.name, 'testSection'));
+    assert(strcmp(da.openMetadata.name, 'testSection'));
 end
 
 %% Test: List sources
@@ -645,7 +646,7 @@ function [] = testFilterSource( varargin )
     d.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainSource.set_metadata(s);
+    mainSource.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.metadata, 'Do not exist')));

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -7,8 +7,7 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestDataArray
-%TESTDATAARRAY tests for DataArray
-%   Detailed explanation goes here
+% TESTDATAARRAY tests for DataArray
 
     funcs = {};
     funcs{end+1} = @testAttributes;
@@ -309,12 +308,12 @@ function [] = testAddSource ( varargin )
     s = b.createSource('sourceTest', 'nixSource');
     tmp = s.createSource('nestedSource1', 'nixSource');
     tmp = s.createSource('nestedSource2', 'nixSource');
-    getDataArray = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    assert(isempty(getDataArray.sources));
-    getDataArray.add_source(s.sources{1}.id);
-    getDataArray.add_source(s.sources{2});
-    assert(size(getDataArray.sources, 1) == 2);
+    assert(isempty(d.sources));
+    d.addSource(s.sources{1}.id);
+    d.addSource(s.sources{2});
+    assert(size(d.sources, 1) == 2);
 end
 
 %% Test: Add sources by entity cell array
@@ -330,20 +329,20 @@ function [] = testAddSources ( varargin )
     assert(isempty(d.sources));
 
     try
-        d.add_sources('hurra');
+        d.addSources('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(d.sources));
 
     try
-        d.add_sources({12, 13});
+        d.addSources({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.Source')));
     end;
     assert(isempty(d.sources));
 
-    d.add_sources(b.sources());
+    d.addSources(b.sources());
     assert(size(d.sources, 1) == 3);
 
     clear d tmp b f;
@@ -360,16 +359,16 @@ function [] = testOpenSource( varargin )
     nSource = s.createSource(sourceName, 'nixSource');
 
     d = b.createDataArray('sourceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
-    d.add_source(nSource);
+    d.addSource(nSource);
 
     % -- test get source by ID
-    assert(~isempty(d.open_source(nSource.id)));
+    assert(~isempty(d.openSource(nSource.id)));
 
     % -- test get source by name
-    assert(~isempty(d.open_source(sourceName)));
+    assert(~isempty(d.openSource(sourceName)));
 
     %-- test open non existing source
-    assert(isempty(d.open_source('I do not exist')));
+    assert(isempty(d.openSource('I do not exist')));
 end
 
 function [] = testOpenSourceIdx( varargin )
@@ -380,13 +379,13 @@ function [] = testOpenSourceIdx( varargin )
     s1 = b.createSource('testSource1', 'nixSource');
     s2 = b.createSource('testSource2', 'nixSource');
     s3 = b.createSource('testSource3', 'nixSource');
-    d.add_source(s1);
-    d.add_source(s2);
-    d.add_source(s3);
+    d.addSource(s1);
+    d.addSource(s2);
+    d.addSource(s3);
 
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(1).name, s1.name));
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(2).name, s2.name));
-    assert(strcmp(f.blocks{1}.dataArrays{1}.open_source_idx(3).name, s3.name));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.openSourceIdx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.openSourceIdx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.dataArrays{1}.openSourceIdx(3).name, s3.name));
 end
 
 %% Test: Remove sources by entity and id
@@ -396,16 +395,16 @@ function [] = testRemoveSource ( varargin )
     s = b.createSource('sourceTest', 'nixSource');
     tmp = s.createSource('nestedSource1', 'nixSource');
     tmp = s.createSource('nestedSource2', 'nixSource');
-    getDataArray = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    getDataArray.add_source(s.sources{1}.id);
-    getDataArray.add_source(s.sources{2});
+    d.addSource(s.sources{1}.id);
+    d.addSource(s.sources{2});
 
-    assert(getDataArray.remove_source(s.sources{2}));
-    assert(getDataArray.remove_source(s.sources{1}.id));
-    assert(isempty(getDataArray.sources));
+    assert(d.removeSource(s.sources{2}));
+    assert(d.removeSource(s.sources{1}.id));
+    assert(isempty(d.sources));
 
-    assert(getDataArray.remove_source('I do not exist'));
+    assert(d.removeSource('I do not exist'));
     assert(size(s.sources, 1) == 2);
 end
 
@@ -417,14 +416,14 @@ function [] = testHasSource( varargin )
     s = b.createSource('sourceTest1', 'nixSource');
     sID = s.id;
     d = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    d.add_source(b.sources{1});
+    d.addSource(b.sources{1});
 
-    assert(~d.has_source('I do not exist'));
-    assert(d.has_source(s));
+    assert(~d.hasSource('I do not exist'));
+    assert(d.hasSource(s));
 
     clear d s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.dataArrays{1}.has_source(sID));
+    assert(f.blocks{1}.dataArrays{1}.hasSource(sID));
 end
 
 %% Test: Source count
@@ -434,14 +433,14 @@ function [] = testSourceCount( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
-    assert(d.source_count() == 0);
-    d.add_source(b.createSource('testSource1', 'nixSource'));
-    assert(d.source_count() == 1);
-    d.add_source(b.createSource('testSource2', 'nixSource'));
+    assert(d.sourceCount() == 0);
+    d.addSource(b.createSource('testSource1', 'nixSource'));
+    assert(d.sourceCount() == 1);
+    d.addSource(b.createSource('testSource2', 'nixSource'));
     
     clear d b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.dataArrays{1}.source_count() == 2);
+    assert(f.blocks{1}.dataArrays{1}.sourceCount() == 2);
 end
 
 %% Test: Dimensions
@@ -606,69 +605,69 @@ function [] = testFilterSource( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [3 2 3]);
     s = b.createSource(filterName, 'nixSource');
-    d.add_source(s);
+    d.addSource(s);
     filterID = s.id;
 	s = b.createSource('testSource1', filterType);
-    d.add_source(s);
+    d.addSource(s);
     filterIDs = {filterID, s.id};
     s = b.createSource('testSource2', filterType);
-    d.add_source(s);
+    d.addSource(s);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     mainSource = b.createSource(mainName, 'nixSource');
-    d.add_source(mainSource);
+    d.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createSource(mainName, 'nixSource');
-    d.add_source(main);
+    d.addSource(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, 'Do not exist')));
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, subName);
+    assert(isempty(f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.source, subName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, mainID));
 
-    filtered = f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, subID);
+    filtered = f.blocks{1}.dataArrays{1}.filterSources(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -11,32 +11,32 @@ function funcs = TestDataArray
 %   Detailed explanation goes here
 
     funcs = {};
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_open_data;
-    funcs{end+1} = @test_set_metadata;
-    funcs{end+1} = @test_open_metadata;
-    funcs{end+1} = @test_list_sources;
-    funcs{end+1} = @test_write_data_double;
-    funcs{end+1} = @test_write_data_logical;
-    funcs{end+1} = @test_write_data_float;
-    funcs{end+1} = @test_write_data_integer;
-    funcs{end+1} = @test_add_source;
-    funcs{end+1} = @test_add_sources;
-    funcs{end+1} = @test_open_source;
-    funcs{end+1} = @test_open_source_idx;
-    funcs{end+1} = @test_remove_source;
-    funcs{end+1} = @test_has_source;
-    funcs{end+1} = @test_source_count;
-    funcs{end+1} = @test_dimensions;
-    funcs{end+1} = @test_open_dimension_idx;
-    funcs{end+1} = @test_dimension_count;
-    funcs{end+1} = @test_datatype;
-    funcs{end+1} = @test_set_data_extent;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_source;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testOpenData;
+    funcs{end+1} = @testSetMetadata;
+    funcs{end+1} = @testOpenMetadata;
+    funcs{end+1} = @testListSources;
+    funcs{end+1} = @testWriteDataDouble;
+    funcs{end+1} = @testWriteDataLogical;
+    funcs{end+1} = @testWriteDataFloat;
+    funcs{end+1} = @testWriteDataInteger;
+    funcs{end+1} = @testAddSource;
+    funcs{end+1} = @testAddSources;
+    funcs{end+1} = @testOpenSource;
+    funcs{end+1} = @testOpenSourceIdx;
+    funcs{end+1} = @testRemoveSource;
+    funcs{end+1} = @testHasSource;
+    funcs{end+1} = @testSourceCount;
+    funcs{end+1} = @testDimensions;
+    funcs{end+1} = @testOpenDimensionIdx;
+    funcs{end+1} = @testDimensionCount;
+    funcs{end+1} = @testDatatype;
+    funcs{end+1} = @testSetDataExtent;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSource;
 end
 
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
@@ -87,38 +87,38 @@ function [] = test_attrs( varargin )
 end
 
 %% Test: Read all data from DataArray
-function [] = test_open_data( varargin )
+function [] = testOpenData( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nix.Block');
 
     da = b.createDataArray('logicalArray', daType, nix.DataType.Bool, [3 3]);
-    assert(islogical(da.read_all));
+    assert(islogical(da.readAllData));
     da = b.createDataArray('doubleDataArray', daType, nix.DataType.Double, [3 3]);
-    assert(isa(da.read_all, 'double'));
+    assert(isa(da.readAllData, 'double'));
     da = b.createDataArray('floatDataArray', daType, nix.DataType.Float, [3 3]);
-    assert(isfloat(da.read_all));
+    assert(isfloat(da.readAllData));
     da = b.createDataArray('Int8DataArray', daType, nix.DataType.Int8, [3 3]);
-    assert(isa(da.read_all, 'int8'));
+    assert(isa(da.readAllData, 'int8'));
     da = b.createDataArray('Int16DataArray', daType, nix.DataType.Int16, [3 3]);
-    assert(isa(da.read_all, 'int16'));
+    assert(isa(da.readAllData, 'int16'));
     da = b.createDataArray('Int32DataArray', daType, nix.DataType.Int32, [3 3]);
-    assert(isa(da.read_all, 'int32'));
+    assert(isa(da.readAllData, 'int32'));
     da = b.createDataArray('Int64DataArray', daType, nix.DataType.Int64, [3 3]);
-    assert(isa(da.read_all, 'int64'));
+    assert(isa(da.readAllData, 'int64'));
     da = b.createDataArray('UInt8DataArray', daType, nix.DataType.UInt8, [3 3]);
-    assert(isa(da.read_all, 'uint8'));
+    assert(isa(da.readAllData, 'uint8'));
     da = b.createDataArray('UInt16DataArray', daType, nix.DataType.UInt16, [3 3]);
-    assert(isa(da.read_all, 'uint16'));
+    assert(isa(da.readAllData, 'uint16'));
     da = b.createDataArray('UInt32DataArray', daType, nix.DataType.UInt32, [3 3]);
-    assert(isa(da.read_all, 'uint32'));
+    assert(isa(da.readAllData, 'uint32'));
     da = b.createDataArray('UInt64DataArray', daType, nix.DataType.UInt64, [3 3]);
-    assert(isa(da.read_all, 'uint64'));
+    assert(isa(da.readAllData, 'uint64'));
 end
 
 %% Test: Set metadata
-function [] = test_set_metadata ( varargin )
+function [] = testSetMetadata ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     secName1 = 'testSection1';
     secName2 = 'testSection2';
@@ -151,7 +151,7 @@ function [] = test_set_metadata ( varargin )
 end
 
 %% Test: Open metadata
-function [] = test_open_metadata( varargin )
+function [] = testOpenMetadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
@@ -162,7 +162,7 @@ function [] = test_open_metadata( varargin )
 end
 
 %% Test: List sources
-function [] = test_list_sources( varargin )
+function [] = testListSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     b = f.blocks{1};
     d1 = b.dataArrays{1};
@@ -172,7 +172,7 @@ function [] = test_list_sources( varargin )
 end
 
 %% Test: Write Data double
-function [] = test_write_data_double( varargin )
+function [] = testWriteDataDouble( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -184,32 +184,32 @@ function [] = test_write_data_double( varargin )
     cellData = {1 2 3 4 5};
     
     da = b.createDataArray('numericArray', typeDA, nix.DataType.Double, 5);
-    da.write_all(numData);
-    assert(isequal(da.read_all(), numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData(), numData));
 
     try
-        da.write_all(logData);
+        da.writeAllData(logData);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
     end
     try
-        da.write_all(charData);
+        da.writeAllData(charData);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
     end
     try
-        da.write_all(cellData);
+        da.writeAllData(cellData);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
     end
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{1}.readAllData, numData));
 end
 
 %% Test: Write Data logical
-function [] = test_write_data_logical( varargin )
+function [] = testWriteDataLogical( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -220,26 +220,26 @@ function [] = test_write_data_logical( varargin )
     charData = ['a' 'b' 'c' 'd' 'e'];
     
     da = b.createDataArray('logicalArray', typeDA, nix.DataType.Bool, 5);
-    da.write_all(logData);
-    assert(isequal(da.read_all, logData));
+    da.writeAllData(logData);
+    assert(isequal(da.readAllData, logData));
     try
-        da.write_all(numData);
+        da.writeAllData(numData);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
     end
     try
-        da.write_all(charData);
+        da.writeAllData(charData);
     catch ME
         assert(strcmp(ME.identifier, 'NIXMX:improperDataType'));
     end
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, logData));
+    assert(isequal(f.blocks{1}.dataArrays{1}.readAllData, logData));
 end
 
 %% Test: Write Data float
-function [] = test_write_data_float( varargin )
+function [] = testWriteDataFloat( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -248,16 +248,16 @@ function [] = test_write_data_float( varargin )
     numData = [1.3 2.4143 3.9878 4.1239 5];
     
     da = b.createDataArray('floatArray', typeDA, nix.DataType.Float, 5);
-    da.write_all(numData);
-    assert(isequal(da.read_all, single(numData)));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, single(numData)));
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, single(numData)));
+    assert(isequal(f.blocks{1}.dataArrays{1}.readAllData, single(numData)));
 end
 
 %% Test: Write Data integer
-function [] = test_write_data_integer( varargin )
+function [] = testWriteDataInteger( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -266,44 +266,44 @@ function [] = test_write_data_integer( varargin )
     numData = [1 2 3; 4 5 6; 7 8 9];
     
     da = b.createDataArray('Int8DataArray', typeDA, nix.DataType.Int8, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('Int16DataArray', typeDA, nix.DataType.Int16, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('Int32DataArray', typeDA, nix.DataType.Int32, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('Int64DataArray', typeDA, nix.DataType.Int64, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('UInt8DataArray', typeDA, nix.DataType.UInt8, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('UInt16DataArray', typeDA, nix.DataType.UInt16, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('UInt32DataArray', typeDA, nix.DataType.UInt32, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
     da = b.createDataArray('UInt64DataArray', typeDA, nix.DataType.UInt64, [3 3]);
-    da.write_all(numData);
-    assert(isequal(da.read_all, numData));
+    da.writeAllData(numData);
+    assert(isequal(da.readAllData, numData));
 
     clear da b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(isequal(f.blocks{1}.dataArrays{1}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{2}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{3}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{4}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{5}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{6}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{7}.read_all, numData));
-    assert(isequal(f.blocks{1}.dataArrays{8}.read_all, numData));
+    assert(isequal(f.blocks{1}.dataArrays{1}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{2}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{3}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{4}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{5}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{6}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{7}.readAllData, numData));
+    assert(isequal(f.blocks{1}.dataArrays{8}.readAllData, numData));
 end
 
 %% Test: Add sources by entity and id
-function [] = test_add_source ( varargin )
+function [] = testAddSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     s = b.createSource('sourceTest', 'nixSource');
@@ -318,7 +318,7 @@ function [] = test_add_source ( varargin )
 end
 
 %% Test: Add sources by entity cell array
-function [] = test_add_sources ( varargin )
+function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -352,7 +352,7 @@ function [] = test_add_sources ( varargin )
 end
 
 %% Test: Open source by ID or name
-function [] = test_open_source( varargin )
+function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
@@ -372,7 +372,7 @@ function [] = test_open_source( varargin )
     assert(isempty(d.open_source('I do not exist')));
 end
 
-function [] = test_open_source_idx( varargin )
+function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -390,7 +390,7 @@ function [] = test_open_source_idx( varargin )
 end
 
 %% Test: Remove sources by entity and id
-function [] = test_remove_source ( varargin )
+function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     s = b.createSource('sourceTest', 'nixSource');
@@ -410,7 +410,7 @@ function [] = test_remove_source ( varargin )
 end
 
 %% Test: has nix.Source by ID or entity
-function [] = test_has_source( varargin )
+function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
@@ -428,7 +428,7 @@ function [] = test_has_source( varargin )
 end
 
 %% Test: Source count
-function [] = test_source_count( varargin )
+function [] = testSourceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -445,7 +445,7 @@ function [] = test_source_count( varargin )
 end
 
 %% Test: Dimensions
-function [] = test_dimensions( varargin )
+function [] = testDimensions( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
@@ -454,44 +454,44 @@ function [] = test_dimensions( varargin )
     assert(isempty(da.dimensions));
     assert(isempty(f.blocks{1}.dataArrays{1}.dimensions));
     
-    da.append_set_dimension();
+    da.appendSetDimension();
     assert(length(da.dimensions) == 1);
     assert(strcmp(da.dimensions{1}.dimensionType, 'set'));
     assert(strcmp(f.blocks{1}.dataArrays{1}.dimensions{1}.dimensionType, 'set'));
     
-    da.append_sampled_dimension(200);
+    da.appendSampledDimension(200);
     assert(length(da.dimensions) == 2);
     assert(strcmp(da.dimensions{2}.dimensionType, 'sample'));
     assert(da.dimensions{2}.samplingInterval == 200);
     assert(f.blocks{1}.dataArrays{1}.dimensions{2}.samplingInterval == 200);
     
     ticks = [1, 2, 3, 4];
-    da.append_range_dimension(ticks);
+    da.appendRangeDimension(ticks);
     assert(length(da.dimensions) == 3);
     assert(strcmp(da.dimensions{3}.dimensionType, 'range'));
     assert(isequal(da.dimensions{3}.ticks, ticks));
     assert(isequal(f.blocks{1}.dataArrays{1}.dimensions{3}.ticks, ticks));
     assert(~da.dimensions{3}.isAlias);
 
-    da.delete_dimensions();
+    da.deleteDimensions();
     assert(isempty(da.dimensions));
    
     try
-        da.append_alias_range_dimension;
+        da.appendAliasRangeDimension;
     catch ME
         assert(strcmp(ME.identifier, 'nix:arg:inval'));
     end;
     
-    da.append_set_dimension();
+    da.appendSetDimension();
     try
-        da.append_alias_range_dimension();
+        da.appendAliasRangeDimension();
     catch ME
         assert(strcmp(ME.identifier, 'nix:arg:inval'));
     end;
     
     daAlias = b.createDataArray('aliasDimTest', 'nix.DataArray', ...
         nix.DataType.Double, 25);
-    daAlias.append_alias_range_dimension();
+    daAlias.appendAliasRangeDimension();
     assert(f.blocks{1}.dataArrays{2}.dimensions{1}.isAlias);
     
     clear daAlias da b f;
@@ -501,7 +501,7 @@ function [] = test_dimensions( varargin )
     %-- Test for the alias dimension shape work around
     daAliasWa = f.blocks{1}.createDataArrayFromData('aliasDimWTest1', ...
         'nix.DataArray', [1 2 3]);
-    daAliasWa.append_alias_range_dimension();
+    daAliasWa.appendAliasRangeDimension();
     assert(daAliasWa.dimensions{1}.isAlias);
     
     daAliasWa = f.blocks{1}.createDataArrayFromData('aliasDimWATest2', ...
@@ -513,51 +513,51 @@ function [] = test_dimensions( varargin )
     assert(isequal(daAliasWa.dataExtent, [3 3]));
 end
 
-function [] = test_open_dimension_idx( varargin )
+function [] = testOpenDimensionIdx( varargin )
 %% Test: Open dimension by index
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     
-    da.append_set_dimension();
-    da.append_sampled_dimension(200);
-    da.append_range_dimension([1, 2, 3, 4]);
+    da.appendSetDimension();
+    da.appendSampledDimension(200);
+    da.appendRangeDimension([1, 2, 3, 4]);
 
     % for some weird reason getting the dimension by index starts with 1
     % instead of 0 compared to all other index functions.
-    assert(strcmp(da.open_dimension_idx(1).dimensionType, 'set'));
-    assert(strcmp(da.open_dimension_idx(2).dimensionType, 'sample'));
-    assert(strcmp(da.open_dimension_idx(3).dimensionType, 'range'));
+    assert(strcmp(da.openDimensionIdx(1).dimensionType, 'set'));
+    assert(strcmp(da.openDimensionIdx(2).dimensionType, 'sample'));
+    assert(strcmp(da.openDimensionIdx(3).dimensionType, 'range'));
 end
 
 %% Test: Dimension count
-function [] = test_dimension_count( varargin )
+function [] = testDimensionCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     
-    assert(da.dimension_count == 0);
+    assert(da.dimensionCount == 0);
 
-    da.append_set_dimension();
-    assert(da.dimension_count == 1);
+    da.appendSetDimension();
+    assert(da.dimensionCount == 1);
 
-    da.append_sampled_dimension(200);
-    assert(da.dimension_count == 2);
+    da.appendSampledDimension(200);
+    assert(da.dimensionCount == 2);
 
-    da.delete_dimensions();
-    assert(da.dimension_count == 0);
+    da.deleteDimensions();
+    assert(da.dimensionCount == 0);
 
-    da.append_range_dimension([1, 2, 3, 4]);
+    da.appendRangeDimension([1, 2, 3, 4]);
 
     clear da b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.dataArrays{1}.dimension_count() == 1);
+    assert(f.blocks{1}.dataArrays{1}.dimensionCount() == 1);
 end
 
 %% Test: Datatype
-function [] = test_datatype( varargin )
+function [] = testDatatype( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     typeDA = 'nix.DataArray';
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -567,23 +567,23 @@ function [] = test_datatype( varargin )
     assert(strcmp(da.datatype, 'double'));
     
     da = b.createDataArray('testDataArray2', typeDA, nix.DataType.Bool, 5);
-    da.write_all(logical([1 0 1 1 1]));
+    da.writeAllData(logical([1 0 1 1 1]));
     assert(strcmp(da.datatype, 'logical'));
 end
 
 %% Test: Set extent
-function [] = test_set_data_extent( varargin )
+function [] = testSetDataExtent( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixblock');
 
     da = b.createDataArrayFromData('testDataArray1', 'nix.DataArray', [1 2 3; 4 5 6]);
     extent = [4 6];
-    da.set_data_extent(extent);
-    assert(da.dataExtent(1) == extent(1) && size(da.read_all, 2) == extent(2));
+    da.setDataExtent(extent);
+    assert(da.dataExtent(1) == extent(1) && size(da.readAllData, 2) == extent(2));
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare DataArray entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -599,7 +599,7 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter sources
-function [] = test_filter_source( varargin )
+function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -307,8 +307,8 @@ function [] = testAddSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     getDataArray = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(isempty(getDataArray.sources));
@@ -357,7 +357,7 @@ function [] = testOpenSource( varargin )
     b = f.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
     sourceName = 'nestedSource';
-    nSource = s.create_source(sourceName, 'nixSource');
+    nSource = s.createSource(sourceName, 'nixSource');
 
     d = b.createDataArray('sourceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     d.add_source(nSource);
@@ -394,8 +394,8 @@ function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     getDataArray = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     getDataArray.add_source(s.sources{1}.id);
@@ -660,7 +660,7 @@ function [] = testFilterSource( varargin )
     d.add_source(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = main.create_source(subName, 'nixSource');
+    s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
     assert(isempty(f.blocks{1}.dataArrays{1}.filter_sources(nix.Filter.source, 'Do not exist')));

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -21,7 +21,7 @@ function [] = test_set_dimension( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
-    d1 = da.append_set_dimension();
+    d1 = da.appendSetDimension();
 
     assert(strcmp(d1.dimensionType, 'set'));
     assert(isempty(d1.labels));
@@ -55,7 +55,7 @@ function [] = test_sample_dimension( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
-    d1 = da.append_sampled_dimension(200);
+    d1 = da.appendSampledDimension(200);
 
     assert(strcmp(d1.dimensionType, 'sample'));
     assert(isempty(d1.label));
@@ -109,7 +109,7 @@ function [] = test_range_dimension( varargin )
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     ticks = [1 2 3 4];
-    d1 = da.append_range_dimension(ticks);
+    d1 = da.appendRangeDimension(ticks);
 
     assert(strcmp(d1.dimensionType, 'range'));
     assert(isempty(d1.label));

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -19,7 +19,7 @@ end
 function [] = test_set_dimension( varargin )
 %% Test: set dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('daTestBlock', 'test nixBlock');
+    b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array(...
         'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_set_dimension();
@@ -54,7 +54,7 @@ end
 function [] = test_sample_dimension( varargin )
 %% Test: sampled dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('daTestBlock', 'test nixBlock');
+    b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array(...
         'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_sampled_dimension(200);
@@ -108,7 +108,7 @@ end
 function [] = test_range_dimension( varargin )
 %% Test: range dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('daTestBlock', 'test nixBlock');
+    b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.create_data_array(...
         'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     ticks = [1 2 3 4];

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -7,16 +7,15 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestDimensions
-%TestDimensions tests for Dimensions
-%   Detailed explanation goes here
+% TestDimensions tests for Dimensions
 
     funcs = {};
-    funcs{end+1} = @test_set_dimension;
-    funcs{end+1} = @test_sample_dimension;
-    funcs{end+1} = @test_range_dimension;
+    funcs{end+1} = @testSetDimension;
+    funcs{end+1} = @testSampleDimension;
+    funcs{end+1} = @testRangeDimension;
 end
 
-function [] = test_set_dimension( varargin )
+function [] = testSetDimension( varargin )
 %% Test: set dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
@@ -50,7 +49,7 @@ function [] = test_set_dimension( varargin )
     end;
 end
 
-function [] = test_sample_dimension( varargin )
+function [] = testSampleDimension( varargin )
 %% Test: sampled dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
@@ -83,8 +82,8 @@ function [] = test_sample_dimension( varargin )
     assert(length(axis) == 10);
     assert(axis(end) == (length(axis) - 1) * d1.samplingInterval + d1.offset);
     
-    assert(d1.position_at(1) == d1.offset);
-    assert(d1.position_at(10) == d1.offset + 9 * d1.samplingInterval);
+    assert(d1.positionAt(1) == d1.offset);
+    assert(d1.positionAt(10) == d1.offset + 9 * d1.samplingInterval);
 
     d1.label = '';
     d1.unit = '';
@@ -99,11 +98,11 @@ function [] = test_sample_dimension( varargin )
     assert(axis(1) == 0);
     assert(axis(end) == (length(axis) - 1) * d1.samplingInterval + d1.offset);
     
-    assert(d1.position_at(1) == d1.offset);
-    assert(d1.position_at(10) == d1.offset + 9 * d1.samplingInterval);
+    assert(d1.positionAt(1) == d1.offset);
+    assert(d1.positionAt(10) == d1.offset + 9 * d1.samplingInterval);
 end
 
-function [] = test_range_dimension( varargin )
+function [] = testRangeDimension( varargin )
 %% Test: range dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
@@ -121,17 +120,17 @@ function [] = test_range_dimension( varargin )
     assert(length(axis) == 3);
     assert(axis(end) == ticks(length(axis)));
 
-    assert(d1.tick_at(1) == ticks(1));
-    assert(d1.tick_at(3) == ticks(3));
+    assert(d1.tickAt(1) == ticks(1));
+    assert(d1.tickAt(3) == ticks(3));
 
-    new_ticks = [5 6 7 8];
+    newTicks = [5 6 7 8];
     d1.label = 'foo';
     d1.unit = 'mV';
-    d1.ticks = new_ticks;
+    d1.ticks = newTicks;
     
     assert(strcmp(d1.label, 'foo'));
     assert(strcmp(d1.unit, 'mV'));
-    assert(isequal(d1.ticks, new_ticks));
+    assert(isequal(d1.ticks, newTicks));
     
     d1.label = '';
     d1.unit = '';

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -20,8 +20,7 @@ function [] = test_set_dimension( varargin )
 %% Test: set dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array(...
-        'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_set_dimension();
 
     assert(strcmp(d1.dimensionType, 'set'));
@@ -55,8 +54,7 @@ function [] = test_sample_dimension( varargin )
 %% Test: sampled dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array(...
-        'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     d1 = da.append_sampled_dimension(200);
 
     assert(strcmp(d1.dimensionType, 'sample'));
@@ -109,8 +107,7 @@ function [] = test_range_dimension( varargin )
 %% Test: range dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
-    da = b.create_data_array(...
-        'daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
     ticks = [1 2 3 4];
     d1 = da.append_range_dimension(ticks);
 

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -22,7 +22,7 @@ function [] = test_open_data ( varargin )
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
-    tmp = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     getFeature = t.features{1};
     assert(~isempty(getFeature.open_data));
@@ -35,7 +35,7 @@ function [] = test_get_set_link_type ( varargin )
     b = f.createBlock('featureTest', 'nixBlock');
     da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
-    feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    feat = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     try
         feat.linkType = '';
@@ -80,7 +80,7 @@ function [] = test_set_data ( varargin )
     da3 = b.createDataArray(daName3, daType, nix.DataType.Double, daData);
     da4 = b.createDataArray(daName4, daType, nix.DataType.Double, daData);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
-    feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    feat = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     assert(strcmp(feat.open_data.name, daName1));
     feat.set_data(da2);

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -20,11 +20,11 @@ end
 function [] = test_open_data ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    getTag = b.create_tag('featureTest', 'nixTag', [1, 2]);
-    tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createTag('featureTest', 'nixTag', [1, 2]);
+    tmp = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     
-    getFeature = getTag.features{1};
+    getFeature = t.features{1};
     assert(~isempty(getFeature.open_data));
 end
 
@@ -33,8 +33,8 @@ function [] = test_get_set_link_type ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    t = b.create_tag('featureTest', 'nixTag', [1, 2]);
+    da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createTag('featureTest', 'nixTag', [1, 2]);
     feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     try
@@ -75,11 +75,11 @@ function [] = test_set_data ( varargin )
     daData = [1 2 3 4 5 6];
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da1 = b.create_data_array(daName1, daType, nix.DataType.Double, daData);
-    da2 = b.create_data_array(daName2, daType, nix.DataType.Double, daData);
-    da3 = b.create_data_array(daName3, daType, nix.DataType.Double, daData);
-    da4 = b.create_data_array(daName4, daType, nix.DataType.Double, daData);
-    t = b.create_tag('featureTest', 'nixTag', [1, 2]);
+    da1 = b.createDataArray(daName1, daType, nix.DataType.Double, daData);
+    da2 = b.createDataArray(daName2, daType, nix.DataType.Double, daData);
+    da3 = b.createDataArray(daName3, daType, nix.DataType.Double, daData);
+    da4 = b.createDataArray(daName4, daType, nix.DataType.Double, daData);
+    t = b.createTag('featureTest', 'nixTag', [1, 2]);
     feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     assert(strcmp(feat.open_data.name, daName1));

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -19,7 +19,7 @@ end
 %% Test: Open data from feature
 function [] = test_open_data ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getTag = b.create_tag('featureTest', 'nixTag', [1, 2]);
     tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -32,7 +32,7 @@ end
 function [] = test_get_set_link_type ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_tag('featureTest', 'nixTag', [1, 2]);
     feat = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -74,7 +74,7 @@ function [] = test_set_data ( varargin )
     daType = 'nixDataArray';
     daData = [1 2 3 4 5 6];
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     da1 = b.create_data_array(daName1, daType, nix.DataType.Double, daData);
     da2 = b.create_data_array(daName2, daType, nix.DataType.Double, daData);
     da3 = b.create_data_array(daName3, daType, nix.DataType.Double, daData);

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -7,29 +7,28 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestFeature
-%TESTTag tests for Tag
-%   Detailed explanation goes here
+% TESTFEATURE tests for Feature
 
     funcs = {};
-    funcs{end+1} = @test_open_data;
-    funcs{end+1} = @test_get_set_link_type;
-    funcs{end+1} = @test_set_data;
+    funcs{end+1} = @testOpenData;
+    funcs{end+1} = @testHandleLinkType;
+    funcs{end+1} = @testSetData;
 end
 
 %% Test: Open data from feature
-function [] = test_open_data ( varargin )
+function [] = testOpenData ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
     tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
-    getFeature = t.features{1};
-    assert(~isempty(getFeature.open_data));
+    feat = t.features{1};
+    assert(~isempty(feat.openData));
 end
 
 %% Test: Get and set nix.LinkType
-function [] = test_get_set_link_type ( varargin )
+function [] = testHandleLinkType ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -65,7 +64,7 @@ function [] = test_get_set_link_type ( varargin )
 end
 
 %% Test: Set data by entity, ID and name
-function [] = test_set_data ( varargin )
+function [] = testSetData ( varargin )
     fileName = 'testRW.h5';
     daName1 = 'featTestDA1';
     daName2 = 'featTestDA2';
@@ -82,14 +81,14 @@ function [] = test_set_data ( varargin )
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
     feat = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
-    assert(strcmp(feat.open_data.name, daName1));
-    feat.set_data(da2);
-    assert(strcmp(f.blocks{1}.tags{1}.features{1}.open_data.name, daName2));
-    feat.set_data(da3.id);
-    assert(strcmp(f.blocks{1}.tags{1}.features{1}.open_data.name, daName3));
-    feat.set_data(da4.name);
+    assert(strcmp(feat.openData.name, daName1));
+    feat.setData(da2);
+    assert(strcmp(f.blocks{1}.tags{1}.features{1}.openData.name, daName2));
+    feat.setData(da3.id);
+    assert(strcmp(f.blocks{1}.tags{1}.features{1}.openData.name, daName3));
+    feat.setData(da4.name);
     
     clear feat t da4 da3 da2 da1 b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.tags{1}.features{1}.open_data.name, daName4));
+    assert(strcmp(f.blocks{1}.tags{1}.features{1}.openData.name, daName4));
 end

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -7,8 +7,7 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestFile
-%TESTFILE tests for File
-%   Detailed explanation goes here
+% TESTFILE tests for File
 
     funcs = {};
     funcs{end+1} = @testReadOnly;
@@ -419,17 +418,17 @@ function [] = testFindSection
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     sl1 = f.createSection('sectionLvl1', 'nixSection');
 
-    sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
-    sl22 = sl1.create_section('sectionLvl2_2', 'nixSection');
+    sl21 = sl1.createSection('sectionLvl2_1', 'nixSection');
+    sl22 = sl1.createSection('sectionLvl2_2', 'nixSection');
 
-    sl31 = sl21.create_section('sectionLvl3_1', 'nixSection');
-    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
-    sl33 = sl21.create_section('sectionLvl3_3', 'nixSection');
+    sl31 = sl21.createSection('sectionLvl3_1', 'nixSection');
+    sl32 = sl21.createSection('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.createSection('sectionLvl3_3', 'nixSection');
 
-    sl41 = sl31.create_section('sectionLvl4_1', 'nixSection');
-    sl42 = sl31.create_section('sectionLvl4_2', 'nixSection');
-    sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
-    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+    sl41 = sl31.createSection('sectionLvl4_1', 'nixSection');
+    sl42 = sl31.createSection('sectionLvl4_2', 'nixSection');
+    sl43 = sl31.createSection('sectionLvl4_3', 'nixSection');
+    sl44 = sl31.createSection('sectionLvl4_4', 'nixSection');
 
     % Check invalid entry
     err = 'Provide a valid search depth';
@@ -466,17 +465,17 @@ function [] = testFindSectionFiltered
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     sl1 = f.createSection('sectionLvl1', 'nixSection');
 
-    sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
-    sl22 = sl1.create_section('sectionLvl2_2', findSection);
+    sl21 = sl1.createSection('sectionLvl2_1', 'nixSection');
+    sl22 = sl1.createSection('sectionLvl2_2', findSection);
 
-    sl31 = sl21.create_section('sectionLvl3_1', 'nixSection');
-    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
-    sl33 = sl21.create_section('sectionLvl3_3', findSection);
+    sl31 = sl21.createSection('sectionLvl3_1', 'nixSection');
+    sl32 = sl21.createSection('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.createSection('sectionLvl3_3', findSection);
 
-    sl41 = sl31.create_section('sectionLvl4_1', 'nixSection');
-    sl42 = sl31.create_section('sectionLvl4_2', 'nixSection');
-    sl43 = sl31.create_section('sectionLvl4_3', findSection);
-    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+    sl41 = sl31.createSection('sectionLvl4_1', 'nixSection');
+    sl42 = sl31.createSection('sectionLvl4_2', 'nixSection');
+    sl43 = sl31.createSection('sectionLvl4_3', findSection);
+    sl44 = sl31.createSection('sectionLvl4_4', 'nixSection');
 
     % test find by id
     filtered = f.filterFindSections(1, nix.Filter.id, sl41.id);

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -316,8 +316,8 @@ function [] = testFilterSection( varargin )
     % test empty id filter
     assert(isempty(f.filterSections(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.filterSections(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.filterSections(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -373,8 +373,8 @@ function [] = testFilterBlock( varargin )
     % test empty id filter
     assert(isempty(f.filterBlocks(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.filterBlocks(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.filterBlocks(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -11,70 +11,70 @@ function funcs = TestFile
 %   Detailed explanation goes here
 
     funcs = {};
-    funcs{end+1} = @test_read_only;
-    funcs{end+1} = @test_read_write;
-    funcs{end+1} = @test_overwrite;
-    funcs{end+1} = @test_is_open;
-    funcs{end+1} = @test_file_mode;
-    funcs{end+1} = @test_validate;
-    funcs{end+1} = @test_create_block;
-    funcs{end+1} = @test_block_count;
-    funcs{end+1} = @test_create_section;
-    funcs{end+1} = @test_section_count;
-    funcs{end+1} = @test_fetch_block;
-    funcs{end+1} = @test_fetch_section;
-    funcs{end+1} = @test_open_section;
-    funcs{end+1} = @test_open_section_idx;
-    funcs{end+1} = @test_open_block;
-    funcs{end+1} = @test_open_block_idx;
-    funcs{end+1} = @test_delete_block;
-    funcs{end+1} = @test_delete_section;
-    funcs{end+1} = @test_has_block;
-    funcs{end+1} = @test_has_section;
-    funcs{end+1} = @test_filter_section;
-    funcs{end+1} = @test_filter_block;
-    funcs{end+1} = @test_find_section;
-    funcs{end+1} = @test_find_section_filtered;
+    funcs{end+1} = @testReadOnly;
+    funcs{end+1} = @testReadWrite;
+    funcs{end+1} = @testOverwrite;
+    funcs{end+1} = @testIsOpen;
+    funcs{end+1} = @testFileMode;
+    funcs{end+1} = @testValidate;
+    funcs{end+1} = @testCreateBlock;
+    funcs{end+1} = @testBlockCount;
+    funcs{end+1} = @testCreateSection;
+    funcs{end+1} = @testSectionCount;
+    funcs{end+1} = @testFetchBlock;
+    funcs{end+1} = @testFetchSection;
+    funcs{end+1} = @testOpenSection;
+    funcs{end+1} = @testOpenSectionIdx;
+    funcs{end+1} = @testOpenBlock;
+    funcs{end+1} = @testOpenBlockIdx;
+    funcs{end+1} = @testDeleteBlock;
+    funcs{end+1} = @testDeleteSection;
+    funcs{end+1} = @testHasBlock;
+    funcs{end+1} = @testHasSection;
+    funcs{end+1} = @testFilterSection;
+    funcs{end+1} = @testFilterBlock;
+    funcs{end+1} = @testFindSection;
+    funcs{end+1} = @testFindSectionFiltered;
 end
 
 %% Test: Open HDF5 file in ReadOnly mode
-function [] = test_read_only( varargin )
+function [] = testReadOnly( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
 end
 
 %% Test: Open HDF5 file in ReadWrite mode
-function [] = test_read_write( varargin )
+function [] = testReadWrite( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.ReadWrite);
 end
 
 %% Test: Open HDF5 file in Overwrite mode
-function [] = test_overwrite( varargin )
+function [] = testOverwrite( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
 end
 
 %% Test: File is open
-function [] = test_is_open( varargin )
+function [] = testIsOpen( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.ReadOnly);
-    assert(f.is_open());
+    assert(f.isOpen());
 end
 
 %% Test: File mode
-function [] = test_file_mode( varargin )
+function [] = testFileMode( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.file_mode() == nix.FileMode.ReadOnly);
+    assert(f.fileMode() == nix.FileMode.ReadOnly);
 
     clear f;
     f = nix.File(testFile, nix.FileMode.ReadWrite);
-    assert(f.file_mode() == nix.FileMode.ReadWrite);
+    assert(f.fileMode() == nix.FileMode.ReadWrite);
 
     clear f;
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    assert(f.file_mode() == nix.FileMode.Overwrite);
+    assert(f.fileMode() == nix.FileMode.Overwrite);
 end
 
 %% Test: Validate
-function [] = test_validate( varargin )
+function [] = testValidate( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     validation = f.validate();
@@ -87,327 +87,327 @@ function [] = test_validate( varargin )
 end
 
 %% Test: Create Block
-function [] = test_create_block( varargin )
-    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+function [] = testCreateBlock( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testBlock 1';
-    newBlock = test_file.create_block(useName, 'testType 1');
-    assert(strcmp(newBlock.name(), useName));
+    b = f.createBlock(useName, 'testType 1');
+    assert(strcmp(b.name(), useName));
 end
 
 %% Test: Block Count
-function [] = test_block_count( varargin )
+function [] = testBlockCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    assert(f.block_count() == 0);
-    b = f.create_block('testBlock 1', 'testType 1');
-    assert(f.block_count() == 1);
-    b = f.create_block('testBlock 2', 'testType 2');
+    assert(f.blockCount() == 0);
+    b = f.createBlock('testBlock 1', 'testType 1');
+    assert(f.blockCount() == 1);
+    b = f.createBlock('testBlock 2', 'testType 2');
 
     clear b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.block_count() == 2);
+    assert(f.blockCount() == 2);
 end
 
 %% Test: Create Section
-function [] = test_create_section( varargin )
-    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+function [] = testCreateSection( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testSection 1';
-    newSection = test_file.create_section(useName, 'testType 1');
+    newSection = f.createSection(useName, 'testType 1');
     assert(strcmp(newSection.name(), useName));
 end
 
 %% Test: Section Count
-function [] = test_section_count( varargin )
+function [] = testSectionCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    assert(f.section_count() == 0);
-    b = f.create_section('testSection 1', 'testType 1');
-    assert(f.section_count() == 1);
-    b = f.create_section('testSection 2', 'testType 2');
+    assert(f.sectionCount() == 0);
+    b = f.createSection('testSection 1', 'testType 1');
+    assert(f.sectionCount() == 1);
+    b = f.createSection('testSection 2', 'testType 2');
 
     clear b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.section_count() == 2);
+    assert(f.sectionCount() == 2);
 end
 
 %% Test: Fetch Block
-function [] = test_fetch_block( varargin )
+function [] = testFetchBlock( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     blockName = 'blockName';
     blockType = 'testBlock';
     f = nix.File(testFile, nix.FileMode.Overwrite);
     assert(isempty(f.blocks));
 
-    b1 = f.create_block(strcat(blockName, '1'), blockType);
+    b1 = f.createBlock(strcat(blockName, '1'), blockType);
     assert(size(f.blocks, 1) == 1);
 
-    check_file = f;
-    b2 = f.create_block(strcat(blockName, '2'), blockType);
+    checkFile = f;
+    b2 = f.createBlock(strcat(blockName, '2'), blockType);
     assert(size(f.blocks, 1) == 2);
-    assert(size(check_file.blocks, 1) == 2);
+    assert(size(checkFile.blocks, 1) == 2);
 
-    clear b2 b1 check_file f;
+    clear b2 b1 checkFile f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
     assert(size(f.blocks, 1) == 2);
 end
 
 %% Test: Fetch Block
-function [] = test_fetch_section( varargin )
+function [] = testFetchSection( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     sectionName = 'sectionName';
     sectionType = 'testSection';
     f = nix.File(testFile, nix.FileMode.Overwrite);
     assert(isempty(f.sections));
 
-    s1 = f.create_section(strcat(sectionName, '1'), sectionType);
+    s1 = f.createSection(strcat(sectionName, '1'), sectionType);
     assert(size(f.sections, 1) == 1);
 
-    check_file = f;
-    s2 = f.create_section(strcat(sectionName, '2'), sectionType);
+    checkFile = f;
+    s2 = f.createSection(strcat(sectionName, '2'), sectionType);
     assert(size(f.sections, 1) == 2);
-    assert(size(check_file.sections, 1) == 2);
+    assert(size(checkFile.sections, 1) == 2);
 
-    clear s2 s1 check_file f;
+    clear s2 s1 checkFile f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
     assert(size(f.sections, 1) == 2);
 end
 
 %% Test: Delete Block
-function [] = test_delete_block( varargin )
-    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+function [] = testDeleteBlock( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testBlock 1';
-    newBlock = test_file.create_block(useName, 'testType 1');
+    newBlock = f.createBlock(useName, 'testType 1');
     assert(strcmp(newBlock.name(), useName));
     
     %-- test delete block by object
-    checkDelete = test_file.delete_block(test_file.blocks{1});
+    checkDelete = f.deleteBlock(f.blocks{1});
     assert(checkDelete);
-    assert(size(test_file.blocks, 1) == 0);
+    assert(size(f.blocks, 1) == 0);
     
     %-- test delete block by id
-    newBlock = test_file.create_block('name', 'type');
-    checkDelete = test_file.delete_block(newBlock.id);
+    newBlock = f.createBlock('name', 'type');
+    checkDelete = f.deleteBlock(newBlock.id);
     assert(checkDelete);
-    assert(size(test_file.blocks, 1) == 0);
+    assert(size(f.blocks, 1) == 0);
 
     %-- test delete non existing block
-    checkDelete = test_file.delete_block('I do not exist');
+    checkDelete = f.deleteBlock('I do not exist');
     assert(~checkDelete);
 end
 
 %% Test: Delete Section
-function [] = test_delete_section( varargin )
-    test_file = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+function [] = testDeleteSection( varargin )
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     useName = 'testSection 1';
-    newSection = test_file.create_section(useName, 'testType 1');
+    newSection = f.createSection(useName, 'testType 1');
     assert(strcmp(newSection.name(), useName));
     
     %-- test delete section by object
-    checkDelete = test_file.delete_section(test_file.sections{1});
+    checkDelete = f.deleteSection(f.sections{1});
     assert(checkDelete);
-    assert(size(test_file.sections, 1) == 0);
+    assert(size(f.sections, 1) == 0);
     
     %-- test delete section by id
-    newSection = test_file.create_section('name', 'type');
-    checkDelete = test_file.delete_section(newSection.id);
+    newSection = f.createSection('name', 'type');
+    checkDelete = f.deleteSection(newSection.id);
     assert(checkDelete);
-    assert(size(test_file.sections, 1) == 0);
+    assert(size(f.sections, 1) == 0);
 
     %-- test delete non existing section
-    checkDelete = test_file.delete_section('I do not exist');
+    checkDelete = f.deleteSection('I do not exist');
     assert(~checkDelete);
 end
 
-function [] = test_open_section( varargin )
+function [] = testOpenSection( varargin )
 %% Test open section
-    test_file = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
-    getSection = test_file.open_section(test_file.sections{1,1}.id);
+    f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
+    getSection = f.openSection(f.sections{1,1}.id);
     assert(strcmp(getSection.name, 'General'));
     
     %-- test open non existing section
-    getSection = test_file.open_section('I dont exist');
+    getSection = f.openSection('I dont exist');
     assert(isempty(getSection));
 end
 
-function [] = test_open_section_idx( varargin )
+function [] = testOpenSectionIdx( varargin )
 %% Test Open Section by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s1 = f.create_section('testSection1', 'nixSection');
-    s2 = f.create_section('testSection2', 'nixSection');
-    s3 = f.create_section('testSection3', 'nixSection');
+    s1 = f.createSection('testSection1', 'nixSection');
+    s2 = f.createSection('testSection2', 'nixSection');
+    s3 = f.createSection('testSection3', 'nixSection');
 
-    assert(strcmp(f.open_section_idx(1).name, s1.name));
-    assert(strcmp(f.open_section_idx(2).name, s2.name));
-    assert(strcmp(f.open_section_idx(3).name, s3.name));
+    assert(strcmp(f.openSectionIdx(1).name, s1.name));
+    assert(strcmp(f.openSectionIdx(2).name, s2.name));
+    assert(strcmp(f.openSectionIdx(3).name, s3.name));
 end
 
-function [] = test_open_block( varargin )
+function [] = testOpenBlock( varargin )
 %% Test Open Block by ID or name
-    test_file = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
+    f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
 
-    getBlockByID = test_file.open_block(test_file.blocks{1,1}.id);
+    getBlockByID = f.openBlock(f.blocks{1,1}.id);
     assert(strcmp(getBlockByID.id, '7b59c0b9-b200-4b53-951d-6851dbd1cdc8'));
 
-    getBlockByName = test_file.open_block(test_file.blocks{1,1}.name);
+    getBlockByName = f.openBlock(f.blocks{1,1}.name);
     assert(strcmp(getBlockByName.name, 'joe097'));
 
     %-- test open non existing block
-    getBlock = test_file.open_block('I dont exist');
+    getBlock = f.openBlock('I dont exist');
     assert(isempty(getBlock));
 end
 
-function [] = test_open_block_idx( varargin )
+function [] = testOpenBlockIdx( varargin )
 %% Test Open Block by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
-    b3 = f.create_block('testBlock3', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
+    b3 = f.createBlock('testBlock3', 'nixBlock');
 
-    assert(strcmp(f.open_block_idx(1).name, b1.name));
-    assert(strcmp(f.open_block_idx(2).name, b2.name));
-    assert(strcmp(f.open_block_idx(3).name, b3.name));
+    assert(strcmp(f.openBlockIdx(1).name, b1.name));
+    assert(strcmp(f.openBlockIdx(2).name, b2.name));
+    assert(strcmp(f.openBlockIdx(3).name, b3.name));
 end
 
 %% Test: nix.File has nix.Block by ID or name
-function [] = test_has_block( varargin )
+function [] = testHasBlock( varargin )
     fileName = 'testRW.h5';
-    blockName = 'has_blockTest';
+    blockName = 'hasBlockTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block(blockName, 'nixBlock');
+    b = f.createBlock(blockName, 'nixBlock');
     bID = b.id;
 
-    assert(~f.has_block('I do not exist'));
-    assert(f.has_block(blockName));
+    assert(~f.hasBlock('I do not exist'));
+    assert(f.hasBlock(blockName));
 
     clear b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.has_block(bID));
+    assert(f.hasBlock(bID));
 end
 
 %% Test: nix.File has nix.Section by ID or name
-function [] = test_has_section( varargin )
+function [] = testHasSection( varargin )
     fileName = 'testRW.h5';
-    secName = 'has_sectionTest';
+    secName = 'hasSectionTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    s = f.create_section(secName, 'nixSection');
+    s = f.createSection(secName, 'nixSection');
     sID = s.id;
 
-    assert(~f.has_section('I do not exist'));
-    assert(f.has_section(secName));
+    assert(~f.hasSection('I do not exist'));
+    assert(f.hasSection(secName));
 
     clear s f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.has_section(sID));
+    assert(f.hasSection(sID));
 end
 
-function [] = test_filter_section( varargin )
+function [] = testFilterSection( varargin )
 %% Test: filter Sections
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
 
-    s = f.create_section(filterName, 'nixSection');
+    s = f.createSection(filterName, 'nixSection');
     filterID = s.id;
-	s = f.create_section('testSection1', filterType);
+	s = f.createSection('testSection1', filterType);
     filterIDs = {filterID, s.id};
-    s = f.create_section('testSection2', filterType);
+    s = f.createSection('testSection2', filterType);
 
     % ToDO add basic filter crash tests
     
     % test empty id filter
-    assert(isempty(f.filter_sections(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.filterSections(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.filter_sections(nix.Filter.accept_all, '');
+    filtered = f.filterSections(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.filter_sections(nix.Filter.id, filterID);
+    filtered = f.filterSections(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.filter_sections(nix.Filter.ids, filterIDs);
+    filtered = f.filterSections(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.filter_sections(nix.Filter.name, filterName);
+    filtered  = f.filterSections(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.filter_sections(nix.Filter.type, filterType);
+    filtered = f.filterSections(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
     
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.filter_sections(nix.Filter.metadata, 'someMetadata');
+        f.filterSections(nix.Filter.metadata, 'someMetadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
     
     % test fail on nix.Filter.source
     try
-        f.filter_sections(nix.Filter.source, 'someSource');
+        f.filterSections(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
 end
 
-function [] = test_filter_block( varargin )
+function [] = testFilterBlock( varargin )
 %% Test: filter Blocks
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
 
-    b = f.create_block(filterName, 'nixBlock');
+    b = f.createBlock(filterName, 'nixBlock');
     filterID = b.id;
-	b = f.create_block('testBlock1', filterType);
+	b = f.createBlock('testBlock1', filterType);
     filterIDs = {filterID, b.id};
-    b = f.create_block('testBlock2', filterType);
+    b = f.createBlock('testBlock2', filterType);
 
     % ToDO add basic filter crash tests
     
     % test empty id filter
-    assert(isempty(f.filter_blocks(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.filterBlocks(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.filter_blocks(nix.Filter.accept_all, '');
+    filtered = f.filterBlocks(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.filter_blocks(nix.Filter.id, filterID);
+    filtered = f.filterBlocks(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.filter_blocks(nix.Filter.ids, filterIDs);
+    filtered = f.filterBlocks(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.filter_blocks(nix.Filter.name, filterName);
+    filtered  = f.filterBlocks(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.filter_blocks(nix.Filter.type, filterType);
+    filtered = f.filterBlocks(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
     
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.filter_blocks(nix.Filter.metadata, 'someMetadata');
+        f.filterBlocks(nix.Filter.metadata, 'someMetadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
     
     % test fail on nix.Filter.source
     try
-        f.filter_blocks(nix.Filter.source, 'someSource');
+        f.filterBlocks(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end
@@ -415,9 +415,9 @@ function [] = test_filter_block( varargin )
 end
 
 %% Test: Find sections w/o filter
-function [] = test_find_section
+function [] = testFindSection
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    sl1 = f.create_section('sectionLvl1', 'nixSection');
+    sl1 = f.createSection('sectionLvl1', 'nixSection');
 
     sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
     sl22 = sl1.create_section('sectionLvl2_2', 'nixSection');
@@ -434,37 +434,37 @@ function [] = test_find_section
     % Check invalid entry
     err = 'Provide a valid search depth';
     try
-        f.find_sections('hurra');
+        f.findSections('hurra');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % find all
-    filtered = f.find_sections(5);
+    filtered = f.findSections(5);
     assert(size(filtered, 1) == 10);
 
     % find until level 4
-    filtered = f.find_sections(4);
+    filtered = f.findSections(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
-    filtered = f.find_sections(3);
+    filtered = f.findSections(3);
     assert(size(filtered, 1) == 6);
 
     % find until level 2
-    filtered = f.find_sections(2);
+    filtered = f.findSections(2);
     assert(size(filtered, 1) == 3);
 
     % find until level 1
-    filtered = f.find_sections(1);
+    filtered = f.findSections(1);
     assert(size(filtered, 1) == 1);
 end
 
 %% Test: Find sections with filter
-function [] = test_find_section_filtered
+function [] = testFindSectionFiltered
     findSection = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    sl1 = f.create_section('sectionLvl1', 'nixSection');
+    sl1 = f.createSection('sectionLvl1', 'nixSection');
 
     sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
     sl22 = sl1.create_section('sectionLvl2_2', findSection);
@@ -479,44 +479,44 @@ function [] = test_find_section_filtered
     sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
 
     % test find by id
-    filtered = f.find_filtered_sections(1, nix.Filter.id, sl41.id);
+    filtered = f.filterFindSections(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = f.find_filtered_sections(4, nix.Filter.id, sl41.id);
+    filtered = f.filterFindSections(4, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = f.find_filtered_sections(1, nix.Filter.ids, filterids);
+    filtered = f.filterFindSections(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = f.find_filtered_sections(4, nix.Filter.ids, filterids);
+    filtered = f.filterFindSections(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = f.find_filtered_sections(1, nix.Filter.name, sl41.name);
+    filtered = f.filterFindSections(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = f.find_filtered_sections(4, nix.Filter.name, sl41.name);
+    filtered = f.filterFindSections(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = f.find_filtered_sections(1, nix.Filter.type, findSection);
+    filtered = f.filterFindSections(1, nix.Filter.type, findSection);
     assert(isempty(filtered));
-    filtered = f.find_filtered_sections(4, nix.Filter.type, findSection);
+    filtered = f.filterFindSections(4, nix.Filter.type, findSection);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSection));
 
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.find_filtered_sections(1, nix.Filter.metadata, 'metadata');
+        f.filterFindSections(1, nix.Filter.metadata, 'metadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        f.find_filtered_sections(1, nix.Filter.source, 'source');
+        f.filterFindSections(1, nix.Filter.source, 'source');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -6,8 +6,9 @@
 % modification, are permitted under the terms of the BSD License. See
 % LICENSE file in the root of the Project.
 
-%% TESTFILE Tests for the nix.Group object
 function funcs = TestGroup
+%% TESTGROUP Tests for the nix.Group object
+
     funcs = {};
     funcs{end+1} = @testAttributes;
     funcs{end+1} = @testAddDataArray;
@@ -623,8 +624,8 @@ function [] = testAddSource ( varargin )
     
     assert(isempty(g.sources));
     assert(isempty(f.blocks{1}.groups{1}.sources));
-    g.add_source(s.sources{1}.id);
-    g.add_source(s.sources{2});
+    g.addSource(s.sources{1}.id);
+    g.addSource(s.sources{2});
     assert(size(g.sources, 1) == 2);
     assert(size(f.blocks{1}.groups{1}.sources, 1) == 2);
     
@@ -646,20 +647,20 @@ function [] = testAddSources ( varargin )
     assert(isempty(g.sources));
 
     try
-        g.add_sources('hurra');
+        g.addSources('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(g.sources));
 
     try
-        g.add_sources({12, 13});
+        g.addSources({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.Source')));
     end;
     assert(isempty(g.sources));
 
-    g.add_sources(b.sources());
+    g.addSources(b.sources());
     assert(size(g.sources, 1) == 3);
 
     clear g tmp b f;
@@ -675,17 +676,17 @@ function [] = testRemoveSource ( varargin )
     tmp = s.createSource('nestedSource1', 'nixSource');
     tmp = s.createSource('nestedSource2', 'nixSource');
     g = b.createGroup('sourceTest', 'nixGroup');
-    g.add_source(s.sources{1}.id);
-    g.add_source(s.sources{2});
+    g.addSource(s.sources{1}.id);
+    g.addSource(s.sources{2});
 
     assert(size(g.sources,1) == 2);
-    g.remove_source(s.sources{2});
+    g.removeSource(s.sources{2});
     assert(size(g.sources,1) == 1);
 
-    g.remove_source(s.sources{1}.id);
+    g.removeSource(s.sources{1}.id);
     assert(isempty(g.sources));
 
-    assert(g.remove_source('I do not exist'));
+    assert(g.removeSource('I do not exist'));
     assert(size(s.sources, 1) == 2);
 end
 
@@ -697,15 +698,17 @@ function [] = testHasSource( varargin )
     b = f.createBlock('testblock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     s = b.createSource(sName, 'nixSource');
-    g.add_source(b.sources{1}.id)
+    g.addSource(b.sources{1}.id)
 
-    assert(~g.has_source('I do not exist'));
-    assert(g.has_source(s.id));
-    assert(g.has_source(s));
+    assert(~g.hasSource('I do not exist'));
+    assert(g.hasSource(s.id));
+    assert(g.hasSource(s));
+    assert(~g.hasSource(sName));
 
     clear s g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
     assert(f.blocks{1}.hasSource(sName));
+    assert(~f.blocks{1}.groups{1}.hasSource(sName));
 end
 
 %% Test: fetch sources
@@ -718,9 +721,9 @@ function [] = testFetchSources( varargin )
     tmp = s.createSource('nestedsource3', 'nixSource');
     g = b.createGroup('sourceTest', 'nixGroup');
 
-    g.add_source(s.sources{1});
-    g.add_source(s.sources{2});
-    g.add_source(s.sources{3});
+    g.addSource(s.sources{1});
+    g.addSource(s.sources{2});
+    g.addSource(s.sources{3});
     assert(size(g.sources, 1) == 3);
 end
 
@@ -733,16 +736,16 @@ function [] = testOpenSource( varargin )
     nSource = s.createSource(sourceName, 'nixSource');
 
     g = b.createGroup('sourceTest', 'nixGroup');
-    g.add_source(s.sources{1});
+    g.addSource(s.sources{1});
 
     % -- test get source by ID
-    assert(~isempty(g.open_source(nSource.id)));
+    assert(~isempty(g.openSource(nSource.id)));
 
     % -- test get source by name
-    assert(~isempty(g.open_source(sourceName)));
+    assert(~isempty(g.openSource(sourceName)));
 
     %-- test open non existing source
-    getNonSource = g.open_source('I do not exist');
+    getNonSource = g.openSource('I do not exist');
     assert(isempty(getNonSource));
 end
 
@@ -753,14 +756,14 @@ function [] = testSourceCount( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     
-    assert(g.source_count() == 0);
-    g.add_source(b.createSource('testSource1', 'nixSource'));
-    assert(g.source_count() == 1);
-    g.add_source(b.createSource('testSource2', 'nixSource'));
+    assert(g.sourceCount() == 0);
+    g.addSource(b.createSource('testSource1', 'nixSource'));
+    assert(g.sourceCount() == 1);
+    g.addSource(b.createSource('testSource2', 'nixSource'));
     
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.groups{1}.source_count() == 2);
+    assert(f.blocks{1}.groups{1}.sourceCount() == 2);
 end
 
 
@@ -866,13 +869,13 @@ function [] = testOpenSourceIdx( varargin )
     s1 = b.createSource('testSource1', 'nixSource');
     s2 = b.createSource('testSource2', 'nixSource');
     s3 = b.createSource('testSource3', 'nixSource');
-    g.add_source(s1);
-    g.add_source(s2);
-    g.add_source(s3);
+    g.addSource(s1);
+    g.addSource(s2);
+    g.addSource(s3);
 
-    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(1).name, s1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(2).name, s2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(3).name, s3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openSourceIdx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openSourceIdx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openSourceIdx(3).name, s3.name));
 end
 
 function [] = testCompare( varargin )
@@ -898,69 +901,69 @@ function [] = testFilterSource( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     s = b.createSource(filterName, 'nixSource');
-    g.add_source(s);
+    g.addSource(s);
     filterID = s.id;
 	s = b.createSource('testSource1', filterType);
-    g.add_source(s);
+    g.addSource(s);
     filterIDs = {filterID, s.id};
     s = b.createSource('testSource2', filterType);
-    g.add_source(s);
+    g.addSource(s);
     
     % test empty id filter
-    assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.groups{1}.filter_sources(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.groups{1}.filterSources(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     mainSource = b.createSource(mainName, 'nixSource');
-    g.add_source(mainSource);
+    g.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.groups{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     mainSource = b.createSource(mainName, 'nixSource');
-    g.add_source(mainSource);
+    g.addSource(mainSource);
     mainID = mainSource.id;
     subName = 'testSubSource1';
     s = mainSource.createSource(subName, 'nixSource');
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, 'Do not exist')));
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, subName);
+    assert(isempty(f.blocks{1}.groups{1}.filterSources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.source, subName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, mainID));
 
-    filtered = f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, subID);
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
@@ -1028,7 +1031,7 @@ function [] = testFilterTag( varargin )
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    main.add_source(s);
+    main.addSource(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterTags(nix.Filter.source, 'Do not exist')));
@@ -1103,7 +1106,7 @@ function [] = testFilterMultiTag( varargin )
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    main.add_source(s);
+    main.addSource(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.source, 'Do not exist')));
@@ -1177,7 +1180,7 @@ function [] = testFilterDataArray( varargin )
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    main.add_source(s);
+    main.addSource(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.source, 'Do not exist')));

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -58,7 +58,7 @@ function [] = test_attrs( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    b.create_group(groupName, groupType);
+    b.createGroup(groupName, groupType);
 
     testGroup = b.groups{1};
     assert(~isempty(testGroup.id));
@@ -92,8 +92,8 @@ function [] = test_add_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
-    g = b.create_group('testGroup', 'nixGroup');
+    da = b.createDataArray(daName, daType, nix.DataType.Double, [2 3]);
+    g = b.createGroup('testGroup', 'nixGroup');
 
     assert(isempty(g.dataArrays));
     assert(isempty(f.blocks{1}.groups{1}.dataArrays));
@@ -111,10 +111,10 @@ function [] = test_add_data_arrays ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    tmp = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [2 3]);
-    tmp = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [2 3]);
-    tmp = b.create_data_array('testDataArray3', 'nixDataArray', nix.DataType.Double, [2 3]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    tmp = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [2 3]);
+    tmp = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [2 3]);
+    tmp = b.createDataArray('testDataArray3', 'nixDataArray', nix.DataType.Double, [2 3]);
 
     assert(isempty(g.dataArrays));
 
@@ -148,9 +148,9 @@ function [] = test_get_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
+    da = b.createDataArray(daName, daType, nix.DataType.Double, [2 3]);
     daID = da.id;
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     g.add_data_array(da);
 
     testClass = 'nix.DataArray';
@@ -173,10 +173,10 @@ function [] = test_remove_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da1 = b.create_data_array(daName1, daType, nix.DataType.Double, 1);
-    da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
-    da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
-    g = b.create_group('testGroup', 'nixGroup');
+    da1 = b.createDataArray(daName1, daType, nix.DataType.Double, 1);
+    da2 = b.createDataArray(daName2, daType, nix.DataType.Double, [2 3]);
+    da3 = b.createDataArray(daName3, daType, nix.DataType.Double, [4 5 6]);
+    g = b.createGroup('testGroup', 'nixGroup');
     g.add_data_array(da1);
     g.add_data_array(da2);
     g.add_data_array(da3);
@@ -209,17 +209,17 @@ function [] = test_update_linked_data_array( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da1 = b.create_data_array(daName1, daType, nix.DataType.Double, [1]);
-    da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
-    da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
-    g = b.create_group('testGroup', 'nixGroup');
+    da1 = b.createDataArray(daName1, daType, nix.DataType.Double, [1]);
+    da2 = b.createDataArray(daName2, daType, nix.DataType.Double, [2 3]);
+    da3 = b.createDataArray(daName3, daType, nix.DataType.Double, [4 5 6]);
+    g = b.createGroup('testGroup', 'nixGroup');
     g.add_data_array(da1);
     g.add_data_array(da2);
     g.add_data_array(da3);
 
     %-- test remove linked DataArray from Block
     assert(size(b.dataArrays, 1) == 3);
-    b.delete_data_array(da1);
+    b.deleteDataArray(da1);
     assert(size(b.dataArrays, 1) == 2)
     assert(isempty(g.get_data_array(daName1)));
     assert(~isempty(g.get_data_array(daName2)));
@@ -227,16 +227,16 @@ function [] = test_update_linked_data_array( varargin )
     %-- test udpate linked DataArray
     upDADefFromGroup = 'def 2';
     g.get_data_array(daName2).definition = upDADefFromGroup;
-    assert(strcmp(b.data_array(daName2).definition, upDADefFromGroup));
+    assert(strcmp(b.openDataArray(daName2).definition, upDADefFromGroup));
 
     upDADefFromBlock = 'def 3';
-    b.data_array(daName3).definition = upDADefFromBlock;
+    b.openDataArray(daName3).definition = upDADefFromBlock;
     assert(strcmp(g.get_data_array(daName3).definition, upDADefFromBlock));
 
     clear da1 da2 da3 g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.data_array(daName2).definition, upDADefFromGroup));
-    assert(strcmp(f.blocks{1}.data_array(daName3).definition, upDADefFromBlock));
+    assert(strcmp(f.blocks{1}.openDataArray(daName2).definition, upDADefFromGroup));
+    assert(strcmp(f.blocks{1}.openDataArray(daName3).definition, upDADefFromBlock));
 end
 
 %% Test: DataArray count
@@ -244,12 +244,12 @@ function [] = test_data_array_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     
     assert(g.data_array_count() == 0);
-    g.add_data_array(b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
+    g.add_data_array(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
     assert(g.data_array_count() == 1);
-    g.add_data_array(b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
+    g.add_data_array(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
 
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -264,10 +264,10 @@ function [] = test_add_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    t1 = b.create_tag(tagName1, 'nixTag', [1.0 1.2 1.3 15.9]);
-    t2 = b.create_tag(tagName2, 'nixTag', [1.0 1.2 1.3 15.9]);
+    t1 = b.createTag(tagName1, 'nixTag', [1.0 1.2 1.3 15.9]);
+    t2 = b.createTag(tagName2, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t2.id;
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     assert(isempty(g.tags));
     assert(isempty(f.blocks{1}.groups{1}.tags));
     g.add_tag(t1);
@@ -288,10 +288,10 @@ function [] = test_add_tags ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    tmp = b.create_tag('testTag1', 'nixTag', [1.0 1.2]);
-    tmp = b.create_tag('testTag2', 'nixTag', [1.0 1.2]);
-    tmp = b.create_tag('testTag3', 'nixTag', [1.0 1.2]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    tmp = b.createTag('testTag1', 'nixTag', [1.0 1.2]);
+    tmp = b.createTag('testTag2', 'nixTag', [1.0 1.2]);
+    tmp = b.createTag('testTag3', 'nixTag', [1.0 1.2]);
 
     assert(isempty(g.tags));
 
@@ -324,8 +324,8 @@ function [] = test_has_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    t = b.create_tag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    t = b.createTag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     g.add_tag(t);
 
     assert(g.has_tag(b.tags{1}.id));
@@ -340,8 +340,8 @@ function [] = test_get_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    t = b.create_tag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    t = b.createTag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t.id;
 
     assert(isempty(f.blocks{1}.groups{1}.get_tag(tID)));
@@ -363,10 +363,10 @@ function [] = test_remove_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    t1 = b.create_tag(tagName1, tagType, [1.0 1.2 1.3 15.9]);
-    t2 = b.create_tag(tagName2, tagType, [1.0 1.2 1.3 15.9]);
-    t3 = b.create_tag(tagName3, tagType, [1.0 1.2 1.3 15.9]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    t1 = b.createTag(tagName1, tagType, [1.0 1.2 1.3 15.9]);
+    t2 = b.createTag(tagName2, tagType, [1.0 1.2 1.3 15.9]);
+    t3 = b.createTag(tagName3, tagType, [1.0 1.2 1.3 15.9]);
     g.add_tag(t1);
     g.add_tag(t2);
     g.add_tag(t3);
@@ -399,12 +399,12 @@ function [] = test_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     
     assert(g.tag_count() == 0);
-    g.add_tag(b.create_tag('testTag1', 'nixTag', [1 2 3]));
+    g.add_tag(b.createTag('testTag1', 'nixTag', [1 2 3]));
     assert(g.tag_count() == 1);
-    g.add_tag(b.create_tag('testTag2', 'nixTag', [1 2 3]));
+    g.add_tag(b.createTag('testTag2', 'nixTag', [1 2 3]));
 
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -420,13 +420,13 @@ function [] = test_add_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
-    tmp = b.create_multi_tag(tagName2, tagType, b.dataArrays{2});
-    g = b.create_group('testGroup', 'nixGroup');
+    tmp = b.createMultiTag(tagName1, tagType, b.dataArrays{1});
+    tmp = b.createMultiTag(tagName2, tagType, b.dataArrays{2});
+    g = b.createGroup('testGroup', 'nixGroup');
 
     assert(isempty(g.multiTags));
     assert(isempty(f.blocks{1}.groups{1}.multiTags));
@@ -449,12 +449,12 @@ function [] = test_add_multi_tags ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    tmp = b.create_data_array(...
+    g = b.createGroup('testGroup', 'nixGroup');
+    tmp = b.createDataArray(...
         'testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_multi_tag('testMultiTag1', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_multi_tag('testMultiTag2', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_multi_tag('testMultiTag3', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createMultiTag('testMultiTag1', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createMultiTag('testMultiTag2', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createMultiTag('testMultiTag3', 'nixMultiTag', b.dataArrays{1});
 
     assert(isempty(g.multiTags));
 
@@ -489,13 +489,13 @@ function [] = test_has_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'mTagTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
-    tmp = b.create_multi_tag(tagName2, tagType, b.dataArrays{2});
-    g = b.create_group('testGroup', 'nixGroup');
+    tmp = b.createMultiTag(tagName1, tagType, b.dataArrays{1});
+    tmp = b.createMultiTag(tagName2, tagType, b.dataArrays{2});
+    g = b.createGroup('testGroup', 'nixGroup');
 
     g.add_multi_tag(b.multiTags{1});
     assert(g.has_multi_tag(b.multiTags{1}.id));
@@ -512,10 +512,10 @@ function [] = test_get_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array(...
+    da = b.createDataArray(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag(tagName, tagType, b.dataArrays{1});
-    g = b.create_group('testGroup', 'nixGroup');
+    t = b.createMultiTag(tagName, tagType, b.dataArrays{1});
+    g = b.createGroup('testGroup', 'nixGroup');
 
     g.add_multi_tag(b.multiTags{1});
     assert(strcmp(f.blocks{1}.groups{1}.get_multi_tag(t.id).name, tagName));
@@ -537,12 +537,12 @@ function [] = test_remove_multi_tag( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    da = b.create_data_array(...
+    da = b.createDataArray(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t1 = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
-    t2 = b.create_multi_tag(tagName2, tagType, b.dataArrays{1});
-    t3 = b.create_multi_tag(tagName3, tagType, b.dataArrays{1});
-    g = b.create_group('testGroup', 'nixGroup');
+    t1 = b.createMultiTag(tagName1, tagType, b.dataArrays{1});
+    t2 = b.createMultiTag(tagName2, tagType, b.dataArrays{1});
+    t3 = b.createMultiTag(tagName3, tagType, b.dataArrays{1});
+    g = b.createGroup('testGroup', 'nixGroup');
     g.add_multi_tag(t1);
     g.add_multi_tag(t2);
     g.add_multi_tag(t3);
@@ -581,13 +581,13 @@ function [] = test_multi_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
     assert(g.multi_tag_count() == 0);
-    g.add_multi_tag(b.create_multi_tag('testMultiTag1', 'nixMultiTag', da));
+    g.add_multi_tag(b.createMultiTag('testMultiTag1', 'nixMultiTag', da));
     assert(g.multi_tag_count() == 1);
-    g.add_multi_tag(b.create_multi_tag('testMultiTag2', 'nixMultiTag', da));
+    g.add_multi_tag(b.createMultiTag('testMultiTag2', 'nixMultiTag', da));
 
     clear da g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -600,10 +600,10 @@ function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    s = b.create_source('sourceTest', 'nixSource');
+    s = b.createSource('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
-    g = b.create_group('sourceTest', 'nixGroup');
+    g = b.createGroup('sourceTest', 'nixGroup');
     
     assert(isempty(g.sources));
     assert(isempty(f.blocks{1}.groups{1}.sources));
@@ -622,10 +622,10 @@ function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('sourceTest', 'nixGroup');
-    tmp = b.create_source('testSource1', 'nixSource');
-    tmp = b.create_source('testSource2', 'nixSource');
-    tmp = b.create_source('testSource3', 'nixSource');
+    g = b.createGroup('sourceTest', 'nixGroup');
+    tmp = b.createSource('testSource1', 'nixSource');
+    tmp = b.createSource('testSource2', 'nixSource');
+    tmp = b.createSource('testSource3', 'nixSource');
 
     assert(isempty(g.sources));
 
@@ -655,10 +655,10 @@ end
 function [] = test_remove_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('test', 'nixBlock');
-    s = b.create_source('test', 'nixSource');
+    s = b.createSource('test', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
-    g = b.create_group('sourceTest', 'nixGroup');
+    g = b.createGroup('sourceTest', 'nixGroup');
     g.add_source(s.sources{1}.id);
     g.add_source(s.sources{2});
 
@@ -679,8 +679,8 @@ function [] = test_has_source( varargin )
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    s = b.create_source(sName, 'nixSource');
+    g = b.createGroup('testGroup', 'nixGroup');
+    s = b.createSource(sName, 'nixSource');
     g.add_source(b.sources{1}.id)
 
     assert(~g.has_source('I do not exist'));
@@ -689,18 +689,18 @@ function [] = test_has_source( varargin )
 
     clear s g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.has_source(sName));
+    assert(f.blocks{1}.hasSource(sName));
 end
 
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('test', 'nixBlock');
-    s = b.create_source('test','nixSource');
+    s = b.createSource('test','nixSource');
     tmp = s.create_source('nestedsource1', 'nixSource');
     tmp = s.create_source('nestedsource2', 'nixSource');
     tmp = s.create_source('nestedsource3', 'nixSource');
-    g = b.create_group('sourceTest', 'nixGroup');
+    g = b.createGroup('sourceTest', 'nixGroup');
 
     g.add_source(s.sources{1});
     g.add_source(s.sources{2});
@@ -712,11 +712,11 @@ end
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = test_file.createBlock('test', 'nixBlock');
-    s = b.create_source('test', 'nixSource');
+    s = b.createSource('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
 
-    g = b.create_group('sourceTest', 'nixGroup');
+    g = b.createGroup('sourceTest', 'nixGroup');
     g.add_source(s.sources{1});
 
     % -- test get source by ID
@@ -735,12 +735,12 @@ function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     
     assert(g.source_count() == 0);
-    g.add_source(b.create_source('testSource1', 'nixSource'));
+    g.add_source(b.createSource('testSource1', 'nixSource'));
     assert(g.source_count() == 1);
-    g.add_source(b.create_source('testSource2', 'nixSource'));
+    g.add_source(b.createSource('testSource2', 'nixSource'));
     
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -758,7 +758,7 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection(secName1, 'nixSection');
     tmp = f.createSection(secName2, 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     assert(isempty(g.open_metadata));
     assert(isempty(f.blocks{1}.groups{1}.open_metadata))
     
@@ -784,7 +784,7 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
+    g = b.createGroup('testGroup', 'nixGroup');
     g.set_metadata(f.sections{1});
 
     assert(strcmp(g.open_metadata.name, 'testSection'));
@@ -794,10 +794,10 @@ function [] = test_open_data_array_idx( varargin )
 %% Test Open DataArray by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    d1 = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
-    d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
-    d3 = b.create_data_array('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
+    d2 = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
+    d3 = b.createDataArray('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
     g.add_data_array(d1);
     g.add_data_array(d2);
     g.add_data_array(d3);
@@ -811,10 +811,10 @@ function [] = test_open_tag_idx( varargin )
 %% Test Open Tag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    t1 = b.create_tag('testTag1', 'nixTag', [1 2]);
-    t2 = b.create_tag('testTag2', 'nixTag', [1 2]);
-    t3 = b.create_tag('testTag3', 'nixTag', [1 2]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    t1 = b.createTag('testTag1', 'nixTag', [1 2]);
+    t2 = b.createTag('testTag2', 'nixTag', [1 2]);
+    t3 = b.createTag('testTag3', 'nixTag', [1 2]);
     g.add_tag(t1);
     g.add_tag(t2);
     g.add_tag(t3);
@@ -828,11 +828,11 @@ function [] = test_open_multi_tag_idx( varargin )
 %% Test Open MultiTag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
-    t1 = b.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
-    t2 = b.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
-    t3 = b.create_multi_tag('testMultiTag3', 'nixMultiTag', d);
+    g = b.createGroup('testGroup', 'nixGroup');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
+    t1 = b.createMultiTag('testMultiTag1', 'nixMultiTag', d);
+    t2 = b.createMultiTag('testMultiTag2', 'nixMultiTag', d);
+    t3 = b.createMultiTag('testMultiTag3', 'nixMultiTag', d);
     g.add_multi_tag(t1);
     g.add_multi_tag(t2);
     g.add_multi_tag(t3);
@@ -846,10 +846,10 @@ function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    s1 = b.create_source('testSource1', 'nixSource');
-    s2 = b.create_source('testSource2', 'nixSource');
-    s3 = b.create_source('testSource3', 'nixSource');
+    g = b.createGroup('testGroup', 'nixGroup');
+    s1 = b.createSource('testSource1', 'nixSource');
+    s2 = b.createSource('testSource2', 'nixSource');
+    s3 = b.createSource('testSource3', 'nixSource');
     g.add_source(s1);
     g.add_source(s2);
     g.add_source(s3);
@@ -864,9 +864,9 @@ function [] = test_compare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    g1 = b1.create_group('testGroup1', 'nixGroup');
-    g2 = b1.create_group('testGroup2', 'nixGroup');
-    g3 = b2.create_group('testGroup1', 'nixGroup');
+    g1 = b1.createGroup('testGroup1', 'nixGroup');
+    g2 = b1.createGroup('testGroup2', 'nixGroup');
+    g3 = b2.createGroup('testGroup1', 'nixGroup');
 
     assert(g1.compare(g2) < 0);
     assert(g1.compare(g1) == 0);
@@ -880,14 +880,14 @@ function [] = test_filter_source( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    s = b.create_source(filterName, 'nixSource');
+    g = b.createGroup('testGroup', 'nixGroup');
+    s = b.createSource(filterName, 'nixSource');
     g.add_source(s);
     filterID = s.id;
-	s = b.create_source('testSource1', filterType);
+	s = b.createSource('testSource1', filterType);
     g.add_source(s);
     filterIDs = {filterID, s.id};
-    s = b.create_source('testSource2', filterType);
+    s = b.createSource('testSource2', filterType);
     g.add_source(s);
     
     % test empty id filter
@@ -918,7 +918,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     g.add_source(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -932,7 +932,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     g.add_source(mainSource);
     mainID = mainSource.id;
     subName = 'testSubSource1';
@@ -955,14 +955,14 @@ function [] = test_filter_tag( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    t = b.create_tag(filterName, 'nixTag', [1 2 3]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    t = b.createTag(filterName, 'nixTag', [1 2 3]);
     g.add_tag(t);
     filterID = t.id;
-	t = b.create_tag('testTag1', filterType, [1 2 3]);
+	t = b.createTag('testTag1', filterType, [1 2 3]);
     g.add_tag(t);
     filterIDs = {filterID, t.id};
-    t = b.create_tag('testTag2', filterType, [1 2 3]);
+    t = b.createTag('testTag2', filterType, [1 2 3]);
     g.add_tag(t);
 
     % test empty id filter
@@ -993,7 +993,7 @@ function [] = test_filter_tag( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    main = b.create_tag(mainName, 'nixTag', [1 2 3]);
+    main = b.createTag(mainName, 'nixTag', [1 2 3]);
     g.add_tag(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -1007,11 +1007,11 @@ function [] = test_filter_tag( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_tag(mainName, 'nixTag', [1 2 3]);
+    main = b.createTag(mainName, 'nixTag', [1 2 3]);
     g.add_tag(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
@@ -1029,15 +1029,15 @@ function [] = test_filter_multi_tag( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    g = b.create_group('testGroup', 'nixGroup');
-    t = b.create_multi_tag(filterName, 'nixMultiTag', d);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    t = b.createMultiTag(filterName, 'nixMultiTag', d);
     g.add_multi_tag(t);
     filterID = t.id;
-	t = b.create_multi_tag('testMultiTag1', filterType, d);
+	t = b.createMultiTag('testMultiTag1', filterType, d);
     g.add_multi_tag(t);
     filterIDs = {filterID, t.id};
-    t = b.create_multi_tag('testMultiTag2', filterType, d);
+    t = b.createMultiTag('testMultiTag2', filterType, d);
     g.add_multi_tag(t);
 
     % test empty id filter
@@ -1068,7 +1068,7 @@ function [] = test_filter_multi_tag( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    main = b.create_multi_tag(mainName, 'nixMultiTag', d);
+    main = b.createMultiTag(mainName, 'nixMultiTag', d);
     g.add_multi_tag(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -1082,11 +1082,11 @@ function [] = test_filter_multi_tag( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_multi_tag(mainName, 'nixMultiTag', d);
+    main = b.createMultiTag(mainName, 'nixMultiTag', d);
     g.add_multi_tag(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
@@ -1104,14 +1104,14 @@ function [] = test_filter_data_array( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    g = b.create_group('testGroup', 'nixGroup');
-    d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     g.add_data_array(d);
     filterID = d.id;
-	d = b.create_data_array('testDataArray1', filterType, nix.DataType.Bool, [2 2]);
+	d = b.createDataArray('testDataArray1', filterType, nix.DataType.Bool, [2 2]);
     g.add_data_array(d);
     filterIDs = {filterID, d.id};
-	d = b.create_data_array('testDataArray2', filterType, nix.DataType.Bool, [2 2]);
+	d = b.createDataArray('testDataArray2', filterType, nix.DataType.Bool, [2 2]);
     g.add_data_array(d);
 
     % test empty id filter
@@ -1142,7 +1142,7 @@ function [] = test_filter_data_array( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
+    main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
     g.add_data_array(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -1156,11 +1156,11 @@ function [] = test_filter_data_array( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
+    main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
     g.add_data_array(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -57,7 +57,7 @@ function [] = test_attrs( varargin )
     defOW = 'group definition';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     b.create_group(groupName, groupType);
 
     testGroup = b.groups{1};
@@ -91,7 +91,7 @@ function [] = test_add_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
     g = b.create_group('testGroup', 'nixGroup');
 
@@ -110,7 +110,7 @@ end
 function [] = test_add_data_arrays ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     tmp = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [2 3]);
     tmp = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [2 3]);
@@ -147,7 +147,7 @@ function [] = test_get_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     da = b.create_data_array(daName, daType, nix.DataType.Double, [2 3]);
     daID = da.id;
     g = b.create_group('testGroup', 'nixGroup');
@@ -172,7 +172,7 @@ function [] = test_remove_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     da1 = b.create_data_array(daName1, daType, nix.DataType.Double, 1);
     da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
     da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
@@ -208,7 +208,7 @@ function [] = test_update_linked_data_array( varargin )
     daType = 'nixDataArray';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     da1 = b.create_data_array(daName1, daType, nix.DataType.Double, [1]);
     da2 = b.create_data_array(daName2, daType, nix.DataType.Double, [2 3]);
     da3 = b.create_data_array(daName3, daType, nix.DataType.Double, [4 5 6]);
@@ -243,7 +243,7 @@ end
 function [] = test_data_array_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     
     assert(g.data_array_count() == 0);
@@ -263,7 +263,7 @@ function [] = test_add_tag( varargin )
     tagName2 = 'testTag2';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     t1 = b.create_tag(tagName1, 'nixTag', [1.0 1.2 1.3 15.9]);
     t2 = b.create_tag(tagName2, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t2.id;
@@ -287,7 +287,7 @@ end
 function [] = test_add_tags ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     tmp = b.create_tag('testTag1', 'nixTag', [1.0 1.2]);
     tmp = b.create_tag('testTag2', 'nixTag', [1.0 1.2]);
@@ -323,7 +323,7 @@ function [] = test_has_tag( varargin )
     tagName = 'testTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t = b.create_tag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     g.add_tag(t);
@@ -339,7 +339,7 @@ function [] = test_get_tag( varargin )
     tagName = 'testTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t = b.create_tag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t.id;
@@ -362,7 +362,7 @@ function [] = test_remove_tag( varargin )
     tagType = 'nixTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t1 = b.create_tag(tagName1, tagType, [1.0 1.2 1.3 15.9]);
     t2 = b.create_tag(tagName2, tagType, [1.0 1.2 1.3 15.9]);
@@ -398,7 +398,7 @@ end
 function [] = test_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     
     assert(g.tag_count() == 0);
@@ -419,7 +419,7 @@ function [] = test_add_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     tmp = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array(...
@@ -448,7 +448,7 @@ end
 function [] = test_add_multi_tags ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     tmp = b.create_data_array(...
         'testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -488,7 +488,7 @@ function [] = test_has_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     tmp = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array(...
@@ -511,7 +511,7 @@ function [] = test_get_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     da = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag(tagName, tagType, b.dataArrays{1});
@@ -536,7 +536,7 @@ function [] = test_remove_multi_tag( varargin )
     tagType = 'nixMultiTag';
 
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('test', 'nixBlock');
+    b = f.createBlock('test', 'nixBlock');
     da = b.create_data_array(...
         'mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t1 = b.create_multi_tag(tagName1, tagType, b.dataArrays{1});
@@ -580,7 +580,7 @@ end
 function [] = test_multi_tag_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
@@ -599,7 +599,7 @@ end
 function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('sourceTest', 'nixBlock');
+    b = f.createBlock('sourceTest', 'nixBlock');
     s = b.create_source('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -621,7 +621,7 @@ end
 function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('sourceTest', 'nixGroup');
     tmp = b.create_source('testSource1', 'nixSource');
     tmp = b.create_source('testSource2', 'nixSource');
@@ -654,7 +654,7 @@ end
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('test', 'nixBlock');
+    b = test_file.createBlock('test', 'nixBlock');
     s = b.create_source('test', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -678,7 +678,7 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     s = b.create_source(sName, 'nixSource');
     g.add_source(b.sources{1}.id)
@@ -695,7 +695,7 @@ end
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('test', 'nixBlock');
+    b = test_file.createBlock('test', 'nixBlock');
     s = b.create_source('test','nixSource');
     tmp = s.create_source('nestedsource1', 'nixSource');
     tmp = s.create_source('nestedsource2', 'nixSource');
@@ -711,7 +711,7 @@ end
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('test', 'nixBlock');
+    b = test_file.createBlock('test', 'nixBlock');
     s = b.create_source('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
@@ -734,7 +734,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     
     assert(g.source_count() == 0);
@@ -755,9 +755,9 @@ function [] = test_set_metadata ( varargin )
     secName2 = 'testGroupSection2';
 
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.create_section(secName1, 'nixSection');
-    tmp = f.create_section(secName2, 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection(secName1, 'nixSection');
+    tmp = f.createSection(secName2, 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     assert(isempty(g.open_metadata));
     assert(isempty(f.blocks{1}.groups{1}.open_metadata))
@@ -782,8 +782,8 @@ end
 function [] = test_open_metadata( varargin )
 %% Test: Open metadata
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     g.set_metadata(f.sections{1});
 
@@ -793,7 +793,7 @@ end
 function [] = test_open_data_array_idx( varargin )
 %% Test Open DataArray by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     d1 = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
     d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
@@ -810,7 +810,7 @@ end
 function [] = test_open_tag_idx( varargin )
 %% Test Open Tag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t1 = b.create_tag('testTag1', 'nixTag', [1 2]);
     t2 = b.create_tag('testTag2', 'nixTag', [1 2]);
@@ -827,7 +827,7 @@ end
 function [] = test_open_multi_tag_idx( varargin )
 %% Test Open MultiTag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
     t1 = b.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
@@ -845,7 +845,7 @@ end
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     s1 = b.create_source('testSource1', 'nixSource');
     s2 = b.create_source('testSource2', 'nixSource');
@@ -862,8 +862,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare group entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     g1 = b1.create_group('testGroup1', 'nixGroup');
     g2 = b1.create_group('testGroup2', 'nixGroup');
     g3 = b2.create_group('testGroup1', 'nixGroup');
@@ -879,7 +879,7 @@ function [] = test_filter_source( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     s = b.create_source(filterName, 'nixSource');
     g.add_source(s);
@@ -921,7 +921,7 @@ function [] = test_filter_source( varargin )
     mainSource = b.create_source(mainName, 'nixSource');
     g.add_source(mainSource);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
@@ -954,7 +954,7 @@ function [] = test_filter_tag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     t = b.create_tag(filterName, 'nixTag', [1 2 3]);
     g.add_tag(t);
@@ -996,7 +996,7 @@ function [] = test_filter_tag( varargin )
     main = b.create_tag(mainName, 'nixTag', [1 2 3]);
     g.add_tag(main);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
@@ -1028,7 +1028,7 @@ function [] = test_filter_multi_tag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 2]);
     g = b.create_group('testGroup', 'nixGroup');
     t = b.create_multi_tag(filterName, 'nixMultiTag', d);
@@ -1071,7 +1071,7 @@ function [] = test_filter_multi_tag( varargin )
     main = b.create_multi_tag(mainName, 'nixMultiTag', d);
     g.add_multi_tag(main);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
@@ -1103,7 +1103,7 @@ function [] = test_filter_data_array( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     g = b.create_group('testGroup', 'nixGroup');
     d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     g.add_data_array(d);
@@ -1145,7 +1145,7 @@ function [] = test_filter_data_array( varargin )
     main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
     g.add_data_array(main);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -778,24 +778,25 @@ function [] = testSetMetadata ( varargin )
     tmp = f.createSection(secName2, 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
-    assert(isempty(g.open_metadata));
-    assert(isempty(f.blocks{1}.groups{1}.open_metadata))
+    assert(isempty(g.openMetadata));
+    assert(isempty(f.blocks{1}.groups{1}.openMetadata))
     
-    g.set_metadata(f.sections{1});
-    assert(strcmp(g.open_metadata.name, secName1));
-    assert(strcmp(f.blocks{1}.groups{1}.open_metadata.name, secName1));
+    g.setMetadata(f.sections{1});
+    assert(strcmp(g.openMetadata.name, secName1));
+    assert(strcmp(f.blocks{1}.groups{1}.openMetadata.name, secName1));
 
-    g.set_metadata(f.sections{2});
-    assert(strcmp(g.open_metadata.name, secName2));
-    assert(strcmp(f.blocks{1}.groups{1}.open_metadata.name, secName2));
-    g.set_metadata('');
-    assert(isempty(g.open_metadata));
-    assert(isempty(f.blocks{1}.groups{1}.open_metadata));
+    g.setMetadata(f.sections{2});
+    assert(strcmp(g.openMetadata.name, secName2));
+    assert(strcmp(f.blocks{1}.groups{1}.openMetadata.name, secName2));
+    g.setMetadata('');
+    assert(isempty(g.openMetadata));
+    assert(isempty(f.blocks{1}.groups{1}.openMetadata));
 
-    g.set_metadata(f.sections{2});
+    g.setMetadata(f.sections{2});
+
     clear tmp g b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-	assert(strcmp(f.blocks{1}.groups{1}.open_metadata.name, secName2));
+	assert(strcmp(f.blocks{1}.groups{1}.openMetadata.name, secName2));
 end
 
 function [] = testOpenMetadata( varargin )
@@ -804,9 +805,9 @@ function [] = testOpenMetadata( varargin )
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
-    g.set_metadata(f.sections{1});
+    g.setMetadata(f.sections{1});
 
-    assert(strcmp(g.open_metadata.name, 'testSection'));
+    assert(strcmp(g.openMetadata.name, 'testSection'));
 end
 
 function [] = testOpenDataArrayIdx( varargin )
@@ -941,7 +942,7 @@ function [] = testFilterSource( varargin )
     g.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainSource.set_metadata(s);
+    mainSource.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
@@ -1016,7 +1017,7 @@ function [] = testFilterTag( varargin )
     g.addTag(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    main.set_metadata(s);
+    main.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterTags(nix.Filter.metadata, 'Do not exist')));
@@ -1091,7 +1092,7 @@ function [] = testFilterMultiTag( varargin )
     g.addMultiTag(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    main.set_metadata(s);
+    main.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.metadata, 'Do not exist')));
@@ -1165,7 +1166,7 @@ function [] = testFilterDataArray( varargin )
     g.addDataArray(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    main.set_metadata(s);
+    main.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.metadata, 'Do not exist')));

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -617,8 +617,8 @@ function [] = testAddSource ( varargin )
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     g = b.createGroup('sourceTest', 'nixGroup');
     
     assert(isempty(g.sources));
@@ -672,8 +672,8 @@ function [] = testRemoveSource ( varargin )
     testFile = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = testFile.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     g = b.createGroup('sourceTest', 'nixGroup');
     g.add_source(s.sources{1}.id);
     g.add_source(s.sources{2});
@@ -713,9 +713,9 @@ function [] = testFetchSources( varargin )
     testFile = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = testFile.createBlock('test', 'nixBlock');
     s = b.createSource('test','nixSource');
-    tmp = s.create_source('nestedsource1', 'nixSource');
-    tmp = s.create_source('nestedsource2', 'nixSource');
-    tmp = s.create_source('nestedsource3', 'nixSource');
+    tmp = s.createSource('nestedsource1', 'nixSource');
+    tmp = s.createSource('nestedsource2', 'nixSource');
+    tmp = s.createSource('nestedsource3', 'nixSource');
     g = b.createGroup('sourceTest', 'nixGroup');
 
     g.add_source(s.sources{1});
@@ -730,7 +730,7 @@ function [] = testOpenSource( varargin )
     b = testFile.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
     sourceName = 'nestedSource';
-    nSource = s.create_source(sourceName, 'nixSource');
+    nSource = s.createSource(sourceName, 'nixSource');
 
     g = b.createGroup('sourceTest', 'nixGroup');
     g.add_source(s.sources{1});
@@ -952,7 +952,7 @@ function [] = testFilterSource( varargin )
     g.add_source(mainSource);
     mainID = mainSource.id;
     subName = 'testSubSource1';
-    s = mainSource.create_source(subName, 'nixSource');
+    s = mainSource.createSource(subName, 'nixSource');
     subID = s.id;
 
     assert(isempty(f.blocks{1}.groups{1}.filter_sources(nix.Filter.source, 'Do not exist')));

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -913,8 +913,8 @@ function [] = testFilterSource( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.groups{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.groups{1}.filterSources(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -988,8 +988,8 @@ function [] = testFilterTag( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.groups{1}.filterTags(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -1063,8 +1063,8 @@ function [] = testFilterMultiTag( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -1137,8 +1137,8 @@ function [] = testFilterDataArray( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id

--- a/tests/TestGroup.m
+++ b/tests/TestGroup.m
@@ -9,47 +9,48 @@
 %% TESTFILE Tests for the nix.Group object
 function funcs = TestGroup
     funcs = {};
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_add_data_array;
-    funcs{end+1} = @test_add_data_arrays;
-    funcs{end+1} = @test_get_data_array;
-    funcs{end+1} = @test_remove_data_array;
-    funcs{end+1} = @test_update_linked_data_array;
-    funcs{end+1} = @test_data_array_count;
-    funcs{end+1} = @test_add_tag;
-    funcs{end+1} = @test_add_tags;
-    funcs{end+1} = @test_has_tag;
-    funcs{end+1} = @test_get_tag;
-    funcs{end+1} = @test_remove_tag;
-    funcs{end+1} = @test_tag_count;
-    funcs{end+1} = @test_add_multi_tag;
-    funcs{end+1} = @test_add_multi_tags;
-    funcs{end+1} = @test_has_multi_tag;
-    funcs{end+1} = @test_get_multi_tag;
-    funcs{end+1} = @test_remove_multi_tag;
-    funcs{end+1} = @test_multi_tag_count;
-    funcs{end+1} = @test_add_source;
-    funcs{end+1} = @test_add_sources;
-    funcs{end+1} = @test_remove_source;
-    funcs{end+1} = @test_has_source;
-    funcs{end+1} = @test_fetch_sources;
-    funcs{end+1} = @test_open_source;
-    funcs{end+1} = @test_source_count;
-    funcs{end+1} = @test_set_metadata;
-    funcs{end+1} = @test_open_metadata;
-    funcs{end+1} = @test_open_data_array_idx;
-    funcs{end+1} = @test_open_tag_idx;
-    funcs{end+1} = @test_open_multi_tag_idx;
-    funcs{end+1} = @test_open_source_idx;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_source;
-    funcs{end+1} = @test_filter_tag;
-    funcs{end+1} = @test_filter_multi_tag;
-    funcs{end+1} = @test_filter_data_array;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testAddDataArray;
+    funcs{end+1} = @testAddDataArrays;
+    funcs{end+1} = @testHasDataArray;
+    funcs{end+1} = @testGetDataArray;
+    funcs{end+1} = @testRemoveDataArray;
+    funcs{end+1} = @testUpdateLinkedDataArray;
+    funcs{end+1} = @testDataArrayCount;
+    funcs{end+1} = @testAddTag;
+    funcs{end+1} = @testAddTags;
+    funcs{end+1} = @testHasTag;
+    funcs{end+1} = @testGetTag;
+    funcs{end+1} = @testRemoveTag;
+    funcs{end+1} = @testTagCount;
+    funcs{end+1} = @testAddMultiTag;
+    funcs{end+1} = @testAddMultiTags;
+    funcs{end+1} = @testHasMultiTag;
+    funcs{end+1} = @testGetMultiTag;
+    funcs{end+1} = @testRemoveMultiTag;
+    funcs{end+1} = @testMultiTagCount;
+    funcs{end+1} = @testAddSource;
+    funcs{end+1} = @testAddSources;
+    funcs{end+1} = @testRemoveSource;
+    funcs{end+1} = @testHasSource;
+    funcs{end+1} = @testFetchSources;
+    funcs{end+1} = @testOpenSource;
+    funcs{end+1} = @testSourceCount;
+    funcs{end+1} = @testSetMetadata;
+    funcs{end+1} = @testOpenMetadata;
+    funcs{end+1} = @testOpenDataArrayIdx;
+    funcs{end+1} = @testOpenTagIdx;
+    funcs{end+1} = @testOpenMultiTagIdx;
+    funcs{end+1} = @testOpenSourceIdx;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSource;
+    funcs{end+1} = @testFilterTag;
+    funcs{end+1} = @testFilterMultiTag;
+    funcs{end+1} = @testFilterDataArray;
 end
 
 %% Test: Access nix.Group attributes
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
     fileName = 'testRW.h5';
     groupName = 'testGroup';
     groupType = 'nixGroup';
@@ -85,7 +86,7 @@ function [] = test_attrs( varargin )
 end
 
 %% Test: Add nix.DataArray to nix.Group
-function [] = test_add_data_array( varargin )
+function [] = testAddDataArray( varargin )
     fileName = 'testRW.h5';
     daName = 'testDataArray';
     daType = 'nixDataArray';
@@ -97,7 +98,7 @@ function [] = test_add_data_array( varargin )
 
     assert(isempty(g.dataArrays));
     assert(isempty(f.blocks{1}.groups{1}.dataArrays));
-    g.add_data_array(da);
+    g.addDataArray(da);
     assert(size(g.dataArrays, 1) == 1);
     assert(strcmp(f.blocks{1}.groups{1}.dataArrays{1}.name, daName));
 
@@ -107,7 +108,7 @@ function [] = test_add_data_array( varargin )
 end
 
 %% Test: Add dataArrays by entity cell array
-function [] = test_add_data_arrays ( varargin )
+function [] = testAddDataArrays ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -119,20 +120,20 @@ function [] = test_add_data_arrays ( varargin )
     assert(isempty(g.dataArrays));
 
     try
-        g.add_data_arrays('hurra');
+        g.addDataArrays('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(g.dataArrays));
 
     try
-        g.add_data_arrays({12, 13});
+        g.addDataArrays({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.DataArray')));
     end;
     assert(isempty(g.dataArrays));
 
-    g.add_data_arrays(b.dataArrays());
+    g.addDataArrays(b.dataArrays());
     assert(size(g.dataArrays, 1) == 3);
 
     clear g tmp b f;
@@ -140,8 +141,24 @@ function [] = test_add_data_arrays ( varargin )
     assert(size(f.blocks{1}.groups{1}.dataArrays, 1) == 3);
 end
 
+%% Test: has nix.DataArray by id or name
+function [] = testHasDataArray( varargin )
+    fileName = 'testRW.h5';
+    daName = 'testDataArray';
+
+    f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
+    b = f.createBlock('test', 'nixBlock');
+    da = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [2 3]);
+    g = b.createGroup('testGroup', 'nixGroup');
+    g.addDataArray(da);
+
+    assert(g.hasDataArray(b.dataArrays{1}.id));
+    assert(g.hasDataArray(daName));
+    assert(~g.hasDataArray('I do not exist'));
+end
+
 %% Test: Get nix.DataArray by id or name
-function [] = test_get_data_array( varargin )
+function [] = testGetDataArray( varargin )
     fileName = 'testRW.h5';
     daName = 'testDataArray';
     daType = 'nixDataArray';
@@ -151,20 +168,20 @@ function [] = test_get_data_array( varargin )
     da = b.createDataArray(daName, daType, nix.DataType.Double, [2 3]);
     daID = da.id;
     g = b.createGroup('testGroup', 'nixGroup');
-    g.add_data_array(da);
+    g.addDataArray(da);
 
     testClass = 'nix.DataArray';
-    daTestID = g.get_data_array(daID);
+    daTestID = g.getDataArray(daID);
     assert(strcmp(class(daTestID), testClass));
     assert(strcmp(daTestID.name, daName));
 
-    daTestName = g.get_data_array(daName);
+    daTestName = g.getDataArray(daName);
     assert(strcmp(class(daTestName), testClass));
     assert(strcmp(daTestName.id, daID));
 end
 
 %% Test: Remove nix.DataArray from nix.Group by id and entity
-function [] = test_remove_data_array( varargin )
+function [] = testRemoveDataArray( varargin )
     fileName = 'testRW.h5';
     daName1 = 'testDataArray1';
     daName2 = 'testDataArray2';
@@ -177,30 +194,30 @@ function [] = test_remove_data_array( varargin )
     da2 = b.createDataArray(daName2, daType, nix.DataType.Double, [2 3]);
     da3 = b.createDataArray(daName3, daType, nix.DataType.Double, [4 5 6]);
     g = b.createGroup('testGroup', 'nixGroup');
-    g.add_data_array(da1);
-    g.add_data_array(da2);
-    g.add_data_array(da3);
+    g.addDataArray(da1);
+    g.addDataArray(da2);
+    g.addDataArray(da3);
 
     assert(size(b.dataArrays, 1) == 3);
-    g.remove_data_array(da3);
+    g.removeDataArray(da3);
     assert(size(b.dataArrays, 1) == 3);
-    assert(isempty(g.get_data_array(da3.name)));
+    assert(isempty(g.getDataArray(da3.name)));
 
-    g.remove_data_array(da2.id);
+    g.removeDataArray(da2.id);
     assert(size(b.dataArrays, 1) == 3);
-    assert(isempty(g.get_data_array(da2.name)));
-    assert(~isempty(g.get_data_array(da1.name)));
+    assert(isempty(g.getDataArray(da2.name)));
+    assert(~isempty(g.getDataArray(da1.name)));
 
     clear da1 da2 da3 g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
     assert(size(f.blocks{1}.dataArrays, 1) == 3);
-    assert(isempty(f.blocks{1}.groups{1}.get_data_array(daName3)));
-    assert(isempty(f.blocks{1}.groups{1}.get_data_array(daName2)));
-    assert(~isempty(f.blocks{1}.groups{1}.get_data_array(daName1)));
+    assert(isempty(f.blocks{1}.groups{1}.getDataArray(daName3)));
+    assert(isempty(f.blocks{1}.groups{1}.getDataArray(daName2)));
+    assert(~isempty(f.blocks{1}.groups{1}.getDataArray(daName1)));
 end
 
 %% Test: Updates of a linked nix.DataArray between nix.Block and nix.Group
-function [] = test_update_linked_data_array( varargin )
+function [] = testUpdateLinkedDataArray( varargin )
     fileName = 'testRW.h5';
     daName1 = 'testDataArray1';
     daName2 = 'testDataArray2';
@@ -213,25 +230,25 @@ function [] = test_update_linked_data_array( varargin )
     da2 = b.createDataArray(daName2, daType, nix.DataType.Double, [2 3]);
     da3 = b.createDataArray(daName3, daType, nix.DataType.Double, [4 5 6]);
     g = b.createGroup('testGroup', 'nixGroup');
-    g.add_data_array(da1);
-    g.add_data_array(da2);
-    g.add_data_array(da3);
+    g.addDataArray(da1);
+    g.addDataArray(da2);
+    g.addDataArray(da3);
 
     %-- test remove linked DataArray from Block
     assert(size(b.dataArrays, 1) == 3);
     b.deleteDataArray(da1);
     assert(size(b.dataArrays, 1) == 2)
-    assert(isempty(g.get_data_array(daName1)));
-    assert(~isempty(g.get_data_array(daName2)));
+    assert(isempty(g.getDataArray(daName1)));
+    assert(~isempty(g.getDataArray(daName2)));
 
     %-- test udpate linked DataArray
     upDADefFromGroup = 'def 2';
-    g.get_data_array(daName2).definition = upDADefFromGroup;
+    g.getDataArray(daName2).definition = upDADefFromGroup;
     assert(strcmp(b.openDataArray(daName2).definition, upDADefFromGroup));
 
     upDADefFromBlock = 'def 3';
     b.openDataArray(daName3).definition = upDADefFromBlock;
-    assert(strcmp(g.get_data_array(daName3).definition, upDADefFromBlock));
+    assert(strcmp(g.getDataArray(daName3).definition, upDADefFromBlock));
 
     clear da1 da2 da3 g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
@@ -240,24 +257,24 @@ function [] = test_update_linked_data_array( varargin )
 end
 
 %% Test: DataArray count
-function [] = test_data_array_count( varargin )
+function [] = testDataArrayCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
-    
-    assert(g.data_array_count() == 0);
-    g.add_data_array(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
-    assert(g.data_array_count() == 1);
-    g.add_data_array(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
+
+    assert(g.dataArrayCount() == 0);
+    g.addDataArray(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
+    assert(g.dataArrayCount() == 1);
+    g.addDataArray(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
 
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.groups{1}.data_array_count() == 2);
+    assert(f.blocks{1}.groups{1}.dataArrayCount() == 2);
 end
 
 %% Test: Add nix.Tag by entity or id
-function [] = test_add_tag( varargin )
+function [] = testAddTag( varargin )
     fileName = 'testRW.h5';
     tagName1 = 'testTag1';
     tagName2 = 'testTag2';
@@ -270,10 +287,10 @@ function [] = test_add_tag( varargin )
     g = b.createGroup('testGroup', 'nixGroup');
     assert(isempty(g.tags));
     assert(isempty(f.blocks{1}.groups{1}.tags));
-    g.add_tag(t1);
+    g.addTag(t1);
     assert(strcmp(g.tags{1}.name, tagName1));
     assert(strcmp(f.blocks{1}.groups{1}.tags{1}.name, tagName1));
-    g.add_tag(tID);
+    g.addTag(tID);
     assert(strcmp(g.tags{2}.name, tagName2));
     assert(size(f.blocks{1}.groups{1}.tags, 1) == 2);
 
@@ -284,7 +301,7 @@ function [] = test_add_tag( varargin )
 end
 
 %% Test: Add tags by entity cell array
-function [] = test_add_tags ( varargin )
+function [] = testAddTags ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -296,20 +313,20 @@ function [] = test_add_tags ( varargin )
     assert(isempty(g.tags));
 
     try
-        g.add_tags('hurra');
+        g.addTags('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(g.tags));
 
     try
-        g.add_tags({12, 13});
+        g.addTags({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.Tag')));
     end;
     assert(isempty(g.tags));
 
-    g.add_tags(b.tags());
+    g.addTags(b.tags());
     assert(size(g.tags, 1) == 3);
 
     clear g tmp b f;
@@ -318,7 +335,7 @@ function [] = test_add_tags ( varargin )
 end
 
 %% Test: has nix.Tag by id or name
-function [] = test_has_tag( varargin )
+function [] = testHasTag( varargin )
     fileName = 'testRW.h5';
     tagName = 'testTag';
 
@@ -326,15 +343,15 @@ function [] = test_has_tag( varargin )
     b = f.createBlock('test', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     t = b.createTag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
-    g.add_tag(t);
+    g.addTag(t);
 
-    assert(g.has_tag(b.tags{1}.id));
-    assert(g.has_tag(tagName));
-    assert(~g.has_tag('I do not exist'));
+    assert(g.hasTag(b.tags{1}.id));
+    assert(g.hasTag(tagName));
+    assert(~g.hasTag('I do not exist'));
 end
 
 %% Test: get nix.Tag by id or name
-function [] = test_get_tag( varargin )
+function [] = testGetTag( varargin )
     fileName = 'testRW.h5';
     tagName = 'testTag';
 
@@ -344,17 +361,17 @@ function [] = test_get_tag( varargin )
     t = b.createTag(tagName, 'nixTag', [1.0 1.2 1.3 15.9]);
     tID = t.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.get_tag(tID)));
-    g.add_tag(t);
-    assert(strcmp(f.blocks{1}.groups{1}.get_tag(tID).name, tagName));
+    assert(isempty(f.blocks{1}.groups{1}.getTag(tID)));
+    g.addTag(t);
+    assert(strcmp(f.blocks{1}.groups{1}.getTag(tID).name, tagName));
 
     clear t g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.groups{1}.get_tag(tagName).name, tagName));
+    assert(strcmp(f.blocks{1}.groups{1}.getTag(tagName).name, tagName));
 end
 
 %% Test: Remove nix.Tag by entity or id
-function [] = test_remove_tag( varargin )
+function [] = testRemoveTag( varargin )
     fileName = 'testRW.h5';
     tagName1 = 'testTag1';
     tagName2 = 'testTag2';
@@ -367,52 +384,52 @@ function [] = test_remove_tag( varargin )
     t1 = b.createTag(tagName1, tagType, [1.0 1.2 1.3 15.9]);
     t2 = b.createTag(tagName2, tagType, [1.0 1.2 1.3 15.9]);
     t3 = b.createTag(tagName3, tagType, [1.0 1.2 1.3 15.9]);
-    g.add_tag(t1);
-    g.add_tag(t2);
-    g.add_tag(t3);
+    g.addTag(t1);
+    g.addTag(t2);
+    g.addTag(t3);
 
-    assert(~g.remove_tag('I do not exist'));
+    assert(~g.removeTag('I do not exist'));
 
     assert(size(f.blocks{1}.tags, 1) == 3);
     assert(size(g.tags, 1) == 3);
     assert(size(f.blocks{1}.groups{1}.tags, 1) == 3);
-    assert(g.remove_tag(t1.id));
+    assert(g.removeTag(t1.id));
     assert(size(f.blocks{1}.tags, 1) == 3);
     assert(size(g.tags, 1) == 2);
     assert(size(f.blocks{1}.groups{1}.tags, 1) == 2);
-    assert(g.remove_tag(t2));
+    assert(g.removeTag(t2));
     assert(size(f.blocks{1}.tags, 1) == 3);
     assert(size(g.tags, 1) == 1);
     assert(size(f.blocks{1}.groups{1}.tags, 1) == 1);
-    assert(~g.remove_tag(t2));
+    assert(~g.removeTag(t2));
     assert(size(f.blocks{1}.tags, 1) == 3);
     assert(size(g.tags, 1) == 1);
     assert(size(f.blocks{1}.groups{1}.tags, 1) == 1);
 
     clear t1 t2 t3 g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.groups{1}.has_tag(tagName3));
+    assert(f.blocks{1}.groups{1}.hasTag(tagName3));
 end
 
 %% Test: Tag count
-function [] = test_tag_count( varargin )
+function [] = testTagCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     
-    assert(g.tag_count() == 0);
-    g.add_tag(b.createTag('testTag1', 'nixTag', [1 2 3]));
-    assert(g.tag_count() == 1);
-    g.add_tag(b.createTag('testTag2', 'nixTag', [1 2 3]));
+    assert(g.tagCount() == 0);
+    g.addTag(b.createTag('testTag1', 'nixTag', [1 2 3]));
+    assert(g.tagCount() == 1);
+    g.addTag(b.createTag('testTag2', 'nixTag', [1 2 3]));
 
     clear g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.groups{1}.tag_count() == 2);
+    assert(f.blocks{1}.groups{1}.tagCount() == 2);
 end
 
 %% Test: Add nix.MultiTag by entity and id
-function [] = test_add_multi_tag( varargin )
+function [] = testAddMultiTag( varargin )
     fileName = 'testRW.h5';
     tagName1 = 'mTagTest1';
     tagName2 = 'mTagTest2';
@@ -430,11 +447,11 @@ function [] = test_add_multi_tag( varargin )
 
     assert(isempty(g.multiTags));
     assert(isempty(f.blocks{1}.groups{1}.multiTags));
-    g.add_multi_tag(b.multiTags{1});
+    g.addMultiTag(b.multiTags{1});
     assert(size(g.multiTags, 1) == 1);
     assert(size(f.blocks{1}.groups{1}.multiTags, 1) == 1);
 
-    g.add_multi_tag(b.multiTags{2}.id);
+    g.addMultiTag(b.multiTags{2}.id);
     assert(size(g.multiTags, 1) == 2);
     assert(size(f.blocks{1}.groups{1}.multiTags, 1) == 2);
 
@@ -445,7 +462,7 @@ function [] = test_add_multi_tag( varargin )
 end
 
 %% Test: Add multiTags by entity cell array
-function [] = test_add_multi_tags ( varargin )
+function [] = testAddMultiTags ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -459,20 +476,20 @@ function [] = test_add_multi_tags ( varargin )
     assert(isempty(g.multiTags));
 
     try
-        g.add_multi_tags('hurra');
+        g.addMultiTags('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(g.multiTags));
 
     try
-        g.add_multi_tags({12, 13});
+        g.addMultiTags({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.MultiTag')));
     end;
     assert(isempty(g.multiTags));
 
-    g.add_multi_tags(b.multiTags());
+    g.addMultiTags(b.multiTags());
     assert(size(g.multiTags, 1) == 3);
 
     clear g tmp b f;
@@ -481,7 +498,7 @@ function [] = test_add_multi_tags ( varargin )
 end
 
 %% Test: has nix.MultiTag by id or name
-function [] = test_has_multi_tag( varargin )
+function [] = testHasMultiTag( varargin )
     fileName = 'testRW.h5';
     tagName1 = 'mTagTest1';
     tagName2 = 'mTagTest2';
@@ -497,15 +514,15 @@ function [] = test_has_multi_tag( varargin )
     tmp = b.createMultiTag(tagName2, tagType, b.dataArrays{2});
     g = b.createGroup('testGroup', 'nixGroup');
 
-    g.add_multi_tag(b.multiTags{1});
-    assert(g.has_multi_tag(b.multiTags{1}.id));
-    g.add_multi_tag(b.multiTags{2});
-    assert(g.has_multi_tag(tagName2));
-    assert(~g.has_multi_tag('I do not exist'));
+    g.addMultiTag(b.multiTags{1});
+    assert(g.hasMultiTag(b.multiTags{1}.id));
+    g.addMultiTag(b.multiTags{2});
+    assert(g.hasMultiTag(tagName2));
+    assert(~g.hasMultiTag('I do not exist'));
 end
 
 %% Test: get nix.MultiTag by id or name
-function [] = test_get_multi_tag( varargin )
+function [] = testGetMultiTag( varargin )
     fileName = 'testRW.h5';
     tagName = 'mTagTest';
     tagType = 'nixMultiTag';
@@ -517,18 +534,18 @@ function [] = test_get_multi_tag( varargin )
     t = b.createMultiTag(tagName, tagType, b.dataArrays{1});
     g = b.createGroup('testGroup', 'nixGroup');
 
-    g.add_multi_tag(b.multiTags{1});
-    assert(strcmp(f.blocks{1}.groups{1}.get_multi_tag(t.id).name, tagName));
+    g.addMultiTag(b.multiTags{1});
+    assert(strcmp(f.blocks{1}.groups{1}.getMultiTag(t.id).name, tagName));
 
     clear t da g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.groups{1}.get_multi_tag(tagName).name, tagName));
+    assert(strcmp(f.blocks{1}.groups{1}.getMultiTag(tagName).name, tagName));
 
-    assert(isempty(f.blocks{1}.groups{1}.get_multi_tag('I do not exist')));
+    assert(isempty(f.blocks{1}.groups{1}.getMultiTag('I do not exist')));
 end
 
 %% Test: Remove nix.MultiTag by entity or id
-function [] = test_remove_multi_tag( varargin )
+function [] = testRemoveMultiTag( varargin )
     fileName = 'testRW.h5';
     tagName1 = 'mTagTest1';
     tagName2 = 'mTagTest2';
@@ -543,60 +560,59 @@ function [] = test_remove_multi_tag( varargin )
     t2 = b.createMultiTag(tagName2, tagType, b.dataArrays{1});
     t3 = b.createMultiTag(tagName3, tagType, b.dataArrays{1});
     g = b.createGroup('testGroup', 'nixGroup');
-    g.add_multi_tag(t1);
-    g.add_multi_tag(t2);
-    g.add_multi_tag(t3);
-    assert(g.has_multi_tag(tagName1));
-    assert(g.has_multi_tag(tagName2));
-    assert(g.has_multi_tag(tagName3));
+    g.addMultiTag(t1);
+    g.addMultiTag(t2);
+    g.addMultiTag(t3);
+    assert(g.hasMultiTag(tagName1));
+    assert(g.hasMultiTag(tagName2));
+    assert(g.hasMultiTag(tagName3));
 
-    assert(~g.remove_multi_tag('I do not exist'));
+    assert(~g.removeMultiTag('I do not exist'));
 
     assert(size(f.blocks{1}.multiTags, 1) == 3);
     assert(size(f.blocks{1}.groups{1}.multiTags, 1) == 3);
-    assert(g.remove_multi_tag(t1.id));
+    assert(g.removeMultiTag(t1.id));
     assert(size(f.blocks{1}.multiTags, 1) == 3);
     assert(size(g.multiTags, 1) == 2);
     assert(size(f.blocks{1}.groups{1}.multiTags, 1) == 2);
-    assert(~g.has_multi_tag(tagName1));
+    assert(~g.hasMultiTag(tagName1));
 
-    assert(g.remove_multi_tag(t2));
+    assert(g.removeMultiTag(t2));
     assert(size(f.blocks{1}.multiTags, 1) == 3);
     assert(size(g.multiTags, 1) == 1);
     assert(size(f.blocks{1}.groups{1}.multiTags, 1) == 1);
-    assert(~g.has_multi_tag(tagName2));
+    assert(~g.hasMultiTag(tagName2));
 
-    assert(~g.remove_multi_tag(t2));
+    assert(~g.removeMultiTag(t2));
     assert(size(f.blocks{1}.multiTags, 1) == 3);
     assert(size(g.multiTags, 1) == 1);
     assert(size(f.blocks{1}.groups{1}.multiTags, 1) == 1);
 
     clear t1 t2 t3 da g b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.groups{1}.has_multi_tag(tagName3));
+    assert(f.blocks{1}.groups{1}.hasMultiTag(tagName3));
 end
 
 %% Test: MultiTag count
-function [] = test_multi_tag_count( varargin )
+function [] = testMultiTagCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
 
-    assert(g.multi_tag_count() == 0);
-    g.add_multi_tag(b.createMultiTag('testMultiTag1', 'nixMultiTag', da));
-    assert(g.multi_tag_count() == 1);
-    g.add_multi_tag(b.createMultiTag('testMultiTag2', 'nixMultiTag', da));
+    assert(g.multiTagCount() == 0);
+    g.addMultiTag(b.createMultiTag('testMultiTag1', 'nixMultiTag', da));
+    assert(g.multiTagCount() == 1);
+    g.addMultiTag(b.createMultiTag('testMultiTag2', 'nixMultiTag', da));
 
     clear da g b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.groups{1}.multi_tag_count() == 2);
+    assert(f.blocks{1}.groups{1}.multiTagCount() == 2);
 end
 
-
 %% Test: Add sources by entity and id
-function [] = test_add_source ( varargin )
+function [] = testAddSource ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -618,7 +634,7 @@ function [] = test_add_source ( varargin )
 end
 
 %% Test: Add sources by entity cell array
-function [] = test_add_sources ( varargin )
+function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -652,9 +668,9 @@ function [] = test_add_sources ( varargin )
 end
 
 %% Test: Remove sources by entity and id
-function [] = test_remove_source ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+function [] = testRemoveSource ( varargin )
+    testFile = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = testFile.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -674,7 +690,7 @@ function [] = test_remove_source ( varargin )
 end
 
 %% Test: nix.Group has nix.Source by ID, name or entity
-function [] = test_has_source( varargin )
+function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -693,9 +709,9 @@ function [] = test_has_source( varargin )
 end
 
 %% Test: fetch sources
-function [] = test_fetch_sources( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+function [] = testFetchSources( varargin )
+    testFile = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = testFile.createBlock('test', 'nixBlock');
     s = b.createSource('test','nixSource');
     tmp = s.create_source('nestedsource1', 'nixSource');
     tmp = s.create_source('nestedsource2', 'nixSource');
@@ -709,9 +725,9 @@ function [] = test_fetch_sources( varargin )
 end
 
 %% Test: Open source by ID or name
-function [] = test_open_source( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.createBlock('test', 'nixBlock');
+function [] = testOpenSource( varargin )
+    testFile = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = testFile.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
     sourceName = 'nestedSource';
     nSource = s.create_source(sourceName, 'nixSource');
@@ -731,7 +747,7 @@ function [] = test_open_source( varargin )
 end
 
 %% Test: Source count
-function [] = test_source_count( varargin )
+function [] = testSourceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -749,7 +765,7 @@ end
 
 
 %% Test: Set metadata, set metadata none
-function [] = test_set_metadata ( varargin )
+function [] = testSetMetadata ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     secName1 = 'testGroupSection1';
     secName2 = 'testGroupSection2';
@@ -779,7 +795,7 @@ function [] = test_set_metadata ( varargin )
 	assert(strcmp(f.blocks{1}.groups{1}.open_metadata.name, secName2));
 end
 
-function [] = test_open_metadata( varargin )
+function [] = testOpenMetadata( varargin )
 %% Test: Open metadata
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
@@ -790,7 +806,7 @@ function [] = test_open_metadata( varargin )
     assert(strcmp(g.open_metadata.name, 'testSection'));
 end
 
-function [] = test_open_data_array_idx( varargin )
+function [] = testOpenDataArrayIdx( varargin )
 %% Test Open DataArray by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -798,16 +814,16 @@ function [] = test_open_data_array_idx( varargin )
     d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
     d2 = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [6 2]);
     d3 = b.createDataArray('testDataArray3', 'nixDataArray', nix.DataType.Double, [9 2]);
-    g.add_data_array(d1);
-    g.add_data_array(d2);
-    g.add_data_array(d3);
+    g.addDataArray(d1);
+    g.addDataArray(d2);
+    g.addDataArray(d3);
     
-    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(1).name, d1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(2).name, d2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_data_array_idx(3).name, d3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openDataArrayIdx(1).name, d1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openDataArrayIdx(2).name, d2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openDataArrayIdx(3).name, d3.name));
 end
 
-function [] = test_open_tag_idx( varargin )
+function [] = testOpenTagIdx( varargin )
 %% Test Open Tag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -815,16 +831,16 @@ function [] = test_open_tag_idx( varargin )
     t1 = b.createTag('testTag1', 'nixTag', [1 2]);
     t2 = b.createTag('testTag2', 'nixTag', [1 2]);
     t3 = b.createTag('testTag3', 'nixTag', [1 2]);
-    g.add_tag(t1);
-    g.add_tag(t2);
-    g.add_tag(t3);
+    g.addTag(t1);
+    g.addTag(t2);
+    g.addTag(t3);
 
-    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(1).name, t1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(2).name, t2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_tag_idx(3).name, t3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openTagIdx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openTagIdx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openTagIdx(3).name, t3.name));
 end
 
-function [] = test_open_multi_tag_idx( varargin )
+function [] = testOpenMultiTagIdx( varargin )
 %% Test Open MultiTag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -833,16 +849,16 @@ function [] = test_open_multi_tag_idx( varargin )
     t1 = b.createMultiTag('testMultiTag1', 'nixMultiTag', d);
     t2 = b.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     t3 = b.createMultiTag('testMultiTag3', 'nixMultiTag', d);
-    g.add_multi_tag(t1);
-    g.add_multi_tag(t2);
-    g.add_multi_tag(t3);
+    g.addMultiTag(t1);
+    g.addMultiTag(t2);
+    g.addMultiTag(t3);
     
-    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(1).name, t1.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(2).name, t2.name));
-    assert(strcmp(f.blocks{1}.groups{1}.open_multi_tag_idx(3).name, t3.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openMultiTagIdx(1).name, t1.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openMultiTagIdx(2).name, t2.name));
+    assert(strcmp(f.blocks{1}.groups{1}.openMultiTagIdx(3).name, t3.name));
 end
 
-function [] = test_open_source_idx( varargin )
+function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -859,7 +875,7 @@ function [] = test_open_source_idx( varargin )
     assert(strcmp(f.blocks{1}.groups{1}.open_source_idx(3).name, s3.name));
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare group entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -875,7 +891,7 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter sources
-function [] = test_filter_source( varargin )
+function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -950,81 +966,81 @@ function [] = test_filter_source( varargin )
 end
 
 %% Test: filter tags
-function [] = test_filter_tag( varargin )
+function [] = testFilterTag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     t = b.createTag(filterName, 'nixTag', [1 2 3]);
-    g.add_tag(t);
+    g.addTag(t);
     filterID = t.id;
 	t = b.createTag('testTag1', filterType, [1 2 3]);
-    g.add_tag(t);
+    g.addTag(t);
     filterIDs = {filterID, t.id};
     t = b.createTag('testTag2', filterType, [1 2 3]);
-    g.add_tag(t);
+    g.addTag(t);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.groups{1}.filter_tags(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterTags(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.groups{1}.filter_tags(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.groups{1}.filterTags(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     main = b.createTag(mainName, 'nixTag', [1 2 3]);
-    g.add_tag(main);
+    g.addTag(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_tags(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.groups{1}.filterTags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createTag(mainName, 'nixTag', [1 2 3]);
-    g.add_tag(main);
+    g.addTag(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_tags(nix.Filter.source, 'Do not exist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterTags(nix.Filter.source, 'Do not exist')));
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.groups{1}.filter_tags(nix.Filter.source, subID);
+    filtered = f.blocks{1}.groups{1}.filterTags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: filter multi tags
-function [] = test_filter_multi_tag( varargin )
+function [] = testFilterMultiTag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -1032,142 +1048,142 @@ function [] = test_filter_multi_tag( varargin )
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 2]);
     g = b.createGroup('testGroup', 'nixGroup');
     t = b.createMultiTag(filterName, 'nixMultiTag', d);
-    g.add_multi_tag(t);
+    g.addMultiTag(t);
     filterID = t.id;
 	t = b.createMultiTag('testMultiTag1', filterType, d);
-    g.add_multi_tag(t);
+    g.addMultiTag(t);
     filterIDs = {filterID, t.id};
     t = b.createMultiTag('testMultiTag2', filterType, d);
-    g.add_multi_tag(t);
+    g.addMultiTag(t);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     main = b.createMultiTag(mainName, 'nixMultiTag', d);
-    g.add_multi_tag(main);
+    g.addMultiTag(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createMultiTag(mainName, 'nixMultiTag', d);
-    g.add_multi_tag(main);
+    g.addMultiTag(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.source, 'Do not exist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.source, 'Do not exist')));
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.groups{1}.filter_multi_tags(nix.Filter.source, subID);
+    filtered = f.blocks{1}.groups{1}.filterMultiTags(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: filter dataArray
-function [] = test_filter_data_array( varargin )
+function [] = testFilterDataArray( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     g = b.createGroup('testGroup', 'nixGroup');
     d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Bool, [2 2]);
-    g.add_data_array(d);
+    g.addDataArray(d);
     filterID = d.id;
 	d = b.createDataArray('testDataArray1', filterType, nix.DataType.Bool, [2 2]);
-    g.add_data_array(d);
+    g.addDataArray(d);
     filterIDs = {filterID, d.id};
 	d = b.createDataArray('testDataArray2', filterType, nix.DataType.Bool, [2 2]);
-    g.add_data_array(d);
+    g.addDataArray(d);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
-    
+
     % test nix.Filter.type
-    filtered = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
-    g.add_data_array(main);
+    g.addDataArray(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Double, [3 2]);
-    g.add_data_array(main);
+    g.addDataArray(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.source, 'Do not exist')));
+    assert(isempty(f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.source, 'Do not exist')));
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.groups{1}.filter_data_arrays(nix.Filter.source, subID);
+    filtered = f.blocks{1}.groups{1}.filterDataArrays(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -59,8 +59,8 @@ function [] = test_add_source ( varargin )
     b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     mTag = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
 
     assert(isempty(mTag.sources));
@@ -121,8 +121,8 @@ function [] = test_remove_source ( varargin )
     tmp = b.createDataArray(...
         'sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
 
     t.add_source(s.sources{1}.id);
@@ -303,8 +303,8 @@ function [] = test_fetch_sources( varargin )
     b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
     t.add_source(s.sources{1}.id);
     t.add_source(s.sources{2});
@@ -332,7 +332,7 @@ function [] = test_open_source( varargin )
     tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.createSource('sourceTest', 'nixSource');
     sName = 'nestedSource';
-    tmp = s.create_source(sName, 'nixSource');
+    tmp = s.createSource(sName, 'nixSource');
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
     t.add_source(s.sources{1});
 
@@ -1132,7 +1132,7 @@ function [] = test_filter_source( varargin )
     t.add_source(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = main.create_source(subName, 'nixSource');
+    s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
     assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, 'Do not exist')));

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -7,8 +7,7 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestMultiTag
-%TESTMultiTag tests for MultiTag
-%   Detailed explanation goes here
+% TESTMultiTag tests for MultiTag
 
     funcs = {};
     funcs{end+1} = @testAddSource;
@@ -66,11 +65,11 @@ function [] = testAddSource ( varargin )
     assert(isempty(t.sources));
     assert(isempty(f.blocks{1}.multiTags{1}.sources));
 
-    t.add_source(s.sources{1}.id);
+    t.addSource(s.sources{1}.id);
     assert(size(t.sources, 1) == 1);
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 1);
 
-    t.add_source(s.sources{2});
+    t.addSource(s.sources{2});
     assert(size(t.sources, 1) == 2);
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 2);
     
@@ -93,20 +92,20 @@ function [] = testAddSources ( varargin )
     assert(isempty(t.sources));
 
     try
-        t.add_sources('hurra');
+        t.addSources('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(t.sources));
 
     try
-        t.add_sources({12, 13});
+        t.addSources({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.Source')));
     end;
     assert(isempty(t.sources));
 
-    t.add_sources(b.sources());
+    t.addSources(b.sources());
     assert(size(t.sources, 1) == 3);
 
     clear t tmp b f;
@@ -125,14 +124,14 @@ function [] = testRemoveSource ( varargin )
     tmp = s.createSource('nestedSource2', 'nixSource');
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
 
-    t.add_source(s.sources{1}.id);
-    t.add_source(s.sources{2});
+    t.addSource(s.sources{1}.id);
+    t.addSource(s.sources{2});
 
-    t.remove_source(s.sources{2});
+    t.removeSource(s.sources{2});
     assert(size(t.sources,1) == 1);
-    t.remove_source(s.sources{1}.id);
+    t.removeSource(s.sources{1}.id);
     assert(isempty(t.sources));
-    assert(t.remove_source('I do not exist'));
+    assert(t.removeSource('I do not exist'));
     assert(size(s.sources,1) == 2);
 end
 
@@ -306,8 +305,8 @@ function [] = testFetchSources( varargin )
     tmp = s.createSource('nestedSource1', 'nixSource');
     tmp = s.createSource('nestedSource2', 'nixSource');
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
-    t.add_source(s.sources{1}.id);
-    t.add_source(s.sources{2});
+    t.addSource(s.sources{1}.id);
+    t.addSource(s.sources{2});
 
     assert(size(t.sources, 1) == 2);
 end
@@ -334,16 +333,16 @@ function [] = testOpenSource( varargin )
     sName = 'nestedSource';
     tmp = s.createSource(sName, 'nixSource');
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
-    t.add_source(s.sources{1});
+    t.addSource(s.sources{1});
 
-    getSourceByID = t.open_source(t.sources{1,1}.id);
+    getSourceByID = t.openSource(t.sources{1,1}.id);
     assert(~isempty(getSourceByID));
 
-    getSourceByName = t.open_source(sName);
+    getSourceByName = t.openSource(sName);
     assert(~isempty(getSourceByName));
     
     %-- test open non existing source
-    s = t.open_source('I do not exist');
+    s = t.openSource('I do not exist');
     assert(isempty(s));
 end
 
@@ -356,32 +355,34 @@ function [] = testOpenSourceIdx( varargin )
     s1 = b.createSource('testSource1', 'nixSource');
     s2 = b.createSource('testSource2', 'nixSource');
     s3 = b.createSource('testSource3', 'nixSource');
-    t.add_source(s1);
-    t.add_source(s2);
-    t.add_source(s3);
+    t.addSource(s1);
+    t.addSource(s2);
+    t.addSource(s3);
 
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(1).name, s1.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(2).name, s2.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_source_idx(3).name, s3.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openSourceIdx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openSourceIdx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openSourceIdx(3).name, s3.name));
 end
 
 %% Test: has nix.Source by ID or entity
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
+    sName = 'sourceTest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.createSource('sourceTest1', 'nixSource');
+    s = b.createSource(sName, 'nixSource');
     sID = s.id;
     tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
-    t.add_source(b.sources{1});
+    t.addSource(b.sources{1});
 
-    assert(~t.has_source('I do not exist'));
-    assert(t.has_source(s));
+    assert(~t.hasSource('I do not exist'));
+    assert(t.hasSource(s));
 
     clear t tmp s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multiTags{1}.has_source(sID));
+    assert(f.blocks{1}.multiTags{1}.hasSource(sID));
+    assert(~f.blocks{1}.multiTags{1}.hasSource(sName));
 end
 
 %% Test: Source count
@@ -392,14 +393,14 @@ function [] = testSourceCount( varargin )
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 
-    assert(t.source_count() == 0);
-    t.add_source(b.createSource('testSource1', 'nixSource'));
-    assert(t.source_count() == 1);
-    t.add_source(b.createSource('testSource2', 'nixSource'));
+    assert(t.sourceCount() == 0);
+    t.addSource(b.createSource('testSource1', 'nixSource'));
+    assert(t.sourceCount() == 1);
+    t.addSource(b.createSource('testSource2', 'nixSource'));
 
     clear t d b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multiTags{1}.source_count() == 2);
+    assert(f.blocks{1}.multiTags{1}.sourceCount() == 2);
 end
 
 %% Test: Open feature by ID
@@ -1078,69 +1079,69 @@ function [] = testFilterSource( varargin )
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 3]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
     s = b.createSource(filterName, 'nixSource');
-    t.add_source(s);
+    t.addSource(s);
     filterID = s.id;
 	s = b.createSource('testSource1', filterType);
-    t.add_source(s);
+    t.addSource(s);
     filterIDs = {filterID, s.id};
     s = b.createSource('testSource2', filterType);
-    t.add_source(s);
+    t.addSource(s);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.multiTags{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     mainSource = b.createSource(mainName, 'nixSource');
-    t.add_source(mainSource);
+    t.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.multiTags{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createSource(mainName, 'nixSource');
-    t.add_source(main);
+    t.addSource(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, 'Do not exist')));
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, subName);
+    assert(isempty(f.blocks{1}.multiTags{1}.filterSources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.source, subName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, mainID));
 
-    filtered = f.blocks{1}.multiTags{1}.filter_sources(nix.Filter.source, subID);
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
@@ -1209,7 +1210,7 @@ function [] = testFilterReference( varargin )
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    main.add_source(s);
+    main.addSource(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.source, 'Do not exist')));

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -1091,8 +1091,8 @@ function [] = testFilterSource( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.multiTags{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.multiTags{1}.filterSources(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
@@ -1167,8 +1167,8 @@ function [] = testFilterReference( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
@@ -1238,8 +1238,8 @@ function [] = testFilterFeature( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.id

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -657,12 +657,12 @@ function [] = test_retrieve_data( varargin )
                                           %        123 124 125 126
 
 	d_pos = b.createDataArrayFromData('positionsDA', 'nixDataArray', pos);
-    d_pos.append_sampled_dimension(0);
-    d_pos.append_sampled_dimension(0);
+    d_pos.appendSampledDimension(0);
+    d_pos.appendSampledDimension(0);
 
     d_ext = b.createDataArrayFromData('extentsDA', 'nixDataArray', ext);
-    d_ext.append_sampled_dimension(0);
-    d_ext.append_sampled_dimension(0);
+    d_ext.appendSampledDimension(0);
+    d_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d_pos);
     t.set_extents(d_ext);
@@ -671,14 +671,14 @@ function [] = test_retrieve_data( varargin )
     raw1 = [111, 112, 113, 114, 115, 116, 117, 118; ...
                 121, 122, 123, 124, 125, 126, 127, 128];
     d1 = b.createDataArrayFromData('reference1', 'nixDataArray', raw1);
-    d1.append_sampled_dimension(1);
-    d1.append_sampled_dimension(1);
+    d1.appendSampledDimension(1);
+    d1.appendSampledDimension(1);
 
     raw2 = [211, 212, 213, 214, 215, 216, 217, 218; ...
                 221, 222, 223, 224, 225, 226, 227, 228];
     d2 = b.createDataArrayFromData('reference2', 'nixDataArray', raw2);
-    d2.append_sampled_dimension(1);
-    d2.append_sampled_dimension(1);
+    d2.appendSampledDimension(1);
+    d2.appendSampledDimension(1);
 
     % add data_arrays as references to multi tag
     t.add_reference(d1);
@@ -720,12 +720,12 @@ function [] = test_retrieve_data_idx( varargin )
                                           %        123 124 125 126
 
 	d_pos = b.createDataArrayFromData('positionsDA', 'nixDataArray', pos);
-    d_pos.append_sampled_dimension(0);
-    d_pos.append_sampled_dimension(0);
+    d_pos.appendSampledDimension(0);
+    d_pos.appendSampledDimension(0);
 
     d_ext = b.createDataArrayFromData('extentsDA', 'nixDataArray', ext);
-    d_ext.append_sampled_dimension(0);
-    d_ext.append_sampled_dimension(0);
+    d_ext.appendSampledDimension(0);
+    d_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d_pos);
     t.set_extents(d_ext);
@@ -734,14 +734,14 @@ function [] = test_retrieve_data_idx( varargin )
     raw1 = [111, 112, 113, 114, 115, 116, 117, 118; ...
                 121, 122, 123, 124, 125, 126, 127, 128];
     d1 = b.createDataArrayFromData('reference1', 'nixDataArray', raw1);
-    d1.append_sampled_dimension(1);
-    d1.append_sampled_dimension(1);
+    d1.appendSampledDimension(1);
+    d1.appendSampledDimension(1);
 
     raw2 = [211, 212, 213, 214, 215, 216, 217, 218; ...
                 221, 222, 223, 224, 225, 226, 227, 228];
     d2 = b.createDataArrayFromData('reference2', 'nixDataArray', raw2);
-    d2.append_sampled_dimension(1);
-    d2.append_sampled_dimension(1);
+    d2.appendSampledDimension(1);
+    d2.appendSampledDimension(1);
 
     % add data_arrays as references to multi tag
     t.add_reference(d1);
@@ -776,16 +776,16 @@ function [] = test_retrieve_feature_data( varargin )
     % create feature data arrays
     raw_feat1 = [11 12 13 14 15 16 17 18];
     da_feat1 = b.createDataArrayFromData('feature1', 'nixDataArray', raw_feat1);
-    da_feat1.append_sampled_dimension(1);
+    da_feat1.appendSampledDimension(1);
 
     raw_feat2 = [21 22 23 24 25 26 27 28];
     da_feat2 = b.createDataArrayFromData('feature2', 'nixDataArray', raw_feat2);
-    da_feat2.append_sampled_dimension(1);
+    da_feat2.appendSampledDimension(1);
 
     % create referenced data array
     raw_feat3 = [31 32 33 34 35 36 37 38];
     da_feat3 = b.createDataArrayFromData('reference', 'nixDataArray', raw_feat3);
-    da_feat3.append_sampled_dimension(1);
+    da_feat3.appendSampledDimension(1);
 
     % create position, extents DA and multi tag
     pos = [0; 3; 5];
@@ -794,8 +794,8 @@ function [] = test_retrieve_feature_data( varargin )
     da_pos = b.createDataArrayFromData('positions', 'nixDataArray', pos);
     da_ext = b.createDataArrayFromData('extents', 'nixDataArray', ext);
 
-    da_pos.append_sampled_dimension(0);
-    da_ext.append_sampled_dimension(0);
+    da_pos.appendSampledDimension(0);
+    da_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da_pos);
     t.set_extents(da_ext);
@@ -865,16 +865,16 @@ function [] = test_retrieve_feature_data_idx( varargin )
     % create feature data arrays
     raw_feat1 = [11 12 13 14 15 16 17 18];
     da_feat1 = b.createDataArrayFromData('feature1', 'nixDataArray', raw_feat1);
-    da_feat1.append_sampled_dimension(1);
+    da_feat1.appendSampledDimension(1);
 
     raw_feat2 = [21 22 23 24 25 26 27 28];
     da_feat2 = b.createDataArrayFromData('feature2', 'nixDataArray', raw_feat2);
-    da_feat2.append_sampled_dimension(1);
+    da_feat2.appendSampledDimension(1);
 
     % create referenced data array
     raw_feat3 = [31 32 33 34 35 36 37 38];
     da_feat3 = b.createDataArrayFromData('reference', 'nixDataArray', raw_feat3);
-    da_feat3.append_sampled_dimension(1);
+    da_feat3.appendSampledDimension(1);
 
     % create position, extents DA and multi tag
     pos = [0; 3; 5];
@@ -883,8 +883,8 @@ function [] = test_retrieve_feature_data_idx( varargin )
     da_pos = b.createDataArrayFromData('positions', 'nixDataArray', pos);
     da_ext = b.createDataArrayFromData('extents', 'nixDataArray', ext);
 
-    da_pos.append_sampled_dimension(0);
-    da_ext.append_sampled_dimension(0);
+    da_pos.appendSampledDimension(0);
+    da_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da_pos);
     t.set_extents(da_ext);

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -11,49 +11,49 @@ function funcs = TestMultiTag
 %   Detailed explanation goes here
 
     funcs = {};
-    funcs{end+1} = @test_add_source;
-    funcs{end+1} = @test_add_sources;
-    funcs{end+1} = @test_remove_source;
-    funcs{end+1} = @test_add_reference;
-    funcs{end+1} = @test_add_references;
-    funcs{end+1} = @test_has_reference;
-    funcs{end+1} = @test_remove_reference;
-    funcs{end+1} = @test_add_feature;
-    funcs{end+1} = @test_has_feature;
-    funcs{end+1} = @test_remove_feature;
-    funcs{end+1} = @test_fetch_references;
-    funcs{end+1} = @test_fetch_sources;
-    funcs{end+1} = @test_fetch_features;
-    funcs{end+1} = @test_open_source;
-    funcs{end+1} = @test_open_source_idx;
-    funcs{end+1} = @test_has_source;
-    funcs{end+1} = @test_source_count;
-    funcs{end+1} = @test_open_feature;
-    funcs{end+1} = @test_open_feature_idx;
-    funcs{end+1} = @test_open_reference;
-    funcs{end+1} = @test_open_reference_idx;
-    funcs{end+1} = @test_feature_count;
-    funcs{end+1} = @test_reference_count;
-    funcs{end+1} = @test_add_positions;
-    funcs{end+1} = @test_has_positions;
-    funcs{end+1} = @test_open_positions;
-    funcs{end+1} = @test_set_open_extents;
-    funcs{end+1} = @test_set_metadata;
-    funcs{end+1} = @test_open_metadata;
-    funcs{end+1} = @test_retrieve_data;
-    funcs{end+1} = @test_retrieve_data_idx;
-    funcs{end+1} = @test_retrieve_feature_data;
-    funcs{end+1} = @test_retrieve_feature_data_idx;
-    funcs{end+1} = @test_set_units;
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_source;
-    funcs{end+1} = @test_filter_reference;
-    funcs{end+1} = @test_filter_feature;
+    funcs{end+1} = @testAddSource;
+    funcs{end+1} = @testAddSources;
+    funcs{end+1} = @testRemoveSource;
+    funcs{end+1} = @testAddReference;
+    funcs{end+1} = @testAddReferences;
+    funcs{end+1} = @testHasReference;
+    funcs{end+1} = @testRemoveReference;
+    funcs{end+1} = @testAddFeature;
+    funcs{end+1} = @testHasFeature;
+    funcs{end+1} = @testRemoveFeature;
+    funcs{end+1} = @testFetchReferences;
+    funcs{end+1} = @testFetchSources;
+    funcs{end+1} = @testFetchFeatures;
+    funcs{end+1} = @testOpenSource;
+    funcs{end+1} = @testOpenSourceIdx;
+    funcs{end+1} = @testHasSource;
+    funcs{end+1} = @testSourceCount;
+    funcs{end+1} = @testOpenFeature;
+    funcs{end+1} = @testOpenFeatureIdx;
+    funcs{end+1} = @testOpenReference;
+    funcs{end+1} = @testOpenReferenceIdx;
+    funcs{end+1} = @testFeatureCount;
+    funcs{end+1} = @testReferenceCount;
+    funcs{end+1} = @testAddPositions;
+    funcs{end+1} = @testHasPositions;
+    funcs{end+1} = @testOpenPositions;
+    funcs{end+1} = @testSetOpenExtents;
+    funcs{end+1} = @testSetMetadata;
+    funcs{end+1} = @testOpenMetadata;
+    funcs{end+1} = @testRetrieveData;
+    funcs{end+1} = @testRetrieveDataIdx;
+    funcs{end+1} = @testRetrieveFeatureData;
+    funcs{end+1} = @testRetrieveFeatureDataIdx;
+    funcs{end+1} = @testSetUnits;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSource;
+    funcs{end+1} = @testFilterReference;
+    funcs{end+1} = @testFilterFeature;
 end
 
 %% Test: Add sources by entity and id
-function [] = test_add_source ( varargin )
+function [] = testAddSource ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -61,26 +61,26 @@ function [] = test_add_source ( varargin )
     s = b.createSource('sourceTest', 'nixSource');
     tmp = s.createSource('nestedSource1', 'nixSource');
     tmp = s.createSource('nestedSource2', 'nixSource');
-    mTag = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
+    t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
 
-    assert(isempty(mTag.sources));
+    assert(isempty(t.sources));
     assert(isempty(f.blocks{1}.multiTags{1}.sources));
 
-    mTag.add_source(s.sources{1}.id);
-    assert(size(mTag.sources, 1) == 1);
+    t.add_source(s.sources{1}.id);
+    assert(size(t.sources, 1) == 1);
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 1);
 
-    mTag.add_source(s.sources{2});
-    assert(size(mTag.sources, 1) == 2);
+    t.add_source(s.sources{2});
+    assert(size(t.sources, 1) == 2);
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 2);
     
-    clear tmp mTag s b f;
+    clear tmp t s b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 2);
 end
 
 %% Test: Add sources by entity cell array
-function [] = test_add_sources ( varargin )
+function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -115,7 +115,7 @@ function [] = test_add_sources ( varargin )
 end
 
 %% Test: Remove sources by entity and id
-function [] = test_remove_source ( varargin )
+function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.createDataArray(...
@@ -137,36 +137,36 @@ function [] = test_remove_source ( varargin )
 end
 
 %% Test: Add references by entity and id
-function [] = test_add_reference ( varargin )
+function [] = testAddReference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.createDataArray('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    mTag = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
+    t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
     tmp = b.createDataArray(...
         'referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.createDataArray(...
         'referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
 
-    assert(isempty(mTag.references));
+    assert(isempty(t.references));
     assert(isempty(f.blocks{1}.multiTags{1}.references));
 
-    mTag.add_reference(b.dataArrays{2}.id);
-    assert(size(mTag.references, 1) == 1);
+    t.addReference(b.dataArrays{2}.id);
+    assert(size(t.references, 1) == 1);
     assert(size(f.blocks{1}.multiTags{1}.references, 1) == 1);
     
-    mTag.add_reference(b.dataArrays{3});
-    assert(size(mTag.references, 1) == 2);
+    t.addReference(b.dataArrays{3});
+    assert(size(t.references, 1) == 2);
     assert(size(f.blocks{1}.multiTags{1}.references, 1) == 2);
     
-    clear tmp mTag b f;
+    clear tmp t b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
     assert(size(f.blocks{1}.multiTags{1}.references, 1) == 2);
 end
 
 %% Test: Add references by entity cell array
-function [] = test_add_references ( varargin )
+function [] = testAddReferences ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -178,20 +178,20 @@ function [] = test_add_references ( varargin )
     assert(isempty(t.references));
 
     try
-        t.add_references('hurra');
+        t.addReferences('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(t.references));
 
     try
-        t.add_references({12, 13});
+        t.addReferences({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.DataArray')));
     end;
     assert(isempty(t.references));
 
-    t.add_references(b.dataArrays);
+    t.addReferences(b.dataArrays);
     assert(size(t.references, 1) == 3);
 
     clear t tmp b f;
@@ -200,7 +200,7 @@ function [] = test_add_references ( varargin )
 end
 
 %% Test: Remove references by entity and id
-function [] = test_remove_reference ( varargin )
+function [] = testRemoveReference ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.createDataArray(...
@@ -211,24 +211,24 @@ function [] = test_remove_reference ( varargin )
         'referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.createDataArray(...
         'referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
-    t.add_reference(b.dataArrays{2}.id);
-    t.add_reference(b.dataArrays{3});
+    t.addReference(b.dataArrays{2}.id);
+    t.addReference(b.dataArrays{3});
 
-    assert(t.remove_reference(b.dataArrays{3}));
-    assert(t.remove_reference(b.dataArrays{2}.id));
+    assert(t.removeReference(b.dataArrays{3}));
+    assert(t.removeReference(b.dataArrays{2}.id));
     assert(isempty(t.references));
 
-    assert(~t.remove_reference('I do not exist'));
+    assert(~t.removeReference('I do not exist'));
     assert(size(b.dataArrays, 1) == 3);
 end
 
 %% Test: Add features by entity and id
-function [] = test_add_feature ( varargin )
+function [] = testAddFeature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    mTag = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
+    t = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
     tmp = b.createDataArray(...
         'featTestDA1', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -243,24 +243,24 @@ function [] = test_add_feature ( varargin )
     tmp = b.createDataArray(...
         'featTestDA6', 'nixDataArray', nix.DataType.Double, [11 12]);
 
-    assert(isempty(mTag.features));
+    assert(isempty(t.features));
     assert(isempty(f.blocks{1}.multiTags{1}.features));
-    tmp = mTag.add_feature(b.dataArrays{2}.id, nix.LinkType.Tagged);
-    tmp = mTag.add_feature(b.dataArrays{3}, nix.LinkType.Tagged);
-    tmp = mTag.add_feature(b.dataArrays{4}.id, nix.LinkType.Untagged);
-    tmp = mTag.add_feature(b.dataArrays{5}, nix.LinkType.Untagged);
-    tmp = mTag.add_feature(b.dataArrays{6}.id, nix.LinkType.Indexed);
-    tmp = mTag.add_feature(b.dataArrays{7}, nix.LinkType.Indexed);
-    assert(size(mTag.features, 1) == 6);
+    tmp = t.addFeature(b.dataArrays{2}.id, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{3}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{4}.id, nix.LinkType.Untagged);
+    tmp = t.addFeature(b.dataArrays{5}, nix.LinkType.Untagged);
+    tmp = t.addFeature(b.dataArrays{6}.id, nix.LinkType.Indexed);
+    tmp = t.addFeature(b.dataArrays{7}, nix.LinkType.Indexed);
+    assert(size(t.features, 1) == 6);
     assert(size(f.blocks{1}.multiTags{1}.features, 1) == 6);
     
-    clear tmp mTag b f;
+    clear tmp t b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
     assert(size(f.blocks{1}.multiTags{1}.features, 1) == 6);
 end
 
 %% Test: Remove features by entity and id
-function [] = test_remove_feature ( varargin )
+function [] = testRemoveFeature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
 	tmp = b.createDataArray(...
@@ -272,33 +272,33 @@ function [] = test_remove_feature ( varargin )
     tmp = b.createDataArray(...
         'featTestDA2', 'nixDataArray', nix.DataType.Double, [3 4]);
 
-    tmp = t.add_feature(b.dataArrays{2}.id, nix.LinkType.Tagged);
-    tmp = t.add_feature(b.dataArrays{3}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{2}.id, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{3}, nix.LinkType.Tagged);
 
-    assert(t.remove_feature(t.features{2}.id));
-    assert(t.remove_feature(t.features{1}));
+    assert(t.removeFeature(t.features{2}.id));
+    assert(t.removeFeature(t.features{1}));
     assert(isempty(t.features));
 
-    assert(~t.remove_feature('I do not exist'));
+    assert(~t.removeFeature('I do not exist'));
     assert(size(b.dataArrays, 1) == 3);
 end
 
 %% Test: fetch references
-function [] = test_fetch_references( varargin )
+function [] = testFetchReferences( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.createDataArray('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
-    t.add_reference(b.dataArrays{2}.id);
-    t.add_reference(b.dataArrays{3});
+    t.addReference(b.dataArrays{2}.id);
+    t.addReference(b.dataArrays{3});
 
     assert(size(t.references, 1) == 2);
 end
 
 %% Test: fetch sources
-function [] = test_fetch_sources( varargin )
+function [] = testFetchSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -313,7 +313,7 @@ function [] = test_fetch_sources( varargin )
 end
 
 %% Test: fetch features
-function [] = test_fetch_features( varargin )
+function [] = testFetchFeatures( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -321,12 +321,12 @@ function [] = test_fetch_features( varargin )
 
     assert(isempty(t.features));
     tmp = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = t.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
     assert(size(t.features, 1) == 1);
 end
 
 %% Test: Open source by ID or name
-function [] = test_open_source( varargin )
+function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -347,7 +347,7 @@ function [] = test_open_source( varargin )
     assert(isempty(s));
 end
 
-function [] = test_open_source_idx( varargin )
+function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -366,7 +366,7 @@ function [] = test_open_source_idx( varargin )
 end
 
 %% Test: has nix.Source by ID or entity
-function [] = test_has_source( varargin )
+function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
@@ -385,7 +385,7 @@ function [] = test_has_source( varargin )
 end
 
 %% Test: Source count
-function [] = test_source_count( varargin )
+function [] = testSourceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -403,22 +403,22 @@ function [] = test_source_count( varargin )
 end
 
 %% Test: Open feature by ID
-function [] = test_open_feature( varargin )
+function [] = testOpenFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
     tmp = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = t.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
-    assert(~isempty(t.open_feature(t.features{1}.id)));
+    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    assert(~isempty(t.openFeature(t.features{1}.id)));
 
     %-- test open non existing feature
-    getFeat = t.open_feature('I do not exist');
+    getFeat = t.openFeature('I do not exist');
     assert(isempty(getFeat));
 end
 
-function [] = test_open_feature_idx( varargin )
+function [] = testOpenFeatureIdx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -427,37 +427,37 @@ function [] = test_open_feature_idx( varargin )
     f1 = b.createDataArray('testFeature1', 'nixDataArray', nix.DataType.Bool, [2 2]);
     f2 = b.createDataArray('testFeature2', 'nixDataArray', nix.DataType.Bool, [2 2]);
     f3 = b.createDataArray('testFeature3', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.add_feature(f1, nix.LinkType.Tagged);
-    t.add_feature(f2, nix.LinkType.Untagged);
-    t.add_feature(f3, nix.LinkType.Indexed);
+    t.addFeature(f1, nix.LinkType.Tagged);
+    t.addFeature(f2, nix.LinkType.Untagged);
+    t.addFeature(f3, nix.LinkType.Indexed);
 
-    assert(f.blocks{1}.multiTags{1}.open_feature_idx(1).linkType == nix.LinkType.Tagged);
-    assert(f.blocks{1}.multiTags{1}.open_feature_idx(2).linkType == nix.LinkType.Untagged);
-    assert(f.blocks{1}.multiTags{1}.open_feature_idx(3).linkType == nix.LinkType.Indexed);
+    assert(f.blocks{1}.multiTags{1}.openFeatureIdx(1).linkType == nix.LinkType.Tagged);
+    assert(f.blocks{1}.multiTags{1}.openFeatureIdx(2).linkType == nix.LinkType.Untagged);
+    assert(f.blocks{1}.multiTags{1}.openFeatureIdx(3).linkType == nix.LinkType.Indexed);
 end
 
 %% Test: Open reference by ID or name
-function [] = test_open_reference( varargin )
+function [] = testOpenReference( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.createDataArray('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
     refName = 'referenceTest';
     tmp = b.createDataArray(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
-    t.add_reference(b.dataArrays{2}.id);
+    t.addReference(b.dataArrays{2}.id);
 
-    getRefByID = t.open_reference(t.references{1,1}.id);
+    getRefByID = t.openReference(t.references{1,1}.id);
     assert(~isempty(getRefByID));
 
-    getRefByName = t.open_reference(refName);
+    getRefByName = t.openReference(refName);
     assert(~isempty(getRefByName));
 
     %-- test open non existing reference
-    getRef = t.open_reference('I do not exist');
+    getRef = t.openReference('I do not exist');
     assert(isempty(getRef));
 end
 
-function [] = test_open_reference_idx( varargin )
+function [] = testOpenReferenceIdx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -466,55 +466,55 @@ function [] = test_open_reference_idx( varargin )
     r1 = b.createDataArray('testReference1', 'nixDataArray', nix.DataType.Bool, [2 2]);
     r2 = b.createDataArray('testReference2', 'nixDataArray', nix.DataType.Bool, [2 2]);
     r3 = b.createDataArray('testReference3', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.add_reference(r1);
-    t.add_reference(r2);
-    t.add_reference(r3);
+    t.addReference(r1);
+    t.addReference(r2);
+    t.addReference(r3);
 
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(1).name, r1.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(2).name, r2.name));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_reference_idx(3).name, r3.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openReferenceIdx(1).name, r1.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openReferenceIdx(2).name, r2.name));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openReferenceIdx(3).name, r3.name));
 end
 
 %% Test: Feature count
-function [] = test_feature_count( varargin )
+function [] = testFeatureCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da);
 
-    assert(t.feature_count() == 0);
-    t.add_feature(b.createDataArray('testDataArray1', 'nixDataArray', ...
+    assert(t.featureCount() == 0);
+    t.addFeature(b.createDataArray('testDataArray1', 'nixDataArray', ...
         nix.DataType.Double, [1 2]), nix.LinkType.Tagged);
-    assert(t.feature_count() == 1);
-    t.add_feature(b.createDataArray('testDataArray2', 'nixDataArray', ...
+    assert(t.featureCount() == 1);
+    t.addFeature(b.createDataArray('testDataArray2', 'nixDataArray', ...
         nix.DataType.Double, [3 4]), nix.LinkType.Tagged);
 
     clear t da b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multiTags{1}.feature_count() == 2);
+    assert(f.blocks{1}.multiTags{1}.featureCount() == 2);
 end
 
 %% Test: Reference count
-function [] = test_reference_count( varargin )
+function [] = testReferenceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da);
 
-    assert(t.reference_count() == 0);
-    t.add_reference(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
-    assert(t.reference_count() == 1);
-    t.add_reference(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
+    assert(t.referenceCount() == 0);
+    t.addReference(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
+    assert(t.referenceCount() == 1);
+    t.addReference(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
     
     clear t da b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multiTags{1}.reference_count() == 2);
+    assert(f.blocks{1}.multiTags{1}.referenceCount() == 2);
 end
 
 %% Test: Add positions by entity and id
-function [] = test_add_positions ( varargin )
+function [] = testAddPositions ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     posName1 = 'positionsTest1';
     posName2 = 'positionsTest2';
@@ -527,45 +527,45 @@ function [] = test_add_positions ( varargin )
     tmp = b.createDataArray(posName1, 'nixDataArray', nix.DataType.Double, [0 1]);
     tmp = b.createDataArray(posName2, 'nixDataArray', nix.DataType.Double, [2 4]);
 
-    t.add_positions(b.dataArrays{2}.id);
-    assert(strcmp(t.open_positions.name, posName1));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_positions.name, posName1));
+    t.addPositions(b.dataArrays{2}.id);
+    assert(strcmp(t.openPositions.name, posName1));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openPositions.name, posName1));
 
-    t.add_positions(b.dataArrays{3});
-    assert(strcmp(t.open_positions.name, posName2));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_positions.name, posName2));
+    t.addPositions(b.dataArrays{3});
+    assert(strcmp(t.openPositions.name, posName2));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openPositions.name, posName2));
     
     clear tmp t b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_positions.name, posName2));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openPositions.name, posName2));
 end
 
 %% Test: Has positions
-function [] = test_has_positions( varargin )
+function [] = testHasPositions( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('positionsTest', 'nixBlock');
     tmp = b.createDataArray('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
-    t.add_positions(b.dataArrays{2}.id);
-    assert(t.has_positions);
+    t.addPositions(b.dataArrays{2}.id);
+    assert(t.hasPositions);
 end
 
 %% Test: Open positions
-function [] = test_open_positions( varargin )
+function [] = testOpenPositions( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('positionsTest', 'nixBlock');
     tmp = b.createDataArray('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
-    t.add_positions(b.dataArrays{2}.id);
-    assert(~isempty(t.open_positions));
+    t.addPositions(b.dataArrays{2}.id);
+    assert(~isempty(t.openPositions));
 end
 
 %% Test: Set extents by entity and ID, open and reset extents
-function [] = test_set_open_extents ( varargin )
+function [] = testSetOpenExtents ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('extentsTest', 'nixBlock');
@@ -580,28 +580,28 @@ function [] = test_set_open_extents ( varargin )
     tmp = b.createDataArray(extName1, 'nixDataArray', nix.DataType.Double, [1, 1]);
     tmp = b.createDataArray(extName2, 'nixDataArray', nix.DataType.Double, [1, 3]);
 
-    assert(isempty(t.open_extents));
-    assert(isempty(f.blocks{1}.multiTags{1}.open_extents));
+    assert(isempty(t.openExtents));
+    assert(isempty(f.blocks{1}.multiTags{1}.openExtents));
     
-    t.add_positions(b.dataArrays{2});
-    t.set_extents(b.dataArrays{4}.id);
-    assert(strcmp(t.open_extents.name, extName1));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_extents.name, extName1));
+    t.addPositions(b.dataArrays{2});
+    t.setExtents(b.dataArrays{4}.id);
+    assert(strcmp(t.openExtents.name, extName1));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openExtents.name, extName1));
 
-    t.set_extents('');
-    assert(isempty(t.open_extents));
-    assert(isempty(f.blocks{1}.multiTags{1}.open_extents));
+    t.setExtents('');
+    assert(isempty(t.openExtents));
+    assert(isempty(f.blocks{1}.multiTags{1}.openExtents));
     
-    t.add_positions(b.dataArrays{3});
-    t.set_extents(b.dataArrays{5});
+    t.addPositions(b.dataArrays{3});
+    t.setExtents(b.dataArrays{5});
     
     clear tmp t da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_extents.name, extName2));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openExtents.name, extName2));
 end
 
 %% Test: Set metadata
-function [] = test_set_metadata ( varargin )
+function [] = testSetMetadata ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     secName1 = 'testSection1';
     secName2 = 'testSection2';
@@ -635,7 +635,7 @@ function [] = test_set_metadata ( varargin )
 end
 
 %% Test: Open metadata
-function [] = test_open_metadata( varargin )
+function [] = testOpenMetadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
@@ -647,7 +647,7 @@ function [] = test_open_metadata( varargin )
 end
 
 %% Test: Retrieve reference data by id or name
-function [] = test_retrieve_data( varargin )
+function [] = testRetrieveData( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
@@ -665,7 +665,7 @@ function [] = test_retrieve_data( varargin )
     d_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d_pos);
-    t.set_extents(d_ext);
+    t.setExtents(d_ext);
 
     % create 2D reference data_arrays
     raw1 = [111, 112, 113, 114, 115, 116, 117, 118; ...
@@ -681,12 +681,12 @@ function [] = test_retrieve_data( varargin )
     d2.appendSampledDimension(1);
 
     % add data_arrays as references to multi tag
-    t.add_reference(d1);
-    t.add_reference(d2);
+    t.addReference(d1);
+    t.addReference(d2);
 
     % test invalid position idx
     try
-        t.retrieve_data(100, 'reference1');
+        t.retrieveData(100, 'reference1');
     catch ME
         assert(~isempty(strfind(ME.message, 'ounds of positions or extents')), ...
             'Invalid position index failed');
@@ -696,7 +696,7 @@ function [] = test_retrieve_data( varargin )
 
     % test invalid reference name
     try
-        t.retrieve_data(1, 'I do not exist');
+        t.retrieveData(1, 'I do not exist');
     catch ME
         assert(~isempty(strfind(ME.message, 'no DataArray with the specified name or id')), ...
             'Invalid reference name failed');
@@ -704,13 +704,13 @@ function [] = test_retrieve_data( varargin )
     assert(exist('ME') == 1, 'Invalid reference name fail, error not raised');
     clear ME;
  
-    assert(isequal(t.retrieve_data(1, d1.name), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
-    assert(isequal(t.retrieve_data(2, d1.id), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
-    assert(isequal(t.retrieve_data(3, d2.id), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
+    assert(isequal(t.retrieveData(1, d1.name), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
+    assert(isequal(t.retrieveData(2, d1.id), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
+    assert(isequal(t.retrieveData(3, d2.id), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
 end
 
 %% Test: Retrieve reference data by index
-function [] = test_retrieve_data_idx( varargin )
+function [] = testRetrieveDataIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
@@ -728,7 +728,7 @@ function [] = test_retrieve_data_idx( varargin )
     d_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d_pos);
-    t.set_extents(d_ext);
+    t.setExtents(d_ext);
 
     % create 2D reference data_arrays
     raw1 = [111, 112, 113, 114, 115, 116, 117, 118; ...
@@ -744,12 +744,12 @@ function [] = test_retrieve_data_idx( varargin )
     d2.appendSampledDimension(1);
 
     % add data_arrays as references to multi tag
-    t.add_reference(d1);
-    t.add_reference(d2);
+    t.addReference(d1);
+    t.addReference(d2);
 
     % test invalid position idx
     try
-        t.retrieve_data_idx(100, 1);
+        t.retrieveDataIdx(100, 1);
     catch ME
         assert(~isempty(strfind(ME.message, 'ounds of positions or extents')), ...
             'Invalid position index failed');
@@ -757,19 +757,19 @@ function [] = test_retrieve_data_idx( varargin )
 
     % test invalid reference idx
     try
-        t.retrieve_data_idx(1, 100);
+        t.retrieveDataIdx(1, 100);
     catch ME
         assert(~isempty(strfind(ME.message, 'out of bounds')), ...
             'Invalid reference index failed');
     end
     
-    assert(isequal(t.retrieve_data_idx(1, 1), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
-    assert(isequal(t.retrieve_data_idx(2, 1), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
-    assert(isequal(t.retrieve_data_idx(3, 2), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
+    assert(isequal(t.retrieveDataIdx(1, 1), raw1(1:1)), 'Retrieve pos 1, ref 1 fail');
+    assert(isequal(t.retrieveDataIdx(2, 1), raw1(2, 2:4)), 'Retrieve pos 2, ref 1 fail');
+    assert(isequal(t.retrieveDataIdx(3, 2), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
 end
 
 %% Test: Retrieve feature data by id or name
-function [] = test_retrieve_feature_data( varargin )
+function [] = testRetrieveFeatureData( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
@@ -798,16 +798,16 @@ function [] = test_retrieve_feature_data( varargin )
     da_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da_pos);
-    t.set_extents(da_ext);
+    t.setExtents(da_ext);
 
     % add feature data_arrays
-    t.add_feature(da_feat1, nix.LinkType.Untagged);
-    t.add_feature(da_feat2, nix.LinkType.Tagged);
-    t.add_feature(da_feat3, nix.LinkType.Indexed);
+    t.addFeature(da_feat1, nix.LinkType.Untagged);
+    t.addFeature(da_feat2, nix.LinkType.Tagged);
+    t.addFeature(da_feat3, nix.LinkType.Indexed);
 
     % test invalid position idx
     try
-        t.retrieve_feature_data(100, '');
+        t.retrieveFeatureData(100, '');
     catch ME
         assert(isempty(strfind(ME.message, 'ounds of positions or extents')), ...
             'Invalid position index failed');
@@ -817,7 +817,7 @@ function [] = test_retrieve_feature_data( varargin )
 
     % test invalid name or id
     try
-        t.retrieve_feature_data(1, 'I do not exist');
+        t.retrieveFeatureData(1, 'I do not exist');
     catch ME
         assert(~isempty(strfind(ME.message, 'no Feature with the specified name or id')), ...
             'Invalid reference name failed');
@@ -826,29 +826,29 @@ function [] = test_retrieve_feature_data( varargin )
     clear ME;
 
     % test untagged ignores position and returns full data
-    retData = t.retrieve_feature_data(100, da_feat1.name);
+    retData = t.retrieveFeatureData(100, da_feat1.name);
     assert(isequal(raw_feat1, retData), 'Untagged fail');
 
     % test tagged properly applies position and extents
-    retData = t.retrieve_feature_data(1, da_feat2.id);
+    retData = t.retrieveFeatureData(1, da_feat2.id);
     assert(isequal(retData, [21]), 'Tagged pos 1 fail');
 
-    retData = t.retrieve_feature_data(2, da_feat2.name);
+    retData = t.retrieveFeatureData(2, da_feat2.name);
     assert(isequal(retData, [24]), 'Tagged pos 2 fail');
 
-    retData = t.retrieve_feature_data(3, da_feat2.id);
+    retData = t.retrieveFeatureData(3, da_feat2.id);
     assert(isequal(retData, [26, 27, 28]), 'Tagged pos 3 fail');
 
     % test indexed returns first and last index value
-    retData = t.retrieve_feature_data(1, da_feat3.id);
+    retData = t.retrieveFeatureData(1, da_feat3.id);
     assert(isequal(retData, raw_feat3(1)), 'Indexed first pos fail');
     
-    retData = t.retrieve_feature_data(8, da_feat3.name);
+    retData = t.retrieveFeatureData(8, da_feat3.name);
     assert(isequal(retData, raw_feat3(end)), 'Indexed last pos fail');
     
     % test indexed fail when accessing position > length of referenced array
     try
-        t.retrieve_feature_data(size(raw_feat3, 2) + 2, da_feat3.id);
+        t.retrieveFeatureData(size(raw_feat3, 2) + 2, da_feat3.id);
     catch ME
         assert(~isempty(strfind(ME.message, 'than the data stored in the feature')), ...
             'Indexed out of length fail');
@@ -858,7 +858,7 @@ function [] = test_retrieve_feature_data( varargin )
 end
 
 %% Test: Retrieve feature data
-function [] = test_retrieve_feature_data_idx( varargin )
+function [] = testRetrieveFeatureDataIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
 
@@ -887,16 +887,16 @@ function [] = test_retrieve_feature_data_idx( varargin )
     da_ext.appendSampledDimension(0);
 
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da_pos);
-    t.set_extents(da_ext);
+    t.setExtents(da_ext);
 
     % add feature data_arrays
-    t.add_feature(da_feat1, nix.LinkType.Untagged);
-    t.add_feature(da_feat2, nix.LinkType.Tagged);
-    t.add_feature(da_feat3, nix.LinkType.Indexed);
+    t.addFeature(da_feat1, nix.LinkType.Untagged);
+    t.addFeature(da_feat2, nix.LinkType.Tagged);
+    t.addFeature(da_feat3, nix.LinkType.Indexed);
 
     % test invalid position idx
     try
-        t.retrieve_feature_data_idx(100, 2);
+        t.retrieveFeatureDataIdx(100, 2);
     catch ME
         assert(~isempty(strfind(ME.message, 'ounds of positions')), ...
             'Invalid position index failed');
@@ -906,7 +906,7 @@ function [] = test_retrieve_feature_data_idx( varargin )
 
     % test invalid feature idx
     try
-        t.retrieve_feature_data_idx(1, 100);
+        t.retrieveFeatureDataIdx(1, 100);
     catch ME
         assert(~isempty(strfind(ME.message, 'out of bounds')), ...
             'Invalid reference index failed');
@@ -915,29 +915,29 @@ function [] = test_retrieve_feature_data_idx( varargin )
     clear ME;
 
     % test untagged ignores position and returns full data
-    retData = t.retrieve_feature_data_idx(100, 1);
+    retData = t.retrieveFeatureDataIdx(100, 1);
     assert(isequal(raw_feat1, retData), 'Untagged fail');
 
     % test tagged properly applies position and extents
-    retData = t.retrieve_feature_data_idx(1, 2);
+    retData = t.retrieveFeatureDataIdx(1, 2);
     assert(isequal(retData, [21]), 'Tagged pos 1 fail');
 
-    retData = t.retrieve_feature_data_idx(2, 2);
+    retData = t.retrieveFeatureDataIdx(2, 2);
     assert(isequal(retData, [24]), 'Tagged pos 2 fail');
 
-    retData = t.retrieve_feature_data_idx(3, 2);
+    retData = t.retrieveFeatureDataIdx(3, 2);
     assert(isequal(retData, [26, 27, 28]), 'Tagged pos 3 fail');
 
     % test indexed returns first and last index value
-    retData = t.retrieve_feature_data_idx(1, 3);
+    retData = t.retrieveFeatureDataIdx(1, 3);
     assert(isequal(retData, raw_feat3(1)), 'Indexed first pos fail');
     
-    retData = t.retrieve_feature_data_idx(8, 3);
+    retData = t.retrieveFeatureDataIdx(8, 3);
     assert(isequal(retData, raw_feat3(end)), 'Indexed last pos fail');
     
     % test indexed fail when accessing position > length of referenced array
     try
-        t.retrieve_feature_data_idx(size(raw_feat3, 2) + 2, 3);
+        t.retrieveFeatureDataIdx(size(raw_feat3, 2) + 2, 3);
     catch ME
         assert(~isempty(strfind(ME.message, 'than the data stored in the feature')), ...
             'Indexed out of length fail');
@@ -947,26 +947,26 @@ function [] = test_retrieve_feature_data_idx( varargin )
 end
 
 %% Test: nix.MultiTag has feature by ID
-function [] = test_has_feature( varargin )
+function [] = testHasFeature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('featureTest', 'nixMultiTag', da);
     daf = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feature = t.add_feature(daf, nix.LinkType.Tagged);
+    feature = t.addFeature(daf, nix.LinkType.Tagged);
     featureID = feature.id;
 
-    assert(~t.has_feature('I do not exist'));
-    assert(t.has_feature(featureID));
+    assert(~t.hasFeature('I do not exist'));
+    assert(t.hasFeature(featureID));
 
     clear feature daf t da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multiTags{1}.has_feature(featureID));
+    assert(f.blocks{1}.multiTags{1}.hasFeature(featureID));
 end
 
 %% Test: nix.MultiTag has reference by ID or name
-function [] = test_has_reference( varargin )
+function [] = testHasReference( varargin )
     fileName = 'testRW.h5';
     daName = 'refTestDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -975,18 +975,18 @@ function [] = test_has_reference( varargin )
     t = b.createMultiTag('referenceTest', 'nixMultiTag', da);
     refName = 'referenceTest';
     daRef = b.createDataArray(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
-    t.add_reference(daRef.id);
+    t.addReference(daRef.id);
 
-    assert(~t.has_reference('I do not exist'));
-    assert(t.has_reference(daRef.id));
+    assert(~t.hasReference('I do not exist'));
+    assert(t.hasReference(daRef.id));
 
     clear t daRef da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.multiTags{1}.has_reference(refName));
+    assert(f.blocks{1}.multiTags{1}.hasReference(refName));
 end
 
 %% Test: Set units
-function [] = test_set_units( varargin )
+function [] = testSetUnits( varargin )
     fileName = 'testRW.h5';
     daName = 'testDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -1020,7 +1020,7 @@ function [] = test_set_units( varargin )
 end
 
 %% Test: Read and write nix.MultiTag attributes
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -1052,7 +1052,7 @@ function [] = test_attrs( varargin )
     assert(isequal(f.blocks{1}.multiTags{1}.type, testType));
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare MultiTag entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -1070,7 +1070,7 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter sources
-function [] = test_filter_source( varargin )
+function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -1146,7 +1146,7 @@ function [] = test_filter_source( varargin )
 end
 
 %% Test: filter references
-function [] = test_filter_reference( varargin )
+function [] = testFilterReference( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -1154,106 +1154,106 @@ function [] = test_filter_reference( varargin )
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
     d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
-    t.add_reference(d);
+    t.addReference(d);
     filterID = d.id;
 	d = b.createDataArray('testDataArray1', filterType, nix.DataType.Double, [1 2]);
-    t.add_reference(d);
+    t.addReference(d);
     filterIDs = {filterID, d.id};
     d = b.createDataArray('testDataArray2', filterType, nix.DataType.Double, [1 2]);
-    t.add_reference(d);
+    t.addReference(d);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_references(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.add_reference(main);
+    t.addReference(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_references(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.add_reference(main);
+    t.addReference(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_references(nix.Filter.source, 'Do not exist')));
+    assert(isempty(f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.source, 'Do not exist')));
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.multiTags{1}.filter_references(nix.Filter.source, subID);
+    filtered = f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: filter features
-function [] = test_filter_feature( varargin )
+function [] = testFilterFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
     d = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.add_feature(d, nix.LinkType.Tagged);
+    feat = t.addFeature(d, nix.LinkType.Tagged);
     filterID = feat.id;
 	d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.add_feature(d, nix.LinkType.Tagged);
+    feat = t.addFeature(d, nix.LinkType.Tagged);
     filterIDs = {filterID, feat.id};
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.multiTags{1}.filter_features(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.multiTags{1}.filter_features(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.multiTags{1}.filter_features(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.multiTags{1}.filter_features(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
 
     % test fail on nix.Filter.name
     err = 'unknown or unsupported filter';
     try
-        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.name, 'someName');
+        f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.name, 'someName');
     catch ME
         assert(strcmp(ME.message, err));
     end
@@ -1261,7 +1261,7 @@ function [] = test_filter_feature( varargin )
     % test fail on nix.Filter.type
     err = 'unknown or unsupported filter';
     try
-        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.type, 'someType');
+        f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.type, 'someType');
     catch ME
         assert(strcmp(ME.message, err));
     end
@@ -1269,14 +1269,14 @@ function [] = test_filter_feature( varargin )
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.metadata, 'someMetadata');
+        f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.metadata, 'someMetadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        f.blocks{1}.multiTags{1}.filter_features(nix.Filter.source, 'someSource');
+        f.blocks{1}.multiTags{1}.filterFeatures(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -614,25 +614,26 @@ function [] = testSetMetadata ( varargin )
     tmp = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createMultiTag('metadataTest', 'nixMultiTag', b.dataArrays{1});
 
-    assert(isempty(t.open_metadata));
-    assert(isempty(f.blocks{1}.multiTags{1}.open_metadata));
+    assert(isempty(t.openMetadata));
+    assert(isempty(f.blocks{1}.multiTags{1}.openMetadata));
 
-    t.set_metadata(f.sections{1});
-    assert(strcmp(t.open_metadata.name, secName1));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_metadata.name, secName1));
+    t.setMetadata(f.sections{1});
+    assert(strcmp(t.openMetadata.name, secName1));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openMetadata.name, secName1));
 
-    t.set_metadata(f.sections{2});
-    assert(strcmp(t.open_metadata.name, secName2));
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_metadata.name, secName2));
+    t.setMetadata(f.sections{2});
+    assert(strcmp(t.openMetadata.name, secName2));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openMetadata.name, secName2));
     
-    t.set_metadata('');
-    assert(isempty(t.open_metadata));
-    assert(isempty(f.blocks{1}.multiTags{1}.open_metadata));
+    t.setMetadata('');
+    assert(isempty(t.openMetadata));
+    assert(isempty(f.blocks{1}.multiTags{1}.openMetadata));
     
-    t.set_metadata(f.sections{2});
+    t.setMetadata(f.sections{2});
+
     clear tmp t b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.multiTags{1}.open_metadata.name, secName2));
+    assert(strcmp(f.blocks{1}.multiTags{1}.openMetadata.name, secName2));
 end
 
 %% Test: Open metadata
@@ -642,9 +643,9 @@ function [] = testOpenMetadata( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     tmp = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createMultiTag('metadataTest', 'nixMultiTag', b.dataArrays{1});
-    t.set_metadata(f.sections{1});
+    t.setMetadata(f.sections{1});
 
-    assert(strcmp(t.open_metadata.name, 'testSection'));
+    assert(strcmp(t.openMetadata.name, 'testSection'));
 end
 
 %% Test: Retrieve reference data by id or name
@@ -1119,7 +1120,7 @@ function [] = testFilterSource( varargin )
     t.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainSource.set_metadata(s);
+    mainSource.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.multiTags{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
@@ -1195,7 +1196,7 @@ function [] = testFilterReference( varargin )
     t.addReference(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    main.set_metadata(s);
+    main.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.multiTags{1}.filterReferences(nix.Filter.metadata, 'Do not exist')));

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -57,11 +57,11 @@ function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    s = b.create_source('sourceTest', 'nixSource');
+    tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.createSource('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
-    mTag = b.create_multi_tag('sourcetest', 'nixMultiTag', b.dataArrays{1});
+    mTag = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
 
     assert(isempty(mTag.sources));
     assert(isempty(f.blocks{1}.multiTags{1}.sources));
@@ -84,11 +84,11 @@ function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_source('testSource1', 'nixSource');
-    tmp = b.create_source('testSource2', 'nixSource');
-    tmp = b.create_source('testSource3', 'nixSource');
+    tmp = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createSource('testSource1', 'nixSource');
+    tmp = b.createSource('testSource2', 'nixSource');
+    tmp = b.createSource('testSource3', 'nixSource');
 
     assert(isempty(t.sources));
 
@@ -118,22 +118,22 @@ end
 function [] = test_remove_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getSource = b.create_source('sourceTest', 'nixSource');
-    tmp = getSource.create_source('nestedSource1', 'nixSource');
-    tmp = getSource.create_source('nestedSource2', 'nixSource');
-    getMTag = b.create_multi_tag('sourcetest', 'nixMultiTag', b.dataArrays{1});
+    s = b.createSource('sourceTest', 'nixSource');
+    tmp = s.create_source('nestedSource1', 'nixSource');
+    tmp = s.create_source('nestedSource2', 'nixSource');
+    t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
 
-    getMTag.add_source(getSource.sources{1}.id);
-    getMTag.add_source(getSource.sources{2});
+    t.add_source(s.sources{1}.id);
+    t.add_source(s.sources{2});
 
-    getMTag.remove_source(getSource.sources{2});
-    assert(size(getMTag.sources,1) == 1);
-    getMTag.remove_source(getSource.sources{1}.id);
-    assert(isempty(getMTag.sources));
-    assert(getMTag.remove_source('I do not exist'));
-    assert(size(getSource.sources,1) == 2);
+    t.remove_source(s.sources{2});
+    assert(size(t.sources,1) == 1);
+    t.remove_source(s.sources{1}.id);
+    assert(isempty(t.sources));
+    assert(t.remove_source('I do not exist'));
+    assert(size(s.sources,1) == 2);
 end
 
 %% Test: Add references by entity and id
@@ -141,12 +141,12 @@ function [] = test_add_reference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    mTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    mTag = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
 
     assert(isempty(mTag.references));
@@ -170,10 +170,10 @@ function [] = test_add_references ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('referenceTest3', 'nixDataArray', nix.DataType.Double, [3 4]);
 
     assert(isempty(t.references));
 
@@ -203,22 +203,22 @@ end
 function [] = test_remove_reference ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
+    t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
-    getMTag.add_reference(b.dataArrays{2}.id);
-    getMTag.add_reference(b.dataArrays{3});
+    t.add_reference(b.dataArrays{2}.id);
+    t.add_reference(b.dataArrays{3});
 
-    assert(getMTag.remove_reference(b.dataArrays{3}));
-    assert(getMTag.remove_reference(b.dataArrays{2}.id));
-    assert(isempty(getMTag.references));
+    assert(t.remove_reference(b.dataArrays{3}));
+    assert(t.remove_reference(b.dataArrays{2}.id));
+    assert(isempty(t.references));
 
-    assert(~getMTag.remove_reference('I do not exist'));
+    assert(~t.remove_reference('I do not exist'));
     assert(size(b.dataArrays, 1) == 3);
 end
 
@@ -227,20 +227,20 @@ function [] = test_add_feature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    mTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    mTag = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA3', 'nixDataArray', nix.DataType.Double, [5 6]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA4', 'nixDataArray', nix.DataType.Double, [7 8]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA5', 'nixDataArray', nix.DataType.Double, [9 10]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA6', 'nixDataArray', nix.DataType.Double, [11 12]);
 
     assert(isempty(mTag.features));
@@ -263,23 +263,23 @@ end
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-	tmp = b.create_data_array(...
+	tmp = b.createDataArray(...
         'featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
+    t = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array(...
+    tmp = b.createDataArray(...
         'featTestDA2', 'nixDataArray', nix.DataType.Double, [3 4]);
 
-    tmp = getMTag.add_feature(b.dataArrays{2}.id, nix.LinkType.Tagged);
-    tmp = getMTag.add_feature(b.dataArrays{3}, nix.LinkType.Tagged);
+    tmp = t.add_feature(b.dataArrays{2}.id, nix.LinkType.Tagged);
+    tmp = t.add_feature(b.dataArrays{3}, nix.LinkType.Tagged);
 
-    assert(getMTag.remove_feature(getMTag.features{2}.id));
-    assert(getMTag.remove_feature(getMTag.features{1}));
-    assert(isempty(getMTag.features));
+    assert(t.remove_feature(t.features{2}.id));
+    assert(t.remove_feature(t.features{1}));
+    assert(isempty(t.features));
 
-    assert(~getMTag.remove_feature('I do not exist'));
+    assert(~t.remove_feature('I do not exist'));
     assert(size(b.dataArrays, 1) == 3);
 end
 
@@ -287,75 +287,75 @@ end
 function [] = test_fetch_references( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
-    getMTag.add_reference(b.dataArrays{2}.id);
-    getMTag.add_reference(b.dataArrays{3});
+    tmp = b.createDataArray('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [5 6]);
+    t.add_reference(b.dataArrays{2}.id);
+    t.add_reference(b.dataArrays{3});
 
-    assert(size(getMTag.references, 1) == 2);
+    assert(size(t.references, 1) == 2);
 end
 
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getSource = b.create_source('sourceTest', 'nixSource');
-    tmp = getSource.create_source('nestedSource1', 'nixSource');
-    tmp = getSource.create_source('nestedSource2', 'nixSource');
-    getMTag = b.create_multi_tag('sourcetest', 'nixMultiTag', b.dataArrays{1});
-    getMTag.add_source(getSource.sources{1}.id);
-    getMTag.add_source(getSource.sources{2});
+    tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.createSource('sourceTest', 'nixSource');
+    tmp = s.create_source('nestedSource1', 'nixSource');
+    tmp = s.create_source('nestedSource2', 'nixSource');
+    t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
+    t.add_source(s.sources{1}.id);
+    t.add_source(s.sources{2});
 
-    assert(size(getMTag.sources, 1) == 2);
+    assert(size(t.sources, 1) == 2);
 end
 
 %% Test: fetch features
 function [] = test_fetch_features( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    assert(isempty(getMTag.features));
-    tmp = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = getMTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
-    assert(size(getMTag.features, 1) == 1);
+    assert(isempty(t.features));
+    tmp = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = t.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
+    assert(size(t.features, 1) == 1);
 end
 
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getSource = b.create_source('sourceTest', 'nixSource');
+    tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.createSource('sourceTest', 'nixSource');
     sName = 'nestedSource';
-    tmp = getSource.create_source(sName, 'nixSource');
-    getMTag = b.create_multi_tag('sourcetest', 'nixMultiTag', b.dataArrays{1});
-    getMTag.add_source(getSource.sources{1});
+    tmp = s.create_source(sName, 'nixSource');
+    t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
+    t.add_source(s.sources{1});
 
-    getSourceByID = getMTag.open_source(getMTag.sources{1,1}.id);
+    getSourceByID = t.open_source(t.sources{1,1}.id);
     assert(~isempty(getSourceByID));
 
-    getSourceByName = getMTag.open_source(sName);
+    getSourceByName = t.open_source(sName);
     assert(~isempty(getSourceByName));
     
     %-- test open non existing source
-    getSource = getMTag.open_source('I do not exist');
-    assert(isempty(getSource));
+    s = t.open_source('I do not exist');
+    assert(isempty(s));
 end
 
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
-    s1 = b.create_source('testSource1', 'nixSource');
-    s2 = b.create_source('testSource2', 'nixSource');
-    s3 = b.create_source('testSource3', 'nixSource');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
+    s1 = b.createSource('testSource1', 'nixSource');
+    s2 = b.createSource('testSource2', 'nixSource');
+    s3 = b.createSource('testSource3', 'nixSource');
     t.add_source(s1);
     t.add_source(s2);
     t.add_source(s3);
@@ -370,10 +370,10 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.create_source('sourceTest1', 'nixSource');
+    s = b.createSource('sourceTest1', 'nixSource');
     sID = s.id;
-    tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('sourcetest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('sourcetest', 'nixMultiTag', b.dataArrays{1});
     t.add_source(b.sources{1});
 
     assert(~t.has_source('I do not exist'));
@@ -389,13 +389,13 @@ function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 
     assert(t.source_count() == 0);
-    t.add_source(b.create_source('testSource1', 'nixSource'));
+    t.add_source(b.createSource('testSource1', 'nixSource'));
     assert(t.source_count() == 1);
-    t.add_source(b.create_source('testSource2', 'nixSource'));
+    t.add_source(b.createSource('testSource2', 'nixSource'));
 
     clear t d b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -406,15 +406,15 @@ end
 function [] = test_open_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = getMTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
-    assert(~isempty(getMTag.open_feature(getMTag.features{1}.id)));
+    tmp = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = t.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
+    assert(~isempty(t.open_feature(t.features{1}.id)));
 
     %-- test open non existing feature
-    getFeat = getMTag.open_feature('I do not exist');
+    getFeat = t.open_feature('I do not exist');
     assert(isempty(getFeat));
 end
 
@@ -422,11 +422,11 @@ function [] = test_open_feature_idx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
-    f1 = b.create_data_array('testFeature1', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    f2 = b.create_data_array('testFeature2', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    f3 = b.create_data_array('testFeature3', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
+    f1 = b.createDataArray('testFeature1', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    f2 = b.createDataArray('testFeature2', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    f3 = b.createDataArray('testFeature3', 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_feature(f1, nix.LinkType.Tagged);
     t.add_feature(f2, nix.LinkType.Untagged);
     t.add_feature(f3, nix.LinkType.Indexed);
@@ -440,20 +440,20 @@ end
 function [] = test_open_reference( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('referencetest', 'nixMultiTag', b.dataArrays{1});
     refName = 'referenceTest';
-    tmp = b.create_data_array(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
-    getMTag.add_reference(b.dataArrays{2}.id);
+    tmp = b.createDataArray(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
+    t.add_reference(b.dataArrays{2}.id);
 
-    getRefByID = getMTag.open_reference(getMTag.references{1,1}.id);
+    getRefByID = t.open_reference(t.references{1,1}.id);
     assert(~isempty(getRefByID));
 
-    getRefByName = getMTag.open_reference(refName);
+    getRefByName = t.open_reference(refName);
     assert(~isempty(getRefByName));
 
     %-- test open non existing reference
-    getRef = getMTag.open_reference('I do not exist');
+    getRef = t.open_reference('I do not exist');
     assert(isempty(getRef));
 end
 
@@ -461,11 +461,11 @@ function [] = test_open_reference_idx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
-    r1 = b.create_data_array('testReference1', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    r2 = b.create_data_array('testReference2', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    r3 = b.create_data_array('testReference3', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
+    r1 = b.createDataArray('testReference1', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    r2 = b.createDataArray('testReference2', 'nixDataArray', nix.DataType.Bool, [2 2]);
+    r3 = b.createDataArray('testReference3', 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(r1);
     t.add_reference(r2);
     t.add_reference(r3);
@@ -480,14 +480,14 @@ function [] = test_feature_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da);
+    da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', da);
 
     assert(t.feature_count() == 0);
-    t.add_feature(b.create_data_array('testDataArray1', 'nixDataArray', ...
+    t.add_feature(b.createDataArray('testDataArray1', 'nixDataArray', ...
         nix.DataType.Double, [1 2]), nix.LinkType.Tagged);
     assert(t.feature_count() == 1);
-    t.add_feature(b.create_data_array('testDataArray2', 'nixDataArray', ...
+    t.add_feature(b.createDataArray('testDataArray2', 'nixDataArray', ...
         nix.DataType.Double, [3 4]), nix.LinkType.Tagged);
 
     clear t da b f;
@@ -500,13 +500,13 @@ function [] = test_reference_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da);
+    da = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', da);
 
     assert(t.reference_count() == 0);
-    t.add_reference(b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
+    t.add_reference(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
     assert(t.reference_count() == 1);
-    t.add_reference(b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
+    t.add_reference(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
     
     clear t da b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -521,21 +521,21 @@ function [] = test_add_positions ( varargin )
     
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('positionsTest', 'nixBlock');
-    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    mTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
 
-    tmp = b.create_data_array(posName1, 'nixDataArray', nix.DataType.Double, [0 1]);
-    tmp = b.create_data_array(posName2, 'nixDataArray', nix.DataType.Double, [2 4]);
+    tmp = b.createDataArray(posName1, 'nixDataArray', nix.DataType.Double, [0 1]);
+    tmp = b.createDataArray(posName2, 'nixDataArray', nix.DataType.Double, [2 4]);
 
-    mTag.add_positions(b.dataArrays{2}.id);
-    assert(strcmp(mTag.open_positions.name, posName1));
+    t.add_positions(b.dataArrays{2}.id);
+    assert(strcmp(t.open_positions.name, posName1));
     assert(strcmp(f.blocks{1}.multiTags{1}.open_positions.name, posName1));
 
-    mTag.add_positions(b.dataArrays{3});
-    assert(strcmp(mTag.open_positions.name, posName2));
+    t.add_positions(b.dataArrays{3});
+    assert(strcmp(t.open_positions.name, posName2));
     assert(strcmp(f.blocks{1}.multiTags{1}.open_positions.name, posName2));
     
-    clear tmp mTag b f;
+    clear tmp t b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
     assert(strcmp(f.blocks{1}.multiTags{1}.open_positions.name, posName2));
 end
@@ -544,24 +544,24 @@ end
 function [] = test_has_positions( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('positionsTest', 'nixBlock');
-    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
+    tmp = b.createDataArray('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
-    getMTag.add_positions(b.dataArrays{2}.id);
-    assert(getMTag.has_positions);
+    t.add_positions(b.dataArrays{2}.id);
+    assert(t.has_positions);
 end
 
 %% Test: Open positions
 function [] = test_open_positions( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('positionsTest', 'nixBlock');
-    tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
+    tmp = b.createDataArray('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
-    getMTag.add_positions(b.dataArrays{2}.id);
-    assert(~isempty(getMTag.open_positions));
+    t.add_positions(b.dataArrays{2}.id);
+    assert(~isempty(t.open_positions));
 end
 
 %% Test: Set extents by entity and ID, open and reset extents
@@ -569,33 +569,33 @@ function [] = test_set_open_extents ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('extentsTest', 'nixBlock');
-    da = b.create_data_array('extentsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6; 1 2 3 4 5 6]);
-    getMTag = b.create_multi_tag('extentstest', 'nixMultiTag', da);
+    da = b.createDataArray('extentsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6; 1 2 3 4 5 6]);
+    t = b.createMultiTag('extentstest', 'nixMultiTag', da);
 
-    tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [1, 1]);
-    tmp = b.create_data_array('positionsTest2', 'nixDataArray', nix.DataType.Double, [1, 3]);
+    tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [1, 1]);
+    tmp = b.createDataArray('positionsTest2', 'nixDataArray', nix.DataType.Double, [1, 3]);
 
     extName1 = 'extentsTest1';
     extName2 = 'extentsTest2';
-    tmp = b.create_data_array(extName1, 'nixDataArray', nix.DataType.Double, [1, 1]);
-    tmp = b.create_data_array(extName2, 'nixDataArray', nix.DataType.Double, [1, 3]);
+    tmp = b.createDataArray(extName1, 'nixDataArray', nix.DataType.Double, [1, 1]);
+    tmp = b.createDataArray(extName2, 'nixDataArray', nix.DataType.Double, [1, 3]);
 
-    assert(isempty(getMTag.open_extents));
+    assert(isempty(t.open_extents));
     assert(isempty(f.blocks{1}.multiTags{1}.open_extents));
     
-    getMTag.add_positions(b.dataArrays{2});
-    getMTag.set_extents(b.dataArrays{4}.id);
-    assert(strcmp(getMTag.open_extents.name, extName1));
+    t.add_positions(b.dataArrays{2});
+    t.set_extents(b.dataArrays{4}.id);
+    assert(strcmp(t.open_extents.name, extName1));
     assert(strcmp(f.blocks{1}.multiTags{1}.open_extents.name, extName1));
 
-    getMTag.set_extents('');
-    assert(isempty(getMTag.open_extents));
+    t.set_extents('');
+    assert(isempty(t.open_extents));
     assert(isempty(f.blocks{1}.multiTags{1}.open_extents));
     
-    getMTag.add_positions(b.dataArrays{3});
-    getMTag.set_extents(b.dataArrays{5});
+    t.add_positions(b.dataArrays{3});
+    t.set_extents(b.dataArrays{5});
     
-    clear tmp getMTag da b f;
+    clear tmp t da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
     assert(strcmp(f.blocks{1}.multiTags{1}.open_extents.name, extName2));
 end
@@ -610,8 +610,8 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection(secName2, 'nixSection');
 
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createMultiTag('metadataTest', 'nixMultiTag', b.dataArrays{1});
 
     assert(isempty(t.open_metadata));
     assert(isempty(f.blocks{1}.multiTags{1}.open_metadata));
@@ -639,8 +639,8 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
-    t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
+    t = b.createMultiTag('metadataTest', 'nixMultiTag', b.dataArrays{1});
     t.set_metadata(f.sections{1});
 
     assert(strcmp(t.open_metadata.name, 'testSection'));
@@ -656,27 +656,27 @@ function [] = test_retrieve_data( varargin )
     pos(3,:) = [0, 2]; ext(3,:) = [2, 4]; % result 113 114 115 116
                                           %        123 124 125 126
 
-	d_pos = b.create_data_array_from_data('positionsDA', 'nixDataArray', pos);
+	d_pos = b.createDataArrayFromData('positionsDA', 'nixDataArray', pos);
     d_pos.append_sampled_dimension(0);
     d_pos.append_sampled_dimension(0);
 
-    d_ext = b.create_data_array_from_data('extentsDA', 'nixDataArray', ext);
+    d_ext = b.createDataArrayFromData('extentsDA', 'nixDataArray', ext);
     d_ext.append_sampled_dimension(0);
     d_ext.append_sampled_dimension(0);
 
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d_pos);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d_pos);
     t.set_extents(d_ext);
 
     % create 2D reference data_arrays
     raw1 = [111, 112, 113, 114, 115, 116, 117, 118; ...
                 121, 122, 123, 124, 125, 126, 127, 128];
-    d1 = b.create_data_array_from_data('reference1', 'nixDataArray', raw1);
+    d1 = b.createDataArrayFromData('reference1', 'nixDataArray', raw1);
     d1.append_sampled_dimension(1);
     d1.append_sampled_dimension(1);
 
     raw2 = [211, 212, 213, 214, 215, 216, 217, 218; ...
                 221, 222, 223, 224, 225, 226, 227, 228];
-    d2 = b.create_data_array_from_data('reference2', 'nixDataArray', raw2);
+    d2 = b.createDataArrayFromData('reference2', 'nixDataArray', raw2);
     d2.append_sampled_dimension(1);
     d2.append_sampled_dimension(1);
 
@@ -719,27 +719,27 @@ function [] = test_retrieve_data_idx( varargin )
     pos(3,:) = [0, 2]; ext(3,:) = [2, 4]; % result 113 114 115 116
                                           %        123 124 125 126
 
-	d_pos = b.create_data_array_from_data('positionsDA', 'nixDataArray', pos);
+	d_pos = b.createDataArrayFromData('positionsDA', 'nixDataArray', pos);
     d_pos.append_sampled_dimension(0);
     d_pos.append_sampled_dimension(0);
 
-    d_ext = b.create_data_array_from_data('extentsDA', 'nixDataArray', ext);
+    d_ext = b.createDataArrayFromData('extentsDA', 'nixDataArray', ext);
     d_ext.append_sampled_dimension(0);
     d_ext.append_sampled_dimension(0);
 
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d_pos);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d_pos);
     t.set_extents(d_ext);
 
     % create 2D reference data_arrays
     raw1 = [111, 112, 113, 114, 115, 116, 117, 118; ...
                 121, 122, 123, 124, 125, 126, 127, 128];
-    d1 = b.create_data_array_from_data('reference1', 'nixDataArray', raw1);
+    d1 = b.createDataArrayFromData('reference1', 'nixDataArray', raw1);
     d1.append_sampled_dimension(1);
     d1.append_sampled_dimension(1);
 
     raw2 = [211, 212, 213, 214, 215, 216, 217, 218; ...
                 221, 222, 223, 224, 225, 226, 227, 228];
-    d2 = b.create_data_array_from_data('reference2', 'nixDataArray', raw2);
+    d2 = b.createDataArrayFromData('reference2', 'nixDataArray', raw2);
     d2.append_sampled_dimension(1);
     d2.append_sampled_dimension(1);
 
@@ -775,29 +775,29 @@ function [] = test_retrieve_feature_data( varargin )
 
     % create feature data arrays
     raw_feat1 = [11 12 13 14 15 16 17 18];
-    da_feat1 = b.create_data_array_from_data('feature1', 'nixDataArray', raw_feat1);
+    da_feat1 = b.createDataArrayFromData('feature1', 'nixDataArray', raw_feat1);
     da_feat1.append_sampled_dimension(1);
 
     raw_feat2 = [21 22 23 24 25 26 27 28];
-    da_feat2 = b.create_data_array_from_data('feature2', 'nixDataArray', raw_feat2);
+    da_feat2 = b.createDataArrayFromData('feature2', 'nixDataArray', raw_feat2);
     da_feat2.append_sampled_dimension(1);
 
     % create referenced data array
     raw_feat3 = [31 32 33 34 35 36 37 38];
-    da_feat3 = b.create_data_array_from_data('reference', 'nixDataArray', raw_feat3);
+    da_feat3 = b.createDataArrayFromData('reference', 'nixDataArray', raw_feat3);
     da_feat3.append_sampled_dimension(1);
 
     % create position, extents DA and multi tag
     pos = [0; 3; 5];
     ext = [1; 1; 3];
 
-    da_pos = b.create_data_array_from_data('positions', 'nixDataArray', pos);
-    da_ext = b.create_data_array_from_data('extents', 'nixDataArray', ext);
+    da_pos = b.createDataArrayFromData('positions', 'nixDataArray', pos);
+    da_ext = b.createDataArrayFromData('extents', 'nixDataArray', ext);
 
     da_pos.append_sampled_dimension(0);
     da_ext.append_sampled_dimension(0);
 
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da_pos);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', da_pos);
     t.set_extents(da_ext);
 
     % add feature data_arrays
@@ -864,29 +864,29 @@ function [] = test_retrieve_feature_data_idx( varargin )
 
     % create feature data arrays
     raw_feat1 = [11 12 13 14 15 16 17 18];
-    da_feat1 = b.create_data_array_from_data('feature1', 'nixDataArray', raw_feat1);
+    da_feat1 = b.createDataArrayFromData('feature1', 'nixDataArray', raw_feat1);
     da_feat1.append_sampled_dimension(1);
 
     raw_feat2 = [21 22 23 24 25 26 27 28];
-    da_feat2 = b.create_data_array_from_data('feature2', 'nixDataArray', raw_feat2);
+    da_feat2 = b.createDataArrayFromData('feature2', 'nixDataArray', raw_feat2);
     da_feat2.append_sampled_dimension(1);
 
     % create referenced data array
     raw_feat3 = [31 32 33 34 35 36 37 38];
-    da_feat3 = b.create_data_array_from_data('reference', 'nixDataArray', raw_feat3);
+    da_feat3 = b.createDataArrayFromData('reference', 'nixDataArray', raw_feat3);
     da_feat3.append_sampled_dimension(1);
 
     % create position, extents DA and multi tag
     pos = [0; 3; 5];
     ext = [1; 1; 3];
 
-    da_pos = b.create_data_array_from_data('positions', 'nixDataArray', pos);
-    da_ext = b.create_data_array_from_data('extents', 'nixDataArray', ext);
+    da_pos = b.createDataArrayFromData('positions', 'nixDataArray', pos);
+    da_ext = b.createDataArrayFromData('extents', 'nixDataArray', ext);
 
     da_pos.append_sampled_dimension(0);
     da_ext.append_sampled_dimension(0);
 
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da_pos);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', da_pos);
     t.set_extents(da_ext);
 
     % add feature data_arrays
@@ -951,9 +951,9 @@ function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('featureTest', 'nixMultiTag', da);
-    daf = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
+    da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('featureTest', 'nixMultiTag', da);
+    daf = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
     feature = t.add_feature(daf, nix.LinkType.Tagged);
     featureID = feature.id;
 
@@ -971,10 +971,10 @@ function [] = test_has_reference( varargin )
     daName = 'refTestDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTestBlock', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('referenceTest', 'nixMultiTag', da);
+    da = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('referenceTest', 'nixMultiTag', da);
     refName = 'referenceTest';
-    daRef = b.create_data_array(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
+    daRef = b.createDataArray(refName, 'nixDataArray', nix.DataType.Double, [3 4]);
     t.add_reference(daRef.id);
 
     assert(~t.has_reference('I do not exist'));
@@ -991,8 +991,8 @@ function [] = test_set_units( varargin )
     daName = 'testDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('unitsTest', 'nixMultiTag', da);
+    da = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('unitsTest', 'nixMultiTag', da);
 
     assert(isempty(t.units));
     try
@@ -1024,8 +1024,8 @@ function [] = test_attrs( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    tmp = b.create_data_array('attributeTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
+    tmp = b.createDataArray('attributeTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 
     testType = 'setType';
     testDefinition = 'definition';
@@ -1057,11 +1057,11 @@ function [] = test_compare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    d = b1.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 2]);
-    t1 = b1.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
-    t2 = b1.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
-    d = b2.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 2]);
-    t3 = b2.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
+    d = b1.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 2]);
+    t1 = b1.createMultiTag('testMultiTag1', 'nixMultiTag', d);
+    t2 = b1.createMultiTag('testMultiTag2', 'nixMultiTag', d);
+    d = b2.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 2]);
+    t3 = b2.createMultiTag('testMultiTag1', 'nixMultiTag', d);
 
     assert(t1.compare(t2) < 0);
     assert(t1.compare(t1) == 0);
@@ -1075,15 +1075,15 @@ function [] = test_filter_source( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 3]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
-    s = b.create_source(filterName, 'nixSource');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 3]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
+    s = b.createSource(filterName, 'nixSource');
     t.add_source(s);
     filterID = s.id;
-	s = b.create_source('testSource1', filterType);
+	s = b.createSource('testSource1', filterType);
     t.add_source(s);
     filterIDs = {filterID, s.id};
-    s = b.create_source('testSource2', filterType);
+    s = b.createSource('testSource2', filterType);
     t.add_source(s);
 
     % test empty id filter
@@ -1114,7 +1114,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     t.add_source(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -1128,7 +1128,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_source(mainName, 'nixSource');
+    main = b.createSource(mainName, 'nixSource');
     t.add_source(main);
     mainID = main.id;
     subName = 'testSubSource1';
@@ -1151,15 +1151,15 @@ function [] = test_filter_reference( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
-    d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
+    d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t.add_reference(d);
     filterID = d.id;
-	d = b.create_data_array('testDataArray1', filterType, nix.DataType.Double, [1 2]);
+	d = b.createDataArray('testDataArray1', filterType, nix.DataType.Double, [1 2]);
     t.add_reference(d);
     filterIDs = {filterID, d.id};
-    d = b.create_data_array('testDataArray2', filterType, nix.DataType.Double, [1 2]);
+    d = b.createDataArray('testDataArray2', filterType, nix.DataType.Double, [1 2]);
     t.add_reference(d);
 
     % test empty id filter
@@ -1190,7 +1190,7 @@ function [] = test_filter_reference( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -1204,11 +1204,11 @@ function [] = test_filter_reference( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
@@ -1224,12 +1224,12 @@ end
 function [] = test_filter_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
-    t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
-    d = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
+    t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
+    d = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     feat = t.add_feature(d, nix.LinkType.Tagged);
     filterID = feat.id;
-	d = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+	d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     feat = t.add_feature(d, nix.LinkType.Tagged);
     filterIDs = {filterID, feat.id};
 

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -56,7 +56,7 @@ end
 function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('sourceTest', 'nixBlock');
+    b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.create_source('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
@@ -83,7 +83,7 @@ end
 function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_source('testSource1', 'nixSource');
@@ -116,8 +116,8 @@ end
 
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('sourceTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.create_data_array(...
         'sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
@@ -140,7 +140,7 @@ end
 function [] = test_add_reference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('referenceTest', 'nixBlock');
+    b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     
@@ -169,7 +169,7 @@ end
 function [] = test_add_references ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
@@ -201,8 +201,8 @@ end
 
 %% Test: Remove references by entity and id
 function [] = test_remove_reference ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('referenceTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.create_data_array(...
         'referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
@@ -226,7 +226,7 @@ end
 function [] = test_add_feature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     mTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
@@ -262,7 +262,7 @@ end
 %% Test: Remove features by entity and id
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
 	tmp = b.create_data_array(...
         'featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
@@ -285,8 +285,8 @@ end
 
 %% Test: fetch references
 function [] = test_fetch_references( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('referenceTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [3 4]);
@@ -299,8 +299,8 @@ end
 
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('sourceTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
@@ -314,8 +314,8 @@ end
 
 %% Test: fetch features
 function [] = test_fetch_features( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('featureTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
@@ -327,8 +327,8 @@ end
 
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('sourceTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourceTest', 'nixBlock');
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getSource = b.create_source('sourceTest', 'nixSource');
     sName = 'nestedSource';
@@ -350,7 +350,7 @@ end
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
     s1 = b.create_source('testSource1', 'nixSource');
@@ -369,7 +369,7 @@ end
 function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     s = b.create_source('sourceTest1', 'nixSource');
     sID = s.id;
     tmp = b.create_data_array('sourceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -388,7 +388,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 
@@ -404,8 +404,8 @@ end
 
 %% Test: Open feature by ID
 function [] = test_open_feature( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('featureTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
@@ -421,7 +421,7 @@ end
 function [] = test_open_feature_idx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
     f1 = b.create_data_array('testFeature1', 'nixDataArray', nix.DataType.Bool, [2 2]);
@@ -438,8 +438,8 @@ end
 
 %% Test: Open reference by ID or name
 function [] = test_open_reference( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('referenceTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     getMTag = b.create_multi_tag('referencetest', 'nixMultiTag', b.dataArrays{1});
     refName = 'referenceTest';
@@ -460,7 +460,7 @@ end
 function [] = test_open_reference_idx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
     r1 = b.create_data_array('testReference1', 'nixDataArray', nix.DataType.Bool, [2 2]);
@@ -479,7 +479,7 @@ end
 function [] = test_feature_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da);
 
@@ -499,7 +499,7 @@ end
 function [] = test_reference_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     da = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', da);
 
@@ -520,7 +520,7 @@ function [] = test_add_positions ( varargin )
     posName2 = 'positionsTest2';
     
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('positionsTest', 'nixBlock');
+    b = f.createBlock('positionsTest', 'nixBlock');
     tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     mTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
 
@@ -542,8 +542,8 @@ end
 
 %% Test: Has positions
 function [] = test_has_positions( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('positionsTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('positionsTest', 'nixBlock');
     tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
@@ -554,8 +554,8 @@ end
 
 %% Test: Open positions
 function [] = test_open_positions( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = test_file.create_block('positionsTest', 'nixBlock');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('positionsTest', 'nixBlock');
     tmp = b.create_data_array('positionsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.create_data_array('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
@@ -568,7 +568,7 @@ end
 function [] = test_set_open_extents ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('extentsTest', 'nixBlock');
+    b = f.createBlock('extentsTest', 'nixBlock');
     da = b.create_data_array('extentsTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6; 1 2 3 4 5 6]);
     getMTag = b.create_multi_tag('extentstest', 'nixMultiTag', da);
 
@@ -606,10 +606,10 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.create_section(secName1, 'nixSection');
-    tmp = f.create_section(secName2, 'nixSection');
+    tmp = f.createSection(secName1, 'nixSection');
+    tmp = f.createSection(secName2, 'nixSection');
 
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
 
@@ -637,8 +637,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     tmp = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.create_multi_tag('metadataTest', 'nixMultiTag', b.dataArrays{1});
     t.set_metadata(f.sections{1});
@@ -649,7 +649,7 @@ end
 %% Test: Retrieve reference data by id or name
 function [] = test_retrieve_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     pos(1,:) = [0, 0]; ext(1,:) = [0, 0]; % result 111
     pos(2,:) = [1, 1]; ext(2,:) = [0, 3]; % result 122 123 124
@@ -712,7 +712,7 @@ end
 %% Test: Retrieve reference data by index
 function [] = test_retrieve_data_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     pos(1,:) = [0, 0]; ext(1,:) = [0, 0]; % result 111
     pos(2,:) = [1, 1]; ext(2,:) = [0, 3]; % result 122 123 124
@@ -771,7 +771,7 @@ end
 %% Test: Retrieve feature data by id or name
 function [] = test_retrieve_feature_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     % create feature data arrays
     raw_feat1 = [11 12 13 14 15 16 17 18];
@@ -860,7 +860,7 @@ end
 %% Test: Retrieve feature data
 function [] = test_retrieve_feature_data_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
 
     % create feature data arrays
     raw_feat1 = [11 12 13 14 15 16 17 18];
@@ -950,7 +950,7 @@ end
 function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('featureTest', 'nixMultiTag', da);
     daf = b.create_data_array('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -970,7 +970,7 @@ function [] = test_has_reference( varargin )
     fileName = 'testRW.h5';
     daName = 'refTestDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('referenceTestBlock', 'nixBlock');
+    b = f.createBlock('referenceTestBlock', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('referenceTest', 'nixMultiTag', da);
     refName = 'referenceTest';
@@ -990,7 +990,7 @@ function [] = test_set_units( varargin )
     fileName = 'testRW.h5';
     daName = 'testDataArray';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('unitsTest', 'nixMultiTag', da);
 
@@ -1023,7 +1023,7 @@ end
 function [] = test_attrs( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     tmp = b.create_data_array('attributeTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', b.dataArrays{1});
 
@@ -1055,8 +1055,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare MultiTag entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     d = b1.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 2]);
     t1 = b1.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
     t2 = b1.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
@@ -1074,7 +1074,7 @@ function [] = test_filter_source( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 3]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
     s = b.create_source(filterName, 'nixSource');
@@ -1117,7 +1117,7 @@ function [] = test_filter_source( varargin )
     mainSource = b.create_source(mainName, 'nixSource');
     t.add_source(mainSource);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
@@ -1150,7 +1150,7 @@ function [] = test_filter_reference( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
     d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -1193,7 +1193,7 @@ function [] = test_filter_reference( varargin )
     main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(main);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
@@ -1223,7 +1223,7 @@ end
 %% Test: filter features
 function [] = test_filter_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
     t = b.create_multi_tag('testMultiTag', 'nixMultiTag', d);
     d = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -10,16 +10,16 @@ function funcs = TestProperty
 % TESTPROPERTY % Tests for the nix.Property object
 
     funcs = {};
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_update_values;
-    funcs{end+1} = @test_values;
-    funcs{end+1} = @test_value_count;
-    funcs{end+1} = @test_values_delete;
-    funcs{end+1} = @test_property_compare;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testUpdateValues;
+    funcs{end+1} = @testValues;
+    funcs{end+1} = @testValueCount;
+    funcs{end+1} = @testDeleteValues;
+    funcs{end+1} = @testCompare;
 end
 
 %% Test: Access Attributes
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('testSectionProperty', 'nixSection');
     p = s.createProperty('testProperty1', nix.DataType.String);
@@ -46,7 +46,7 @@ function [] = test_attrs( varargin )
 end
 
 %% Test: Access values
-function [] = test_values( varargin )
+function [] = testValues( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
     currProp = s.createPropertyWithValue('booleanProperty', {true, false, true});
@@ -57,7 +57,7 @@ function [] = test_values( varargin )
 end
 
 %% Test: Update values and uncertainty
-function [] = test_update_values( varargin )
+function [] = testUpdateValues( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
@@ -108,31 +108,31 @@ function [] = test_update_values( varargin )
 end
 
 %% Test: Value count
-function [] = test_value_count( varargin )
+function [] = testValueCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
     p = s.createPropertyWithValue('booleanProperty', {true, false, true});
 
-    assert(p.value_count() == 3);
+    assert(p.valueCount() == 3);
     p.values = {};
-    assert(p.value_count() == 0);
+    assert(p.valueCount() == 0);
     p.values = {false};
 
     clear p s f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.sections{1}.properties{1}.value_count() == 1);
+    assert(f.sections{1}.properties{1}.valueCount() == 1);
 end
 
 %% Test: Delete values
-function [] = test_values_delete( varargin )
+function [] = testDeleteValues( varargin )
     testFile = fullfile(pwd,'tests','testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
 
     p = s.createPropertyWithValue('property1', {true, false, true});
     assert(~isempty(p.values));
-    p.values_delete();
+    p.deleteValues();
     assert(isempty(p.values));
 
     clear p s f;
@@ -141,7 +141,7 @@ function [] = test_values_delete( varargin )
 end
 
 %% Test: Compare properties
-function [] = test_property_compare( varargin )
+function [] = testCompare( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s1 = f.createSection('testSection1', 'nixSection');

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -7,8 +7,7 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestProperty
-%TESTPROPERTY % Tests for the nix.Property object
-%   Detailed explanation goes here
+% TESTPROPERTY % Tests for the nix.Property object
 
     funcs = {};
     funcs{end+1} = @test_attrs;
@@ -23,7 +22,7 @@ end
 function [] = test_attrs( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('testSectionProperty', 'nixSection');
-    p = s.create_property('testProperty1', nix.DataType.String);
+    p = s.createProperty('testProperty1', nix.DataType.String);
 
     assert(~isempty(p.id));
     assert(strcmpi(p.datatype, 'char'));
@@ -50,7 +49,7 @@ end
 function [] = test_values( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
-    currProp = s.create_property_with_value('booleanProperty', {true, false, true});
+    currProp = s.createPropertyWithValue('booleanProperty', {true, false, true});
 
     assert(size(currProp.values, 1) == 3);
     assert(currProp.values{1}.value);
@@ -63,19 +62,19 @@ function [] = test_update_values( varargin )
     s = f.createSection('mainSection', 'nixSection');
 
     %-- test update boolean
-    updateBool = s.create_property_with_value('booleanProperty', {true, false, true});
+    updateBool = s.createPropertyWithValue('booleanProperty', {true, false, true});
     assert(updateBool.values{1}.value);
     updateBool.values{1}.value = false;
     assert(~updateBool.values{1}.value);
 
     %-- test update string
-    updateString = s.create_property_with_value('stringProperty', {'this', 'has', 'strings'});
+    updateString = s.createPropertyWithValue('stringProperty', {'this', 'has', 'strings'});
     assert(strcmp(updateString.values{3}.value, 'strings'));
     updateString.values{3}.value = 'more strings';
     assert(strcmp(updateString.values{3}.value, 'more strings'));
 
     %-- test update double / test set uncertainty
-    updateDouble = s.create_property_with_value('doubleProperty', {2, 3, 4, 5});
+    updateDouble = s.createPropertyWithValue('doubleProperty', {2, 3, 4, 5});
     assert(updateDouble.values{1}.value == 2);
     updateDouble.values{1}.value = 2.2;
     assert(updateDouble.values{1}.value == 2.2);
@@ -103,7 +102,7 @@ function [] = test_update_values( varargin )
     %-- test add new values by value structure
     val1 = newValues.values{1};
     val2 = newValues.values{2};
-    updateNewDouble = s.create_property('doubleProperty2', nix.DataType.Double);
+    updateNewDouble = s.createProperty('doubleProperty2', nix.DataType.Double);
     updateNewDouble.values = {val1, val2};
     assert(s.properties{end}.values{2}.value == val2.value);
 end
@@ -113,7 +112,7 @@ function [] = test_value_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
-    p = s.create_property_with_value('booleanProperty', {true, false, true});
+    p = s.createPropertyWithValue('booleanProperty', {true, false, true});
 
     assert(p.value_count() == 3);
     p.values = {};
@@ -131,7 +130,7 @@ function [] = test_values_delete( varargin )
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
 
-    p = s.create_property_with_value('property1', {true, false, true});
+    p = s.createPropertyWithValue('property1', {true, false, true});
     assert(~isempty(p.values));
     p.values_delete();
     assert(isempty(p.values));
@@ -148,7 +147,7 @@ function [] = test_property_compare( varargin )
     s1 = f.createSection('testSection1', 'nixSection');
     s2 = f.createSection('testSection2', 'nixSection');
 
-    p = s1.create_property_with_value('property', {true, false, true});
+    p = s1.createPropertyWithValue('property', {true, false, true});
 
     % test invalid property comparison
     try
@@ -164,6 +163,6 @@ function [] = test_property_compare( varargin )
     assert(~p.compare(p));
 
     % test property not eqal
-    pNEq = s2.create_property_with_value('property', {true, false});
+    pNEq = s2.createPropertyWithValue('property', {true, false});
     assert(p.compare(pNEq) ~= 0);
 end

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -22,7 +22,7 @@ end
 %% Test: Access Attributes
 function [] = test_attrs( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('testSectionProperty', 'nixSection');
+    s = f.createSection('testSectionProperty', 'nixSection');
     p = s.create_property('testProperty1', nix.DataType.String);
 
     assert(~isempty(p.id));
@@ -49,7 +49,7 @@ end
 %% Test: Access values
 function [] = test_values( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
     currProp = s.create_property_with_value('booleanProperty', {true, false, true});
 
     assert(size(currProp.values, 1) == 3);
@@ -60,7 +60,7 @@ end
 %% Test: Update values and uncertainty
 function [] = test_update_values( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
 
     %-- test update boolean
     updateBool = s.create_property_with_value('booleanProperty', {true, false, true});
@@ -112,7 +112,7 @@ end
 function [] = test_value_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     p = s.create_property_with_value('booleanProperty', {true, false, true});
 
     assert(p.value_count() == 3);
@@ -129,7 +129,7 @@ end
 function [] = test_values_delete( varargin )
     testFile = fullfile(pwd,'tests','testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
 
     p = s.create_property_with_value('property1', {true, false, true});
     assert(~isempty(p.values));
@@ -145,8 +145,8 @@ end
 function [] = test_property_compare( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s1 = f.create_section('testSection1', 'nixSection');
-    s2 = f.create_section('testSection2', 'nixSection');
+    s1 = f.createSection('testSection1', 'nixSection');
+    s2 = f.createSection('testSection2', 'nixSection');
 
     p = s1.create_property_with_value('property', {true, false, true});
 

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -627,8 +627,8 @@ function [] = testFilterSection( varargin )
     % test empty id filter
     assert(isempty(f.sections{1}.filterSections(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.sections{1}.filterSections(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.sections{1}.filterSections(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
@@ -679,8 +679,8 @@ function [] = testFilterProperty( varargin )
     % test empty id filter
     assert(isempty(f.sections{1}.filterProperties(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.sections{1}.filterProperties(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.sections{1}.filterProperties(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 2);
     
     % test nix.Filter.id

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -796,46 +796,46 @@ function [] = testFilterFindSections
     side1 = side.createSection(sideName, 'nixSection');
 
     % test find by id
-    filtered = sl1.FilterFindSections(1, nix.Filter.id, sl41.id);
+    filtered = sl1.filterFindSections(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = sl1.FilterFindSections(4, nix.Filter.id, sl41.id);
+    filtered = sl1.filterFindSections(4, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = sl1.FilterFindSections(1, nix.Filter.ids, filterids);
+    filtered = sl1.filterFindSections(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = sl1.FilterFindSections(4, nix.Filter.ids, filterids);
+    filtered = sl1.filterFindSections(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = sl1.FilterFindSections(5, nix.Filter.name, sideName);
+    filtered = sl1.filterFindSections(5, nix.Filter.name, sideName);
     assert(isempty(filtered));
-    filtered = sl1.FilterFindSections(1, nix.Filter.name, sl41.name);
+    filtered = sl1.filterFindSections(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = sl1.FilterFindSections(4, nix.Filter.name, sl41.name);
+    filtered = sl1.filterFindSections(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = sl1.FilterFindSections(1, nix.Filter.type, findSection);
+    filtered = sl1.filterFindSections(1, nix.Filter.type, findSection);
     assert(isempty(filtered));
-    filtered = sl1.FilterFindSections(4, nix.Filter.type, findSection);
+    filtered = sl1.filterFindSections(4, nix.Filter.type, findSection);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSection));
 
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        sl1.FilterFindSections(1, nix.Filter.metadata, 'metadata');
+        sl1.filterFindSections(1, nix.Filter.metadata, 'metadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        sl1.FilterFindSections(1, nix.Filter.source, 'source');
+        sl1.filterFindSections(1, nix.Filter.source, 'source');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -49,7 +49,7 @@ end
 %% Test: Create Section
 function [] = test_create_section( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
 
     assert(isempty(s.sections));
     tmp = s.create_section('testSection1', 'nixSection');
@@ -60,7 +60,7 @@ end
 %% Test: Delete Section by entity or ID
 function [] = test_delete_section( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
     tmp = s.create_section('testSection1', 'nixSection');
     tmp = s.create_section('testSection2', 'nixSection');
 
@@ -101,7 +101,7 @@ end
 function [] = test_open_section_idx( varargin )
 %% Test Open Section by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     s1 = s.create_section('testSection1', 'nixSection');
     s2 = s.create_section('testSection2', 'nixSection');
     s3 = s.create_section('testSection3', 'nixSection');
@@ -136,7 +136,7 @@ end
 function [] = test_section_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
 
     assert(s.section_count() == 0);
     tmp = s.create_section('testSection1', 'nixSection');
@@ -152,7 +152,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes / Links
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('foo', 'bar');
+    s = f.createSection('foo', 'bar');
 
     assert(~isempty(s.id));
 
@@ -187,7 +187,7 @@ end
 %% Test: Create property by data type
 function [] = test_create_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
 
     s.create_property('newProperty1', nix.DataType.Double);
     s.create_property('newProperty2', nix.DataType.Bool);
@@ -199,7 +199,7 @@ end
 %% Test: Create property with value
 function [] = test_create_property_with_value( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
 
     % test create by array
     s.create_property_with_value('doubleProperty1', [5, 6, 7, 8]);
@@ -260,7 +260,7 @@ end
 %% Test: Delete property by entity, propertyStruct, ID and name
 function [] = test_delete_property( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
     s.create_property('newProperty1', nix.DataType.Double);
     s.create_property('newProperty2', nix.DataType.Bool);
     s.create_property('newProperty3', nix.DataType.String);
@@ -287,7 +287,7 @@ end
 function [] = test_open_property_idx( varargin )
 %% Test Open Propery by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     p1 = s.create_property('testProperty1', nix.DataType.Double);
     p2 = s.create_property('testProperty2', nix.DataType.Bool);
     p3 = s.create_property('testProperty3', nix.DataType.String);
@@ -301,7 +301,7 @@ end
 function [] = test_property_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
 
     assert(s.property_count() == 0);
     tmp = s.create_property('newProperty1', nix.DataType.Double);
@@ -316,9 +316,9 @@ end
 %% Test: set, open and remove section link
 function [] = test_link( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    mainSec = f.create_section('mainSection', 'nixSection');
-    tmp = f.create_section('linkSection1', 'nixSection');
-    tmp = f.create_section('linkSection2', 'nixSection');
+    mainSec = f.createSection('mainSection', 'nixSection');
+    tmp = f.createSection('linkSection1', 'nixSection');
+    tmp = f.createSection('linkSection2', 'nixSection');
     
     assert(isempty(mainSec.openLink));
     mainSec.set_link(f.sections{3}.id);
@@ -333,8 +333,8 @@ end
 %% Test: inherited properties
 function [] = test_inherited_properties( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s = f.create_section('mainSection', 'nixSection');
-    ls = f.create_section('linkSection', 'nixSection');
+    s = f.createSection('mainSection', 'nixSection');
+    ls = f.createSection('linkSection', 'nixSection');
     
     assert(isempty(s.inherited_properties));
 
@@ -352,11 +352,11 @@ end
 %% Test: referring data arrays
 function [] = test_referring_data_arrays( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     d1 = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     d2 = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_data_arrays));
 
@@ -377,11 +377,11 @@ function [] = test_referring_block_data_arrays( varargin )
     testName = 'testDataArray1';
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     d1 = b1.create_data_array(testName, 'nixDataArray', nix.DataType.Double, [1 2]);
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     d2 = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     
     d1.set_metadata(s);
     d2.set_metadata(s);
@@ -409,11 +409,11 @@ end
 %% Test: referring tags
 function [] = test_referring_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     t1 = b1.create_tag('testTag1', 'nixTag', [1, 2]);
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     t2 = b2.create_tag('testTag2', 'nixTag', [3, 4]);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_tags));
 
@@ -434,11 +434,11 @@ function [] = test_referring_block_tags( varargin )
     testName = 'testTag1';
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     t1 = b1.create_tag(testName, 'nixTag', [1, 2]);
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     t2 = b2.create_tag('testTag2', 'nixTag', [3, 4]);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
 
     t1.set_metadata(s);
     t2.set_metadata(s);
@@ -466,13 +466,13 @@ end
 %% Test: referring multi tags
 function [] = test_referring_multi_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     d = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t1 = b1.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     d = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     t2 = b2.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_multi_tags));
 
@@ -493,13 +493,13 @@ function [] = test_referring_block_multi_tags( varargin )
     testName = 'testMultiTag1';
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     d = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     t1 = b1.create_multi_tag(testName, 'nixMultiTag', d);
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     d = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     t2 = b2.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
 
     t1.set_metadata(s);
     t2.set_metadata(s);
@@ -527,11 +527,11 @@ end
 %% Test: referring sources
 function [] = test_referring_sources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     s1 = b1.create_source('testSource1', 'nixSource');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     s2 = b2.create_source('testSource2', 'nixSource');
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_sources));
 
@@ -552,11 +552,11 @@ function [] = test_referring_block_sources( varargin )
     testName = 'testSource1';
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
     s1 = b1.create_source(testName, 'nixSource');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     s2 = b2.create_source('testSource2', 'nixSource');
-    s = f.create_section('testSection', 'nixSection');
+    s = f.createSection('testSection', 'nixSection');
 
     s1.set_metadata(s);
     s2.set_metadata(s);
@@ -584,9 +584,9 @@ end
 %% Test: referring blocks
 function [] = test_referring_blocks( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
-    s = f.create_section('testSection', 'nixSection');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
+    s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_blocks));
 
@@ -603,8 +603,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare group entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    s1 = f.create_section('testSection1', 'nixSection');
-    s2 = f.create_section('testSection2', 'nixSection');
+    s1 = f.createSection('testSection1', 'nixSection');
+    s2 = f.createSection('testSection2', 'nixSection');
 
     assert(s1.compare(s2) < 0);
     assert(s1.compare(s1) == 0);
@@ -616,7 +616,7 @@ function [] = test_filter_section( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    ms = f.create_section('testSection', 'nixSection');
+    ms = f.createSection('testSection', 'nixSection');
     s = ms.create_section(filterName, 'nixSection');
     filterID = s.id;
 	s = ms.create_section('testSection1', filterType);
@@ -671,7 +671,7 @@ end
 function [] = test_filter_property( varargin )
     filterName = 'filterMe';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    ms = f.create_section('testSection', 'nixSection');
+    ms = f.createSection('testSection', 'nixSection');
     p = ms.create_property(filterName, nix.DataType.Double);
     filterID = p.id;
 	s = ms.create_property('testProperty', nix.DataType.Bool);
@@ -726,7 +726,7 @@ end
 %% Test: Find sections w/o filter
 function [] = test_find_section
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    main = f.create_section('testSection', 'nixSection');
+    main = f.createSection('testSection', 'nixSection');
     sl1 = main.create_section('sectionLvl1', 'nixSection');
 
     sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
@@ -741,7 +741,7 @@ function [] = test_find_section
     sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
     sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
 
-    side = f.create_section('sideSection', 'nixSection');
+    side = f.createSection('sideSection', 'nixSection');
     side1 = side.create_section('sideSubSection', 'nixSection');
 
     % Check invalid entry
@@ -777,7 +777,7 @@ end
 function [] = test_find_section_filtered
     findSection = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    main = f.create_section('testSection', 'nixSection');
+    main = f.createSection('testSection', 'nixSection');
     sl1 = main.create_section('sectionLvl1', 'nixSection');
 
     sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
@@ -793,7 +793,7 @@ function [] = test_find_section_filtered
     sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
 
     sideName = 'sideSubSection';
-    side = f.create_section('sideSection', 'nixSection');
+    side = f.createSection('sideSection', 'nixSection');
     side1 = side.create_section(sideName, 'nixSection');
 
     % test find by id
@@ -846,7 +846,7 @@ end
 function [] = test_find_related
     findSectionType = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    main = f.create_section('testSection', 'nixSection');
+    main = f.createSection('testSection', 'nixSection');
     sl1 = main.create_section('sectionLvl1', 'nixSection');
 
     sl21 = sl1.create_section('sectionLvl2_1', findSectionType);
@@ -862,7 +862,7 @@ function [] = test_find_related
     sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
 
     sideName = 'sideSubSection';
-    side = f.create_section('sideSection', 'nixSection');
+    side = f.createSection('sideSection', 'nixSection');
     side1 = side.create_section(sideName, 'nixSection');
 
     % find first downstream by id

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -7,8 +7,7 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestSection
-%TESTFILE % Tests for the nix.Section object
-%   Detailed explanation goes here
+% TESTSECTION Tests for the nix.Section object
 
     funcs = {};
     funcs{end+1} = @testCreateSection;
@@ -360,14 +359,14 @@ function [] = testReferringDataArrays( varargin )
     
     assert(isempty(s.referringDataArrays));
 
-    d1.set_metadata(s);
+    d1.setMetadata(s);
     assert(~isempty(s.referringDataArrays));
     
-    d2.set_metadata(s);
+    d2.setMetadata(s);
     assert(size(s.referringDataArrays, 1) == 2);
     
     b2.deleteDataArray(d2);
-    d1.set_metadata('');
+    d1.setMetadata('');
     assert(isempty(s.referringDataArrays));
 end
 
@@ -383,8 +382,8 @@ function [] = testReferringBlockDataArrays( varargin )
     d2 = b2.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = f.createSection('testSection', 'nixSection');
     
-    d1.set_metadata(s);
-    d2.set_metadata(s);
+    d1.setMetadata(s);
+    d2.setMetadata(s);
 
     % test multiple arguments fail
     try
@@ -417,14 +416,14 @@ function [] = testReferringTags( varargin )
     
     assert(isempty(s.referringTags));
 
-    t1.set_metadata(s);
+    t1.setMetadata(s);
     assert(~isempty(s.referringTags));
     
-    t2.set_metadata(s);
+    t2.setMetadata(s);
     assert(size(s.referringTags, 1) == 2);
     
     b2.deleteTag(t2);
-    t1.set_metadata('');
+    t1.setMetadata('');
     assert(isempty(s.referringTags));
 end
 
@@ -440,8 +439,8 @@ function [] = testReferringBlockTags( varargin )
     t2 = b2.createTag('testTag2', 'nixTag', [3, 4]);
     s = f.createSection('testSection', 'nixSection');
 
-    t1.set_metadata(s);
-    t2.set_metadata(s);
+    t1.setMetadata(s);
+    t2.setMetadata(s);
 
     % test multiple arguments fail
     try
@@ -476,14 +475,14 @@ function [] = testReferringMultiTags( varargin )
     
     assert(isempty(s.referringMultiTags));
 
-    t1.set_metadata(s);
+    t1.setMetadata(s);
     assert(~isempty(s.referringMultiTags));
     
-    t2.set_metadata(s);
+    t2.setMetadata(s);
     assert(size(s.referringMultiTags, 1) == 2);
     
     b2.deleteMultiTag(t2);
-    t1.set_metadata('');
+    t1.setMetadata('');
     assert(isempty(s.referringMultiTags));
 end
 
@@ -501,8 +500,8 @@ function [] = testReferringBlockMultiTags( varargin )
     t2 = b2.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     s = f.createSection('testSection', 'nixSection');
 
-    t1.set_metadata(s);
-    t2.set_metadata(s);
+    t1.setMetadata(s);
+    t2.setMetadata(s);
 
     % test multiple arguments fail
     try
@@ -535,14 +534,14 @@ function [] = testReferringSources( varargin )
     
     assert(isempty(s.referringSources));
 
-    s1.set_metadata(s);
+    s1.setMetadata(s);
     assert(~isempty(s.referringSources));
     
-    s2.set_metadata(s);
+    s2.setMetadata(s);
     assert(size(s.referringSources, 1) == 2);
     
     b2.deleteSource(s2);
-    s1.set_metadata('');
+    s1.setMetadata('');
     assert(isempty(s.referringSources));
 end
 
@@ -558,8 +557,8 @@ function [] = testReferringBlockSources( varargin )
     s2 = b2.createSource('testSource2', 'nixSource');
     s = f.createSection('testSection', 'nixSection');
 
-    s1.set_metadata(s);
-    s2.set_metadata(s);
+    s1.setMetadata(s);
+    s2.setMetadata(s);
 
     % test multiple arguments fail
     try
@@ -590,13 +589,13 @@ function [] = testReferringBlocks( varargin )
     
     assert(isempty(s.referringBlocks));
 
-    b1.set_metadata(s);
+    b1.setMetadata(s);
     assert(~isempty(s.referringBlocks));
     
-    b2.set_metadata(s);
+    b2.setMetadata(s);
     assert(size(s.referringBlocks, 1) == 2);
     
-    b2.set_metadata('')
+    b2.setMetadata('')
     assert(size(s.referringBlocks, 1) == 1);
 end
 

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -11,68 +11,68 @@ function funcs = TestSection
 %   Detailed explanation goes here
 
     funcs = {};
-    funcs{end+1} = @test_create_section;
-    funcs{end+1} = @test_delete_section;
-    funcs{end+1} = @test_list_subsections;
-    funcs{end+1} = @test_open_section;
-    funcs{end+1} = @test_open_section_idx;
-    funcs{end+1} = @test_parent;
-    funcs{end+1} = @test_has_section;
-    funcs{end+1} = @test_section_count;
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_properties;
-    funcs{end+1} = @test_create_property;
-    funcs{end+1} = @test_create_property_with_value;
-    funcs{end+1} = @test_delete_property;
-    funcs{end+1} = @test_open_property;
-    funcs{end+1} = @test_open_property_idx;
-    funcs{end+1} = @test_property_count;
-    funcs{end+1} = @test_link;
-    funcs{end+1} = @test_inherited_properties;
-    funcs{end+1} = @test_referring_data_arrays;
-    funcs{end+1} = @test_referring_block_data_arrays;
-    funcs{end+1} = @test_referring_tags;
-    funcs{end+1} = @test_referring_block_tags;
-    funcs{end+1} = @test_referring_multi_tags;
-    funcs{end+1} = @test_referring_block_multi_tags;
-    funcs{end+1} = @test_referring_sources;
-    funcs{end+1} = @test_referring_block_sources;
-    funcs{end+1} = @test_referring_blocks;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_section;
-    funcs{end+1} = @test_filter_property;
-    funcs{end+1} = @test_find_section;
-    funcs{end+1} = @test_find_section_filtered;
-    funcs{end+1} = @test_find_related;
+    funcs{end+1} = @testCreateSection;
+    funcs{end+1} = @testDeleteSection;
+    funcs{end+1} = @testListSubsections;
+    funcs{end+1} = @testOpenSection;
+    funcs{end+1} = @testOpenSectionIdx;
+    funcs{end+1} = @testParent;
+    funcs{end+1} = @testHasSection;
+    funcs{end+1} = @testSectionCount;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testProperties;
+    funcs{end+1} = @testCreateProperty;
+    funcs{end+1} = @testCreatePropertyWithValue;
+    funcs{end+1} = @testDeleteProperty;
+    funcs{end+1} = @testOpenProperty;
+    funcs{end+1} = @testOpenPropertyIdx;
+    funcs{end+1} = @testPropertyCount;
+    funcs{end+1} = @testLink;
+    funcs{end+1} = @testInheritedProperties;
+    funcs{end+1} = @testReferringDataArrays;
+    funcs{end+1} = @testReferringBlockDataArrays;
+    funcs{end+1} = @testReferringTags;
+    funcs{end+1} = @testReferringBlockTags;
+    funcs{end+1} = @testReferringMultiTags;
+    funcs{end+1} = @testReferringBlockMultiTags;
+    funcs{end+1} = @testReferringSources;
+    funcs{end+1} = @testReferringBlockSources;
+    funcs{end+1} = @testReferringBlocks;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSection;
+    funcs{end+1} = @testFilterProperty;
+    funcs{end+1} = @testFindSection;
+    funcs{end+1} = @testFilterFindSections;
+    funcs{end+1} = @testFindRelated;
 end
 
 %% Test: Create Section
-function [] = test_create_section( varargin )
+function [] = testCreateSection( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
     assert(isempty(s.sections));
-    tmp = s.create_section('testSection1', 'nixSection');
-    tmp = s.create_section('testSection2', 'nixSection');
+    tmp = s.createSection('testSection1', 'nixSection');
+    tmp = s.createSection('testSection2', 'nixSection');
     assert(size(s.sections, 1) == 2);
 end
 
 %% Test: Delete Section by entity or ID
-function [] = test_delete_section( varargin )
+function [] = testDeleteSection( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
-    tmp = s.create_section('testSection1', 'nixSection');
-    tmp = s.create_section('testSection2', 'nixSection');
+    tmp = s.createSection('testSection1', 'nixSection');
+    tmp = s.createSection('testSection2', 'nixSection');
 
-    assert(s.delete_section(s.sections{2}.id));
+    assert(s.deleteSection(s.sections{2}.id));
     assert(size(s.sections, 1) == 1);
-    assert(s.delete_section(s.sections{1}));
+    assert(s.deleteSection(s.sections{1}));
     assert(isempty(s.sections));
 
-    assert(~s.delete_section('I do not exist'));
+    assert(~s.deleteSection('I do not exist'));
 end
 
-function [] = test_list_subsections( varargin )
+function [] = testListSubsections( varargin )
 %% Test: List/fetch subsections
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     s1 = f.sections{3};
@@ -80,38 +80,38 @@ function [] = test_list_subsections( varargin )
     assert(size(s1.sections, 1) == 4);
 end
 
-function [] = test_open_section( varargin )
+function [] = testOpenSection( varargin )
 %% Test: Open subsection by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     s1 = f.sections{3};
 
     sid = s1.sections{1}.id;
-    s2 = s1.open_section(sid);
+    s2 = s1.openSection(sid);
     assert(strcmp(s2.id, sid));
 
     name = s1.sections{1}.name;
-    s2 = s1.open_section(name);
+    s2 = s1.openSection(name);
     assert(strcmp(s2.id, s1.sections{1}.id));
     
     %-- test open non existing section
-    getSection = s1.open_section('I dont exist');
+    getSection = s1.openSection('I dont exist');
     assert(isempty(getSection));
 end
 
-function [] = test_open_section_idx( varargin )
+function [] = testOpenSectionIdx( varargin )
 %% Test Open Section by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
-    s1 = s.create_section('testSection1', 'nixSection');
-    s2 = s.create_section('testSection2', 'nixSection');
-    s3 = s.create_section('testSection3', 'nixSection');
+    s1 = s.createSection('testSection1', 'nixSection');
+    s2 = s.createSection('testSection2', 'nixSection');
+    s3 = s.createSection('testSection3', 'nixSection');
 
-    assert(strcmp(f.sections{1}.open_section_idx(1).name, s1.name));
-    assert(strcmp(f.sections{1}.open_section_idx(2).name, s2.name));
-    assert(strcmp(f.sections{1}.open_section_idx(3).name, s3.name));
+    assert(strcmp(f.sections{1}.openSectionIdx(1).name, s1.name));
+    assert(strcmp(f.sections{1}.openSectionIdx(2).name, s2.name));
+    assert(strcmp(f.sections{1}.openSectionIdx(3).name, s3.name));
 end
 
-function [] = test_parent( varargin )
+function [] = testParent( varargin )
 %% Test: get parent section
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     s1 = f.sections{3};
@@ -122,34 +122,34 @@ function [] = test_parent( varargin )
     assert(strcmp(s2.parent.id, s1.id));
 end
 
-function [] = test_has_section( varargin )
+function [] = testHasSection( varargin )
 %% Test: Has Section
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     root = f.sections{3};
     child = root.sections{1};
 
-    assert(root.has_section(child.id));
-    assert(~root.has_section('whatever'));
+    assert(root.hasSection(child.id));
+    assert(~root.hasSection('whatever'));
 end
 
 %% Test: Section count
-function [] = test_section_count( varargin )
+function [] = testSectionCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
-    assert(s.section_count() == 0);
-    tmp = s.create_section('testSection1', 'nixSection');
-    assert(s.section_count() == 1);
-    tmp = s.create_section('testSection2', 'nixSection');
+    assert(s.sectionCount() == 0);
+    tmp = s.createSection('testSection1', 'nixSection');
+    assert(s.sectionCount() == 1);
+    tmp = s.createSection('testSection2', 'nixSection');
 
     clear tmp s f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.sections{1}.section_count() == 2);
+    assert(f.sections{1}.sectionCount() == 2);
 end
 
 
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
 %% Test: Access Attributes / Links
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('foo', 'bar');
@@ -174,7 +174,7 @@ function [] = test_attrs( varargin )
     assert(isempty(s.repository));
 end
 
-function [] = test_properties( varargin )
+function [] = testProperties( varargin )
 %% Test: Properties
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     trial = f.sections{2}.sections{2}.sections{1};
@@ -185,56 +185,56 @@ function [] = test_properties( varargin )
 end
 
 %% Test: Create property by data type
-function [] = test_create_property( varargin )
+function [] = testCreateProperty( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
-    s.create_property('newProperty1', nix.DataType.Double);
-    s.create_property('newProperty2', nix.DataType.Bool);
-    s.create_property('newProperty3', nix.DataType.String);
+    s.createProperty('newProperty1', nix.DataType.Double);
+    s.createProperty('newProperty2', nix.DataType.Bool);
+    s.createProperty('newProperty3', nix.DataType.String);
     assert(size(s.properties, 1) == 3);
     assert(strcmp(s.properties{1}.name, 'newProperty1'));
 end
 
 %% Test: Create property with value
-function [] = test_create_property_with_value( varargin )
+function [] = testCreatePropertyWithValue( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
     % test create by array
-    s.create_property_with_value('doubleProperty1', [5, 6, 7, 8]);
+    s.createPropertyWithValue('doubleProperty1', [5, 6, 7, 8]);
     assert(strcmp(s.properties{end}.name, 'doubleProperty1'));
     assert(s.properties{end}.values{1}.value == 5);
     assert(size(s.properties{end}.values, 1) == 4);
     assert(strcmpi(s.properties{end}.datatype, 'double'));
 
     % test create by cell array
-    s.create_property_with_value('doubleProperty2', {5, 6, 7, 8});
+    s.createPropertyWithValue('doubleProperty2', {5, 6, 7, 8});
     assert(strcmp(s.properties{end}.name, 'doubleProperty2'));
     assert(s.properties{end}.values{2}.value == 6);
     assert(size(s.properties{end}.values, 1) == 4);
     assert(strcmpi(s.properties{end}.datatype, 'double'));
 
-    s.create_property_with_value('stringProperty1', ['a', 'string']);
+    s.createPropertyWithValue('stringProperty1', ['a', 'string']);
     assert(strcmp(s.properties{end}.name, 'stringProperty1'));
     assert(strcmp(s.properties{end}.values{1}.value, 'a'));
     assert(size(s.properties{end}.values, 1) == 7);
     assert(strcmpi(s.properties{end}.datatype, 'char'));
 
-    s.create_property_with_value('stringProperty2', {'this', 'has', 'strings'});
+    s.createPropertyWithValue('stringProperty2', {'this', 'has', 'strings'});
     assert(strcmp(s.properties{end}.name, 'stringProperty2'));
     assert(strcmp(s.properties{end}.values{1}.value, 'this'));
     assert(size(s.properties{end}.values, 1) == 3);
     assert(strcmpi(s.properties{end}.datatype, 'char'));
 
-    s.create_property_with_value('booleanProperty1', [true, false, true]);
+    s.createPropertyWithValue('booleanProperty1', [true, false, true]);
     assert(strcmp(s.properties{end}.name, 'booleanProperty1'));
     assert(s.properties{end}.values{1}.value);
     assert(~s.properties{end}.values{2}.value);
     assert(size(s.properties{end}.values, 1) == 3);
     assert(strcmpi(s.properties{end}.datatype, 'logical'));
 
-    s.create_property_with_value('booleanProperty2', {true, false, true});
+    s.createPropertyWithValue('booleanProperty2', {true, false, true});
     assert(strcmp(s.properties{end}.name, 'booleanProperty2'));
     assert(s.properties{end}.values{1}.value);
     assert(~s.properties{end}.values{2}.value);
@@ -243,14 +243,14 @@ function [] = test_create_property_with_value( varargin )
 
     val1 = s.properties{1}.values{1};
     val2 = s.properties{1}.values{2};
-    s.create_property_with_value('doubleByStrunct1', [val1, val2]);
+    s.createPropertyWithValue('doubleByStrunct1', [val1, val2]);
     assert(strcmp(s.properties{end}.name, 'doubleByStrunct1'));
     assert(s.properties{end}.values{1}.value == 5);
     assert(size(s.properties{end}.values, 1) == 2);
     assert(strcmpi(s.properties{end}.datatype, 'double'));
     
     val3 = s.properties{1}.values{3};
-    s.create_property_with_value('doubleByStrunct2', {val1, val2, val3});
+    s.createPropertyWithValue('doubleByStrunct2', {val1, val2, val3});
     assert(strcmp(s.properties{end}.name, 'doubleByStrunct2'));
     assert(s.properties{end}.values{3}.value == 7);
     assert(size(s.properties{end}.values, 1) == 3);
@@ -258,99 +258,99 @@ function [] = test_create_property_with_value( varargin )
 end
 
 %% Test: Delete property by entity, propertyStruct, ID and name
-function [] = test_delete_property( varargin )
+function [] = testDeleteProperty( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
-    s.create_property('newProperty1', nix.DataType.Double);
-    s.create_property('newProperty2', nix.DataType.Bool);
-    s.create_property('newProperty3', nix.DataType.String);
-    s.create_property('newProperty4', nix.DataType.Double);
+    s.createProperty('newProperty1', nix.DataType.Double);
+    s.createProperty('newProperty2', nix.DataType.Bool);
+    s.createProperty('newProperty3', nix.DataType.String);
+    s.createProperty('newProperty4', nix.DataType.Double);
 
-    assert(s.delete_property('newProperty4'));
-    assert(s.delete_property(s.properties{3}.id));
+    assert(s.deleteProperty('newProperty4'));
+    assert(s.deleteProperty(s.properties{3}.id));
     delProp = s.properties{2};
-    assert(s.delete_property(delProp));
-    assert(s.delete_property(s.properties{1}));
+    assert(s.deleteProperty(delProp));
+    assert(s.deleteProperty(s.properties{1}));
 
-    assert(~s.delete_property('I do not exist'));
+    assert(~s.deleteProperty('I do not exist'));
 end
 
 %% Test: Open property by ID and name
-function [] = test_open_property( varargin )
+function [] = testOpenProperty( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     trial = f.sections{2}.sections{2}.sections{1};
 
-    assert(~isempty(trial.open_property(trial.properties{1}.id)));
-    assert(~isempty(trial.open_property(trial.properties{1}.name)));
+    assert(~isempty(trial.openProperty(trial.properties{1}.id)));
+    assert(~isempty(trial.openProperty(trial.properties{1}.name)));
 end
 
-function [] = test_open_property_idx( varargin )
+function [] = testOpenPropertyIdx( varargin )
 %% Test Open Propery by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
-    p1 = s.create_property('testProperty1', nix.DataType.Double);
-    p2 = s.create_property('testProperty2', nix.DataType.Bool);
-    p3 = s.create_property('testProperty3', nix.DataType.String);
+    p1 = s.createProperty('testProperty1', nix.DataType.Double);
+    p2 = s.createProperty('testProperty2', nix.DataType.Bool);
+    p3 = s.createProperty('testProperty3', nix.DataType.String);
 
-    assert(strcmp(f.sections{1}.open_property_idx(1).name, p1.name));
-    assert(strcmp(f.sections{1}.open_property_idx(2).name, p2.name));
-    assert(strcmp(f.sections{1}.open_property_idx(3).name, p3.name));
+    assert(strcmp(f.sections{1}.openPropertyIdx(1).name, p1.name));
+    assert(strcmp(f.sections{1}.openPropertyIdx(2).name, p2.name));
+    assert(strcmp(f.sections{1}.openPropertyIdx(3).name, p3.name));
 end
 
 %% Test: Property count
-function [] = test_property_count( varargin )
+function [] = testPropertyCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
 
-    assert(s.property_count() == 0);
-    tmp = s.create_property('newProperty1', nix.DataType.Double);
-    assert(s.property_count() == 1);
-    tmp = s.create_property('newProperty2', nix.DataType.Bool);
+    assert(s.propertyCount() == 0);
+    tmp = s.createProperty('newProperty1', nix.DataType.Double);
+    assert(s.propertyCount() == 1);
+    tmp = s.createProperty('newProperty2', nix.DataType.Bool);
 
     clear tmp s f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.sections{1}.property_count() == 2);
+    assert(f.sections{1}.propertyCount() == 2);
 end
 
 %% Test: set, open and remove section link
-function [] = test_link( varargin )
+function [] = testLink( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     mainSec = f.createSection('mainSection', 'nixSection');
     tmp = f.createSection('linkSection1', 'nixSection');
     tmp = f.createSection('linkSection2', 'nixSection');
     
     assert(isempty(mainSec.openLink));
-    mainSec.set_link(f.sections{3}.id);
+    mainSec.setLink(f.sections{3}.id);
     assert(strcmp(mainSec.openLink.name, 'linkSection2'));
-    mainSec.set_link(f.sections{2});
+    mainSec.setLink(f.sections{2});
     assert(strcmp(mainSec.openLink.name, 'linkSection1'));
     
-    mainSec.set_link('');
+    mainSec.setLink('');
     assert(isempty(mainSec.openLink));
 end
 
 %% Test: inherited properties
-function [] = test_inherited_properties( varargin )
+function [] = testInheritedProperties( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
     ls = f.createSection('linkSection', 'nixSection');
     
-    assert(isempty(s.inherited_properties));
+    assert(isempty(s.inheritedProperties));
 
-    s.set_link(ls);
-    assert(isempty(s.inherited_properties));
+    s.setLink(ls);
+    assert(isempty(s.inheritedProperties));
 
-    lp = ls.create_property('testProperty2', nix.DataType.String);
-    assert(~isempty(s.inherited_properties));
-    assert(strcmp(s.inherited_properties{1}.name, lp.name));
+    lp = ls.createProperty('testProperty2', nix.DataType.String);
+    assert(~isempty(s.inheritedProperties));
+    assert(strcmp(s.inheritedProperties{1}.name, lp.name));
     
-    s.create_property('testProperty1', nix.DataType.String);
-    assert(size(s.inherited_properties, 1) == 2);
+    s.createProperty('testProperty1', nix.DataType.String);
+    assert(size(s.inheritedProperties, 1) == 2);
 end
 
 %% Test: referring data arrays
-function [] = test_referring_data_arrays( varargin )
+function [] = testReferringDataArrays( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     d1 = b1.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -358,21 +358,21 @@ function [] = test_referring_data_arrays( varargin )
     d2 = b2.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = f.createSection('testSection', 'nixSection');
     
-    assert(isempty(s.referring_data_arrays));
+    assert(isempty(s.referringDataArrays));
 
     d1.set_metadata(s);
-    assert(~isempty(s.referring_data_arrays));
+    assert(~isempty(s.referringDataArrays));
     
     d2.set_metadata(s);
-    assert(size(s.referring_data_arrays, 1) == 2);
+    assert(size(s.referringDataArrays, 1) == 2);
     
     b2.deleteDataArray(d2);
     d1.set_metadata('');
-    assert(isempty(s.referring_data_arrays));
+    assert(isempty(s.referringDataArrays));
 end
 
 %% Test: referring block data arrays
-function [] = test_referring_block_data_arrays( varargin )
+function [] = testReferringBlockDataArrays( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testDataArray1';
 
@@ -388,26 +388,26 @@ function [] = test_referring_block_data_arrays( varargin )
 
     % test multiple arguments fail
     try
-        s.referring_data_arrays('a', 'b');
+        s.referringDataArrays('a', 'b');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test non block entity argument fail
     try
-        s.referring_data_arrays(s);
+        s.referringDataArrays(s);
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test return only tags from block 1
-    testDataArray = s.referring_data_arrays(b1);
+    testDataArray = s.referringDataArrays(b1);
     assert(size(testDataArray, 2) == 1);
     assert(strcmp(testDataArray{1}.name, testName));
 end
 
 %% Test: referring tags
-function [] = test_referring_tags( varargin )
+function [] = testReferringTags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     t1 = b1.createTag('testTag1', 'nixTag', [1, 2]);
@@ -415,21 +415,21 @@ function [] = test_referring_tags( varargin )
     t2 = b2.createTag('testTag2', 'nixTag', [3, 4]);
     s = f.createSection('testSection', 'nixSection');
     
-    assert(isempty(s.referring_tags));
+    assert(isempty(s.referringTags));
 
     t1.set_metadata(s);
-    assert(~isempty(s.referring_tags));
+    assert(~isempty(s.referringTags));
     
     t2.set_metadata(s);
-    assert(size(s.referring_tags, 1) == 2);
+    assert(size(s.referringTags, 1) == 2);
     
     b2.deleteTag(t2);
     t1.set_metadata('');
-    assert(isempty(s.referring_tags));
+    assert(isempty(s.referringTags));
 end
 
 %% Test: referring block tags
-function [] = test_referring_block_tags( varargin )
+function [] = testReferringBlockTags( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testTag1';
 
@@ -445,26 +445,26 @@ function [] = test_referring_block_tags( varargin )
 
     % test multiple arguments fail
     try
-        s.referring_tags('a', 'b');
+        s.referringTags('a', 'b');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test non block entity argument fail
     try
-        s.referring_tags(s);
+        s.referringTags(s);
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test return only tags from block 1
-    testTag = s.referring_tags(b1);
+    testTag = s.referringTags(b1);
     assert(size(testTag, 2) == 1);
     assert(strcmp(testTag{1}.name, testName));
 end
 
 %% Test: referring multi tags
-function [] = test_referring_multi_tags( varargin )
+function [] = testReferringMultiTags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     d = b1.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -474,21 +474,21 @@ function [] = test_referring_multi_tags( varargin )
     t2 = b2.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     s = f.createSection('testSection', 'nixSection');
     
-    assert(isempty(s.referring_multi_tags));
+    assert(isempty(s.referringMultiTags));
 
     t1.set_metadata(s);
-    assert(~isempty(s.referring_multi_tags));
+    assert(~isempty(s.referringMultiTags));
     
     t2.set_metadata(s);
-    assert(size(s.referring_multi_tags, 1) == 2);
+    assert(size(s.referringMultiTags, 1) == 2);
     
     b2.deleteMultiTag(t2);
     t1.set_metadata('');
-    assert(isempty(s.referring_multi_tags));
+    assert(isempty(s.referringMultiTags));
 end
 
 %% Test: referring block multi tags
-function [] = test_referring_block_multi_tags( varargin )
+function [] = testReferringBlockMultiTags( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testMultiTag1';
 
@@ -506,26 +506,26 @@ function [] = test_referring_block_multi_tags( varargin )
 
     % test multiple arguments fail
     try
-        s.referring_multi_tags('a', 'b');
+        s.referringMultiTags('a', 'b');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test non block entity argument fail
     try
-        s.referring_multi_tags(s);
+        s.referringMultiTags(s);
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test return only tags from block 1
-    testTag = s.referring_multi_tags(b1);
+    testTag = s.referringMultiTags(b1);
     assert(size(testTag, 2) == 1);
     assert(strcmp(testTag{1}.name, testName));
 end
 
 %% Test: referring sources
-function [] = test_referring_sources( varargin )
+function [] = testReferringSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     s1 = b1.createSource('testSource1', 'nixSource');
@@ -533,21 +533,21 @@ function [] = test_referring_sources( varargin )
     s2 = b2.createSource('testSource2', 'nixSource');
     s = f.createSection('testSection', 'nixSection');
     
-    assert(isempty(s.referring_sources));
+    assert(isempty(s.referringSources));
 
     s1.set_metadata(s);
-    assert(~isempty(s.referring_sources));
+    assert(~isempty(s.referringSources));
     
     s2.set_metadata(s);
-    assert(size(s.referring_sources, 1) == 2);
+    assert(size(s.referringSources, 1) == 2);
     
     b2.deleteSource(s2);
     s1.set_metadata('');
-    assert(isempty(s.referring_sources));
+    assert(isempty(s.referringSources));
 end
 
 %% Test: referring block sources
-function [] = test_referring_block_sources( varargin )
+function [] = testReferringBlockSources( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testSource1';
 
@@ -563,44 +563,44 @@ function [] = test_referring_block_sources( varargin )
 
     % test multiple arguments fail
     try
-        s.referring_sources('a', 'b');
+        s.referringSources('a', 'b');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test non block entity argument fail
     try
-        s.referring_sources(s);
+        s.referringSources(s);
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test return only sources from block 1
-    testSource = s.referring_sources(b1);
+    testSource = s.referringSources(b1);
     assert(size(testSource, 2) == 1);
     assert(strcmp(testSource{1}.name, testName));
 end
 
 %% Test: referring blocks
-function [] = test_referring_blocks( varargin )
+function [] = testReferringBlocks( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
     s = f.createSection('testSection', 'nixSection');
     
-    assert(isempty(s.referring_blocks));
+    assert(isempty(s.referringBlocks));
 
     b1.set_metadata(s);
-    assert(~isempty(s.referring_blocks));
+    assert(~isempty(s.referringBlocks));
     
     b2.set_metadata(s);
-    assert(size(s.referring_blocks, 1) == 2);
+    assert(size(s.referringBlocks, 1) == 2);
     
     b2.set_metadata('')
-    assert(size(s.referring_blocks, 1) == 1);
+    assert(size(s.referringBlocks, 1) == 1);
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare group entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s1 = f.createSection('testSection1', 'nixSection');
@@ -612,97 +612,97 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter Sections
-function [] = test_filter_section( varargin )
+function [] = testFilterSection( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     ms = f.createSection('testSection', 'nixSection');
-    s = ms.create_section(filterName, 'nixSection');
+    s = ms.createSection(filterName, 'nixSection');
     filterID = s.id;
-	s = ms.create_section('testSection1', filterType);
+	s = ms.createSection('testSection1', filterType);
     filterIDs = {filterID, s.id};
-    s = ms.create_section('testSection2', filterType);
+    s = ms.createSection('testSection2', filterType);
 
     % ToDO add basic filter crash tests
     
     % test empty id filter
-    assert(isempty(f.sections{1}.filter_sections(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.sections{1}.filterSections(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.sections{1}.filter_sections(nix.Filter.accept_all, '');
+    filtered = f.sections{1}.filterSections(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
     
     % test nix.Filter.id
-    filtered = f.sections{1}.filter_sections(nix.Filter.id, filterID);
+    filtered = f.sections{1}.filterSections(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.sections{1}.filter_sections(nix.Filter.ids, filterIDs);
+    filtered = f.sections{1}.filterSections(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.sections{1}.filter_sections(nix.Filter.name, filterName);
+    filtered  = f.sections{1}.filterSections(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.sections{1}.filter_sections(nix.Filter.type, filterType);
+    filtered = f.sections{1}.filterSections(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
     
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.sections{1}.filter_sections(nix.Filter.metadata, 'someMetadata');
+        f.sections{1}.filterSections(nix.Filter.metadata, 'someMetadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
     
     % test fail on nix.Filter.source
     try
-        f.sections{1}.filter_sections(nix.Filter.source, 'someSource');
+        f.sections{1}.filterSections(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end
 end
 
 %% Test: filter properties
-function [] = test_filter_property( varargin )
+function [] = testFilterProperty( varargin )
     filterName = 'filterMe';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     ms = f.createSection('testSection', 'nixSection');
-    p = ms.create_property(filterName, nix.DataType.Double);
+    p = ms.createProperty(filterName, nix.DataType.Double);
     filterID = p.id;
-	s = ms.create_property('testProperty', nix.DataType.Bool);
+	s = ms.createProperty('testProperty', nix.DataType.Bool);
     filterIDs = {filterID, s.id};
     
     % test empty id filter
-    assert(isempty(f.sections{1}.filter_properties(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.sections{1}.filterProperties(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.sections{1}.filter_properties(nix.Filter.accept_all, '');
+    filtered = f.sections{1}.filterProperties(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 2);
     
     % test nix.Filter.id
-    filtered = f.sections{1}.filter_properties(nix.Filter.id, filterID);
+    filtered = f.sections{1}.filterProperties(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.sections{1}.filter_properties(nix.Filter.ids, filterIDs);
+    filtered = f.sections{1}.filterProperties(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
 
     % test nix.Filter.name
-    filtered  = f.sections{1}.filter_properties(nix.Filter.name, filterName);
+    filtered  = f.sections{1}.filterProperties(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
 
     % test fail on nix.Filter.type
     err = 'unknown or unsupported filter';
     try
-        f.sections{1}.filter_properties(nix.Filter.type, 'someType');
+        f.sections{1}.filterProperties(nix.Filter.type, 'someType');
     catch ME
         assert(strcmp(ME.message, err));
     end
@@ -710,196 +710,196 @@ function [] = test_filter_property( varargin )
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.sections{1}.filter_properties(nix.Filter.metadata, 'someMetadata');
+        f.sections{1}.filterProperties(nix.Filter.metadata, 'someMetadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        f.sections{1}.filter_properties(nix.Filter.source, 'someSource');
+        f.sections{1}.filterProperties(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end
 end
 
 %% Test: Find sections w/o filter
-function [] = test_find_section
+function [] = testFindSection
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     main = f.createSection('testSection', 'nixSection');
-    sl1 = main.create_section('sectionLvl1', 'nixSection');
+    sl1 = main.createSection('sectionLvl1', 'nixSection');
 
-    sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
-    sl22 = sl1.create_section('sectionLvl2_2', 'nixSection');
+    sl21 = sl1.createSection('sectionLvl2_1', 'nixSection');
+    sl22 = sl1.createSection('sectionLvl2_2', 'nixSection');
 
-    sl31 = sl21.create_section('sectionLvl3_1', 'nixSection');
-    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
-    sl33 = sl21.create_section('sectionLvl3_3', 'nixSection');
+    sl31 = sl21.createSection('sectionLvl3_1', 'nixSection');
+    sl32 = sl21.createSection('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.createSection('sectionLvl3_3', 'nixSection');
 
-    sl41 = sl31.create_section('sectionLvl4_1', 'nixSection');
-    sl42 = sl31.create_section('sectionLvl4_2', 'nixSection');
-    sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
-    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+    sl41 = sl31.createSection('sectionLvl4_1', 'nixSection');
+    sl42 = sl31.createSection('sectionLvl4_2', 'nixSection');
+    sl43 = sl31.createSection('sectionLvl4_3', 'nixSection');
+    sl44 = sl31.createSection('sectionLvl4_4', 'nixSection');
 
     side = f.createSection('sideSection', 'nixSection');
-    side1 = side.create_section('sideSubSection', 'nixSection');
+    side1 = side.createSection('sideSubSection', 'nixSection');
 
     % Check invalid entry
     err = 'Provide a valid search depth';
     try
-        sl1.find_sections('hurra');
+        sl1.findSections('hurra');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % find all
-    filtered = sl1.find_sections(5);
+    filtered = sl1.findSections(5);
     assert(size(filtered, 1) == 10);
 
     % find until level 4
-    filtered = sl1.find_sections(4);
+    filtered = sl1.findSections(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
-    filtered = sl1.find_sections(3);
+    filtered = sl1.findSections(3);
     assert(size(filtered, 1) == 6);
 
     % find until level 2
-    filtered = sl1.find_sections(2);
+    filtered = sl1.findSections(2);
     assert(size(filtered, 1) == 3);
 
     % find until level 1
-    filtered = sl1.find_sections(1);
+    filtered = sl1.findSections(1);
     assert(size(filtered, 1) == 1);
 end
 
 %% Test: Find sections with filters
-function [] = test_find_section_filtered
+function [] = testFilterFindSections
     findSection = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     main = f.createSection('testSection', 'nixSection');
-    sl1 = main.create_section('sectionLvl1', 'nixSection');
+    sl1 = main.createSection('sectionLvl1', 'nixSection');
 
-    sl21 = sl1.create_section('sectionLvl2_1', 'nixSection');
-    sl22 = sl1.create_section('sectionLvl2_2', findSection);
+    sl21 = sl1.createSection('sectionLvl2_1', 'nixSection');
+    sl22 = sl1.createSection('sectionLvl2_2', findSection);
 
-    sl31 = sl21.create_section('sectionLvl3_1', findSection);
-    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
-    sl33 = sl21.create_section('sectionLvl3_3', 'nixSection');
+    sl31 = sl21.createSection('sectionLvl3_1', findSection);
+    sl32 = sl21.createSection('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.createSection('sectionLvl3_3', 'nixSection');
 
-    sl41 = sl31.create_section('sectionLvl4_1', findSection);
-    sl42 = sl31.create_section('sectionLvl4_2', 'nixSection');
-    sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
-    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+    sl41 = sl31.createSection('sectionLvl4_1', findSection);
+    sl42 = sl31.createSection('sectionLvl4_2', 'nixSection');
+    sl43 = sl31.createSection('sectionLvl4_3', 'nixSection');
+    sl44 = sl31.createSection('sectionLvl4_4', 'nixSection');
 
     sideName = 'sideSubSection';
     side = f.createSection('sideSection', 'nixSection');
-    side1 = side.create_section(sideName, 'nixSection');
+    side1 = side.createSection(sideName, 'nixSection');
 
     % test find by id
-    filtered = sl1.find_filtered_sections(1, nix.Filter.id, sl41.id);
+    filtered = sl1.FilterFindSections(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(4, nix.Filter.id, sl41.id);
+    filtered = sl1.FilterFindSections(4, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = sl1.find_filtered_sections(1, nix.Filter.ids, filterids);
+    filtered = sl1.FilterFindSections(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = sl1.find_filtered_sections(4, nix.Filter.ids, filterids);
+    filtered = sl1.FilterFindSections(4, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = sl1.find_filtered_sections(5, nix.Filter.name, sideName);
+    filtered = sl1.FilterFindSections(5, nix.Filter.name, sideName);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(1, nix.Filter.name, sl41.name);
+    filtered = sl1.FilterFindSections(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(4, nix.Filter.name, sl41.name);
+    filtered = sl1.FilterFindSections(4, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = sl1.find_filtered_sections(1, nix.Filter.type, findSection);
+    filtered = sl1.FilterFindSections(1, nix.Filter.type, findSection);
     assert(isempty(filtered));
-    filtered = sl1.find_filtered_sections(4, nix.Filter.type, findSection);
+    filtered = sl1.FilterFindSections(4, nix.Filter.type, findSection);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSection));
 
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        sl1.find_filtered_sections(1, nix.Filter.metadata, 'metadata');
+        sl1.FilterFindSections(1, nix.Filter.metadata, 'metadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        sl1.find_filtered_sections(1, nix.Filter.source, 'source');
+        sl1.FilterFindSections(1, nix.Filter.source, 'source');
     catch ME
         assert(strcmp(ME.message, err));
     end
 end
 
 %% Test: Find sections related to the current section
-function [] = test_find_related
+function [] = testFindRelated
     findSectionType = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     main = f.createSection('testSection', 'nixSection');
-    sl1 = main.create_section('sectionLvl1', 'nixSection');
+    sl1 = main.createSection('sectionLvl1', 'nixSection');
 
-    sl21 = sl1.create_section('sectionLvl2_1', findSectionType);
-    sl22 = sl1.create_section('sectionLvl2_2', findSectionType);
+    sl21 = sl1.createSection('sectionLvl2_1', findSectionType);
+    sl22 = sl1.createSection('sectionLvl2_2', findSectionType);
 
-    sl31 = sl21.create_section('sectionLvl3_1', findSectionType);
-    sl32 = sl21.create_section('sectionLvl3_2', 'nixSection');
-    sl33 = sl21.create_section('sectionLvl3_3', 'nixSection');
+    sl31 = sl21.createSection('sectionLvl3_1', findSectionType);
+    sl32 = sl21.createSection('sectionLvl3_2', 'nixSection');
+    sl33 = sl21.createSection('sectionLvl3_3', 'nixSection');
 
-    sl41 = sl31.create_section('sectionLvl4_1', findSectionType);
-    sl42 = sl31.create_section('sectionLvl4_2', findSectionType);
-    sl43 = sl31.create_section('sectionLvl4_3', 'nixSection');
-    sl44 = sl31.create_section('sectionLvl4_4', 'nixSection');
+    sl41 = sl31.createSection('sectionLvl4_1', findSectionType);
+    sl42 = sl31.createSection('sectionLvl4_2', findSectionType);
+    sl43 = sl31.createSection('sectionLvl4_3', 'nixSection');
+    sl44 = sl31.createSection('sectionLvl4_4', 'nixSection');
 
     sideName = 'sideSubSection';
     side = f.createSection('sideSection', 'nixSection');
-    side1 = side.create_section(sideName, 'nixSection');
+    side1 = side.createSection(sideName, 'nixSection');
 
     % find first downstream by id
-    rel = sl21.find_related(nix.Filter.id, sl44.id);
+    rel = sl21.findRelated(nix.Filter.id, sl44.id);
     assert(size(rel, 1) == 1);
 
     % find first updstream by ids
-    rel = sl33.find_related(nix.Filter.ids, {sl21.id, sl1.id});
+    rel = sl33.findRelated(nix.Filter.ids, {sl21.id, sl1.id});
     assert(size(rel, 1) == 1);
 
     % find first downstream by name, one occurrence
-    rel = sl21.find_related(nix.Filter.name, 'sectionLvl4_4');
+    rel = sl21.findRelated(nix.Filter.name, 'sectionLvl4_4');
     assert(size(rel, 1) == 1);
 
     % find first downstream by type, one occurrence
-    rel = sl21.find_related(nix.Filter.type, findSectionType);
+    rel = sl21.findRelated(nix.Filter.type, findSectionType);
     assert(size(rel, 1) == 1);
 
     % find first downstream by type, multiple occurrences
-    rel = sl31.find_related(nix.Filter.type, findSectionType);
+    rel = sl31.findRelated(nix.Filter.type, findSectionType);
     assert(size(rel, 1) == 2);
 
     % find first upstream by name, one occurrence
-    rel = sl31.find_related(nix.Filter.name, 'sectionLvl2_1');
+    rel = sl31.findRelated(nix.Filter.name, 'sectionLvl2_1');
     assert(size(rel, 1) == 1);
 
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        sl1.find_related(nix.Filter.metadata, 'metadata');
+        sl1.findRelated(nix.Filter.metadata, 'metadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        sl1.find_related(nix.Filter.source, 'source');
+        sl1.findRelated(nix.Filter.source, 'source');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -353,9 +353,9 @@ end
 function [] = test_referring_data_arrays( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    d1 = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d1 = b1.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    d2 = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d2 = b2.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_data_arrays));
@@ -366,7 +366,7 @@ function [] = test_referring_data_arrays( varargin )
     d2.set_metadata(s);
     assert(size(s.referring_data_arrays, 1) == 2);
     
-    b2.delete_data_array(d2);
+    b2.deleteDataArray(d2);
     d1.set_metadata('');
     assert(isempty(s.referring_data_arrays));
 end
@@ -378,9 +378,9 @@ function [] = test_referring_block_data_arrays( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    d1 = b1.create_data_array(testName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    d1 = b1.createDataArray(testName, 'nixDataArray', nix.DataType.Double, [1 2]);
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    d2 = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d2 = b2.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = f.createSection('testSection', 'nixSection');
     
     d1.set_metadata(s);
@@ -410,9 +410,9 @@ end
 function [] = test_referring_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    t1 = b1.create_tag('testTag1', 'nixTag', [1, 2]);
+    t1 = b1.createTag('testTag1', 'nixTag', [1, 2]);
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    t2 = b2.create_tag('testTag2', 'nixTag', [3, 4]);
+    t2 = b2.createTag('testTag2', 'nixTag', [3, 4]);
     s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_tags));
@@ -423,7 +423,7 @@ function [] = test_referring_tags( varargin )
     t2.set_metadata(s);
     assert(size(s.referring_tags, 1) == 2);
     
-    b2.delete_tag(t2);
+    b2.deleteTag(t2);
     t1.set_metadata('');
     assert(isempty(s.referring_tags));
 end
@@ -435,9 +435,9 @@ function [] = test_referring_block_tags( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    t1 = b1.create_tag(testName, 'nixTag', [1, 2]);
+    t1 = b1.createTag(testName, 'nixTag', [1, 2]);
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    t2 = b2.create_tag('testTag2', 'nixTag', [3, 4]);
+    t2 = b2.createTag('testTag2', 'nixTag', [3, 4]);
     s = f.createSection('testSection', 'nixSection');
 
     t1.set_metadata(s);
@@ -467,11 +467,11 @@ end
 function [] = test_referring_multi_tags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    d = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t1 = b1.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
+    d = b1.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t1 = b1.createMultiTag('testMultiTag1', 'nixMultiTag', d);
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    d = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t2 = b2.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
+    d = b2.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t2 = b2.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_multi_tags));
@@ -482,7 +482,7 @@ function [] = test_referring_multi_tags( varargin )
     t2.set_metadata(s);
     assert(size(s.referring_multi_tags, 1) == 2);
     
-    b2.delete_multi_tag(t2);
+    b2.deleteMultiTag(t2);
     t1.set_metadata('');
     assert(isempty(s.referring_multi_tags));
 end
@@ -494,11 +494,11 @@ function [] = test_referring_block_multi_tags( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    d = b1.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t1 = b1.create_multi_tag(testName, 'nixMultiTag', d);
+    d = b1.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t1 = b1.createMultiTag(testName, 'nixMultiTag', d);
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    d = b2.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t2 = b2.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
+    d = b2.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t2 = b2.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     s = f.createSection('testSection', 'nixSection');
 
     t1.set_metadata(s);
@@ -528,9 +528,9 @@ end
 function [] = test_referring_sources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    s1 = b1.create_source('testSource1', 'nixSource');
+    s1 = b1.createSource('testSource1', 'nixSource');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    s2 = b2.create_source('testSource2', 'nixSource');
+    s2 = b2.createSource('testSource2', 'nixSource');
     s = f.createSection('testSection', 'nixSection');
     
     assert(isempty(s.referring_sources));
@@ -541,7 +541,7 @@ function [] = test_referring_sources( varargin )
     s2.set_metadata(s);
     assert(size(s.referring_sources, 1) == 2);
     
-    b2.delete_source(s2);
+    b2.deleteSource(s2);
     s1.set_metadata('');
     assert(isempty(s.referring_sources));
 end
@@ -553,9 +553,9 @@ function [] = test_referring_block_sources( varargin )
 
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
-    s1 = b1.create_source(testName, 'nixSource');
+    s1 = b1.createSource(testName, 'nixSource');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    s2 = b2.create_source('testSource2', 'nixSource');
+    s2 = b2.createSource('testSource2', 'nixSource');
     s = f.createSection('testSection', 'nixSection');
 
     s1.set_metadata(s);

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -36,7 +36,7 @@ function [] = test_fetch_sources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
-    s = b.create_source('sourcetest', 'nixSource');
+    s = b.createSource('sourcetest', 'nixSource');
 
     assert(isempty(s.sources));
     assert(isempty(f.blocks{1}.sources{1}.sources));
@@ -54,22 +54,21 @@ end
 
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
-
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
-    getSource = getBlock.create_source('sourcetest', 'nixSource');
-    assert(isempty(getSource.sources));
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourcetest', 'nixBlock');
+    s = b.createSource('sourcetest', 'nixSource');
+    assert(isempty(s.sources));
 
     sourceName = 'nestedsource';
-    createSource = getSource.create_source(sourceName, 'nixSource');
-    getSourceByID = getSource.open_source(createSource.id);
+    createSource = s.create_source(sourceName, 'nixSource');
+    getSourceByID = s.open_source(createSource.id);
     assert(~isempty(getSourceByID));
 
-    getSourceByName = getSource.open_source(sourceName);
+    getSourceByName = s.open_source(sourceName);
     assert(~isempty(getSourceByName));
 
     %-- test open non existing source
-    getNonSource = getSource.open_source('I dont exist');
+    getNonSource = s.open_source('I dont exist');
     assert(isempty(getNonSource));
 end
 
@@ -77,7 +76,7 @@ function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('testSource', 'nixSource');
+    s = b.createSource('testSource', 'nixSource');
     s1 = s.create_source('testSource1', 'nixSource');
     s2 = s.create_source('testSource2', 'nixSource');
     s3 = s.create_source('testSource3', 'nixSource');
@@ -92,7 +91,7 @@ function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('testSource', 'nixSource');
+    s = b.createSource('testSource', 'nixSource');
 
     assert(s.source_count() == 0);
     s.create_source('testSource1', 'nixSource');
@@ -113,7 +112,7 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection('testSection1', 'nixSection');
     tmp = f.createSection('testSection2', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('testSource', 'nixSource');
+    s = b.createSource('testSource', 'nixSource');
 
     assert(isempty(s.open_metadata));
     assert(isempty(f.blocks{1}.sources{1}.open_metadata));
@@ -141,7 +140,7 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('testSource', 'nixSource');
+    s = b.createSource('testSource', 'nixSource');
     s.set_metadata(f.sections{1});
 
     assert(strcmp(s.open_metadata.name, 'testSection'));
@@ -151,35 +150,35 @@ end
 function [] = test_create_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
-    getSource = b.create_source('sourcetest', 'nixSource');
-    assert(isempty(getSource.sources));
+    s = b.createSource('sourcetest', 'nixSource');
+    assert(isempty(s.sources));
 
-    createSource = getSource.create_source('nestedsource', 'nixSource');
-    assert(~isempty(getSource.sources));
+    createSource = s.create_source('nestedsource', 'nixSource');
+    assert(~isempty(s.sources));
     assert(strcmp(createSource.name, 'nestedsource'));
     assert(strcmp(createSource.type, 'nixSource'));
 end
 
 %% Test: delete source
 function [] = test_delete_source( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
-    getSource = getBlock.create_source('sourcetest', 'nixSource');
-    assert(isempty(getSource.sources));
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourcetest', 'nixBlock');
+    s = b.createSource('sourcetest', 'nixSource');
+    assert(isempty(s.sources));
 
-    tmp = getSource.create_source('nestedsource1', 'nixSource');
-    tmp = getSource.create_source('nestedsource2', 'nixSource');
-    assert(getSource.delete_source('nestedsource1'));
-    assert(getSource.delete_source(getSource.sources{1}.id));
-    assert(~getSource.delete_source('I do not exist'));
-    assert(isempty(getSource.sources));
+    tmp = s.create_source('nestedsource1', 'nixSource');
+    tmp = s.create_source('nestedsource2', 'nixSource');
+    assert(s.delete_source('nestedsource1'));
+    assert(s.delete_source(s.sources{1}.id));
+    assert(~s.delete_source('I do not exist'));
+    assert(isempty(s.sources));
 end
 
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'test nixBlock');
-    s = b.create_source('sourcetest', 'test nixSource');
+    s = b.createSource('sourcetest', 'test nixSource');
 
     assert(~isempty(s.id));
     assert(strcmp(s.name, 'sourcetest'));
@@ -202,7 +201,7 @@ function [] = test_has_source( varargin )
     sName = 'nestedsource';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.create_source('sourcetest', 'nixSource');
+    s = b.createSource('sourcetest', 'nixSource');
     nested = s.create_source(sName, 'nixSource');
     nestedID = nested.id;
 
@@ -221,7 +220,7 @@ function [] = test_parent_source( varargin )
     b = f.createBlock('sourcetest', 'nixBlock');
     sourceName1 = 'testSource1';
     sourceName2 = 'testSource2';
-    s1 = b.create_source(sourceName1, 'nixSource');
+    s1 = b.createSource(sourceName1, 'nixSource');
     s2 = s1.create_source(sourceName2, 'nixSource');
     s3 = s2.create_source('testSource3', 'nixSource');
 
@@ -234,16 +233,16 @@ function [] = test_referring_data_arrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('testSource', 'nixSource');
+    s = b.createSource('testSource', 'nixSource');
 
     assert(isempty(s.referring_data_arrays));
 
-    d1 = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d1.add_source(s);
     assert(~isempty(s.referring_data_arrays));
     assert(strcmp(s.referring_data_arrays{1}.name, d1.name));
 
-    d2 = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d2 = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2.add_source(s);
     assert(size(s.referring_data_arrays, 1) == 2);
 end
@@ -253,16 +252,16 @@ function [] = test_referring_tags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('testSource', 'nixSource');
+    s = b.createSource('testSource', 'nixSource');
 
     assert(isempty(s.referring_tags));
 
-    t1 = b.create_tag('testTag1', 'nixTag', [1, 2]);
+    t1 = b.createTag('testTag1', 'nixTag', [1, 2]);
     t1.add_source(s);
     assert(~isempty(s.referring_tags));
     assert(strcmp(s.referring_tags{1}.name, t1.name));
 
-    t2 = b.create_tag('testTag2', 'nixTag', [1, 2]);
+    t2 = b.createTag('testTag2', 'nixTag', [1, 2]);
     t2.add_source(s);
     assert(size(s.referring_tags, 1) == 2);
 end
@@ -272,17 +271,17 @@ function [] = test_referring_multi_tags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    s = b.create_source('testSource', 'nixSource');
+    d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    s = b.createSource('testSource', 'nixSource');
 
     assert(isempty(s.referring_multi_tags));
 
-    t1 = b.create_multi_tag('testMultiTag1', 'nixMultiTag', d);
+    t1 = b.createMultiTag('testMultiTag1', 'nixMultiTag', d);
     t1.add_source(s);
     assert(~isempty(s.referring_multi_tags));
     assert(strcmp(s.referring_multi_tags{1}.name, t1.name));
 
-    t2 = b.create_multi_tag('testMultiTag2', 'nixMultiTag', d);
+    t2 = b.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     t2.add_source(s);
     assert(size(s.referring_multi_tags, 1) == 2);
 end
@@ -292,9 +291,9 @@ function [] = test_compare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    s1 = b1.create_source('testSource1', 'nixSource');
-    s2 = b1.create_source('testSource2', 'nixSource');
-    s3 = b2.create_source('testSource1', 'nixSource');
+    s1 = b1.createSource('testSource1', 'nixSource');
+    s2 = b1.createSource('testSource2', 'nixSource');
+    s3 = b2.createSource('testSource1', 'nixSource');
 
     assert(s1.compare(s2) < 0);
     assert(s1.compare(s1) == 0);
@@ -308,7 +307,7 @@ function [] = test_filter_source( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    ms = b.create_source('testSource', 'nixSource');
+    ms = b.createSource('testSource', 'nixSource');
     s = ms.create_source(filterName, 'nixSource');
     filterID = s.id;
 	s = ms.create_source('testSource1', filterType);
@@ -376,7 +375,7 @@ end
 function [] = test_find_source
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('mainSource', 'nixSource');
+    s = b.createSource('mainSource', 'nixSource');
     sl1 = s.create_source('sourceLvl1', 'nixSource');
 
     sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
@@ -425,7 +424,7 @@ function [] = test_find_source_filtered
     findSource = 'nixFindSource';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    s = b.create_source('mainSource', 'nixSource');
+    s = b.createSource('mainSource', 'nixSource');
     sl1 = s.create_source('sourceLvl1', 'nixSource');
 
     sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -35,7 +35,7 @@ end
 function [] = test_fetch_sources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('sourcetest', 'nixBlock');
+    b = f.createBlock('sourcetest', 'nixBlock');
     s = b.create_source('sourcetest', 'nixSource');
 
     assert(isempty(s.sources));
@@ -56,7 +56,7 @@ end
 function [] = test_open_source( varargin )
 
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('sourcetest', 'nixBlock');
+    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
     getSource = getBlock.create_source('sourcetest', 'nixSource');
     assert(isempty(getSource.sources));
 
@@ -76,7 +76,7 @@ end
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
     s1 = s.create_source('testSource1', 'nixSource');
     s2 = s.create_source('testSource2', 'nixSource');
@@ -91,7 +91,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
 
     assert(s.source_count() == 0);
@@ -110,9 +110,9 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection1', 'nixSection');
-    tmp = f.create_section('testSection2', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection1', 'nixSection');
+    tmp = f.createSection('testSection2', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
 
     assert(isempty(s.open_metadata));
@@ -139,8 +139,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
     s.set_metadata(f.sections{1});
 
@@ -149,9 +149,9 @@ end
 
 %% Test: create source
 function [] = test_create_source ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('sourcetest', 'nixBlock');
-    getSource = getBlock.create_source('sourcetest', 'nixSource');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('sourcetest', 'nixBlock');
+    getSource = b.create_source('sourcetest', 'nixSource');
     assert(isempty(getSource.sources));
 
     createSource = getSource.create_source('nestedsource', 'nixSource');
@@ -163,7 +163,7 @@ end
 %% Test: delete source
 function [] = test_delete_source( varargin )
     test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('sourcetest', 'nixBlock');
+    getBlock = test_file.createBlock('sourcetest', 'nixBlock');
     getSource = getBlock.create_source('sourcetest', 'nixSource');
     assert(isempty(getSource.sources));
 
@@ -178,7 +178,7 @@ end
 function [] = test_attrs( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('tagtest', 'test nixBlock');
+    b = f.createBlock('tagtest', 'test nixBlock');
     s = b.create_source('sourcetest', 'test nixSource');
 
     assert(~isempty(s.id));
@@ -201,7 +201,7 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     sName = 'nestedsource';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     s = b.create_source('sourcetest', 'nixSource');
     nested = s.create_source(sName, 'nixSource');
     nestedID = nested.id;
@@ -218,7 +218,7 @@ end
 function [] = test_parent_source( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('sourcetest', 'nixBlock');
+    b = f.createBlock('sourcetest', 'nixBlock');
     sourceName1 = 'testSource1';
     sourceName2 = 'testSource2';
     s1 = b.create_source(sourceName1, 'nixSource');
@@ -233,7 +233,7 @@ end
 function [] = test_referring_data_arrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
 
     assert(isempty(s.referring_data_arrays));
@@ -252,7 +252,7 @@ end
 function [] = test_referring_tags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('testSource', 'nixSource');
 
     assert(isempty(s.referring_tags));
@@ -271,7 +271,7 @@ end
 function [] = test_referring_multi_tags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     d = b.create_data_array('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.create_source('testSource', 'nixSource');
 
@@ -290,8 +290,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare Source entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     s1 = b1.create_source('testSource1', 'nixSource');
     s2 = b1.create_source('testSource2', 'nixSource');
     s3 = b2.create_source('testSource1', 'nixSource');
@@ -307,7 +307,7 @@ function [] = test_filter_source( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     ms = b.create_source('testSource', 'nixSource');
     s = ms.create_source(filterName, 'nixSource');
     filterID = s.id;
@@ -345,7 +345,7 @@ function [] = test_filter_source( varargin )
     mainName = 'testSubSection';
     mainSource = ms.create_source(mainName, 'nixSource');
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
@@ -375,7 +375,7 @@ end
 %% Test: Find source w/o filter
 function [] = test_find_source
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('mainSource', 'nixSource');
     sl1 = s.create_source('sourceLvl1', 'nixSource');
 
@@ -424,7 +424,7 @@ end
 function [] = test_find_source_filtered
     findSource = 'nixFindSource';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     s = b.create_source('mainSource', 'nixSource');
     sl1 = s.create_source('sourceLvl1', 'nixSource');
 
@@ -469,7 +469,7 @@ function [] = test_find_source_filtered
     assert(strcmp(filtered{1}.type, findSource));
 
     % test nix.Filter.metadata
-    sec = f.create_section('testSection', 'nixSection');
+    sec = f.createSection('testSection', 'nixSection');
     sl43.set_metadata(sec);
     filtered = s.find_filtered_sources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -315,8 +315,8 @@ function [] = testFilterSource( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.sources{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -112,25 +112,25 @@ function [] = testSetMetadata ( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
 
-    assert(isempty(s.open_metadata));
-    assert(isempty(f.blocks{1}.sources{1}.open_metadata));
+    assert(isempty(s.openMetadata));
+    assert(isempty(f.blocks{1}.sources{1}.openMetadata));
 
-    s.set_metadata(f.sections{1});
-    assert(strcmp(s.open_metadata.name, secName1));
-    assert(strcmp(f.blocks{1}.sources{1}.open_metadata.name, secName1));
+    s.setMetadata(f.sections{1});
+    assert(strcmp(s.openMetadata.name, secName1));
+    assert(strcmp(f.blocks{1}.sources{1}.openMetadata.name, secName1));
 
-    s.set_metadata(f.sections{2});
-    assert(strcmp(s.open_metadata.name, secName2));
-    assert(strcmp(f.blocks{1}.sources{1}.open_metadata.name, secName2));
+    s.setMetadata(f.sections{2});
+    assert(strcmp(s.openMetadata.name, secName2));
+    assert(strcmp(f.blocks{1}.sources{1}.openMetadata.name, secName2));
 
-    s.set_metadata('');
-    assert(isempty(s.open_metadata));
-    assert(isempty(f.blocks{1}.sources{1}.open_metadata));
+    s.setMetadata('');
+    assert(isempty(s.openMetadata));
+    assert(isempty(f.blocks{1}.sources{1}.openMetadata));
 
-	s.set_metadata(f.sections{2});
+	s.setMetadata(f.sections{2});
     clear tmp b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.sources{1}.open_metadata.name, secName2));
+    assert(strcmp(f.blocks{1}.sources{1}.openMetadata.name, secName2));
 end
 
 %% Test: Open metadata
@@ -139,9 +139,9 @@ function [] = testOpenMetadata( varargin )
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
-    s.set_metadata(f.sections{1});
+    s.setMetadata(f.sections{1});
 
-    assert(strcmp(s.open_metadata.name, 'testSection'));
+    assert(strcmp(s.openMetadata.name, 'testSection'));
 end
 
 %% Test: create source
@@ -343,7 +343,7 @@ function [] = testFilterSource( varargin )
     mainSource = ms.createSource(mainName, 'nixSource');
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainSource.set_metadata(s);
+    mainSource.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.sources{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
@@ -467,7 +467,7 @@ function [] = testFilterFindSource( varargin )
 
     % test nix.Filter.metadata
     sec = f.createSection('testSection', 'nixSection');
-    sl43.set_metadata(sec);
+    sl43.setMetadata(sec);
     filtered = s.filterFindSources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));
     filtered = s.filterFindSources(5, nix.Filter.metadata, sec.id);

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -236,12 +236,12 @@ function [] = testReferringDataArrays( varargin )
     assert(isempty(s.referringDataArrays));
 
     d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    d1.add_source(s);
+    d1.addSource(s);
     assert(~isempty(s.referringDataArrays));
     assert(strcmp(s.referringDataArrays{1}.name, d1.name));
 
     d2 = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    d2.add_source(s);
+    d2.addSource(s);
     assert(size(s.referringDataArrays, 1) == 2);
 end
 
@@ -255,12 +255,12 @@ function [] = testReferringTags( varargin )
     assert(isempty(s.referringTags));
 
     t1 = b.createTag('testTag1', 'nixTag', [1, 2]);
-    t1.add_source(s);
+    t1.addSource(s);
     assert(~isempty(s.referringTags));
     assert(strcmp(s.referringTags{1}.name, t1.name));
 
     t2 = b.createTag('testTag2', 'nixTag', [1, 2]);
-    t2.add_source(s);
+    t2.addSource(s);
     assert(size(s.referringTags, 1) == 2);
 end
 
@@ -275,12 +275,12 @@ function [] = testReferringMultiTags( varargin )
     assert(isempty(s.referringMultiTags));
 
     t1 = b.createMultiTag('testMultiTag1', 'nixMultiTag', d);
-    t1.add_source(s);
+    t1.addSource(s);
     assert(~isempty(s.referringMultiTags));
     assert(strcmp(s.referringMultiTags{1}.name, t1.name));
 
     t2 = b.createMultiTag('testMultiTag2', 'nixMultiTag', d);
-    t2.add_source(s);
+    t2.addSource(s);
     assert(size(s.referringMultiTags, 1) == 2);
 end
 

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -7,32 +7,30 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestSource
-%TESTSOURCE tests for Source
-%   Detailed explanation goes here
-
+% TESTSOURCE tests for Source
     funcs = {};
-    funcs{end+1} = @test_create_source;
-    funcs{end+1} = @test_delete_source;
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_fetch_sources;
-    funcs{end+1} = @test_has_source;
-    funcs{end+1} = @test_open_source;
-    funcs{end+1} = @test_open_source_idx;
-    funcs{end+1} = @test_source_count;
-    funcs{end+1} = @test_parent_source;
-    funcs{end+1} = @test_set_metadata;
-    funcs{end+1} = @test_open_metadata;
-    funcs{end+1} = @test_referring_data_arrays;
-    funcs{end+1} = @test_referring_tags;
-    funcs{end+1} = @test_referring_multi_tags;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_source;
-    funcs{end+1} = @test_find_source;
-    funcs{end+1} = @test_find_source_filtered;
+    funcs{end+1} = @testCreateSource;
+    funcs{end+1} = @testDeleteSource;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testFetchSources;
+    funcs{end+1} = @testHasSource;
+    funcs{end+1} = @testOpenSource;
+    funcs{end+1} = @testOpenSourceIdx;
+    funcs{end+1} = @testSourceCount;
+    funcs{end+1} = @testParentSource;
+    funcs{end+1} = @testSetMetadata;
+    funcs{end+1} = @testOpenMetadata;
+    funcs{end+1} = @testReferringDataArrays;
+    funcs{end+1} = @testReferringTags;
+    funcs{end+1} = @testReferringMultiTags;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSource;
+    funcs{end+1} = @testFindSource;
+    funcs{end+1} = @testFilterFindSource;
 end
 
 %% Test: fetch sources
-function [] = test_fetch_sources( varargin )
+function [] = testFetchSources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
@@ -40,10 +38,10 @@ function [] = test_fetch_sources( varargin )
 
     assert(isempty(s.sources));
     assert(isempty(f.blocks{1}.sources{1}.sources));
-    tmp = s.create_source('nestedsource1', 'nixSource');
+    tmp = s.createSource('nestedsource1', 'nixSource');
     assert(size(s.sources, 1) == 1);
     assert(size(f.blocks{1}.sources{1}.sources, 1) == 1);
-    tmp = s.create_source('nestedsource2', 'nixSource');
+    tmp = s.createSource('nestedsource2', 'nixSource');
     assert(size(s.sources, 1) == 2);
     assert(size(f.blocks{1}.sources{1}.sources, 1) == 2);
     
@@ -53,58 +51,58 @@ function [] = test_fetch_sources( varargin )
 end
 
 %% Test: Open source by ID or name
-function [] = test_open_source( varargin )
+function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
     s = b.createSource('sourcetest', 'nixSource');
     assert(isempty(s.sources));
 
     sourceName = 'nestedsource';
-    createSource = s.create_source(sourceName, 'nixSource');
-    getSourceByID = s.open_source(createSource.id);
+    createSource = s.createSource(sourceName, 'nixSource');
+    getSourceByID = s.openSource(createSource.id);
     assert(~isempty(getSourceByID));
 
-    getSourceByName = s.open_source(sourceName);
+    getSourceByName = s.openSource(sourceName);
     assert(~isempty(getSourceByName));
 
     %-- test open non existing source
-    getNonSource = s.open_source('I dont exist');
+    getNonSource = s.openSource('I dont exist');
     assert(isempty(getNonSource));
 end
 
-function [] = test_open_source_idx( varargin )
+function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
-    s1 = s.create_source('testSource1', 'nixSource');
-    s2 = s.create_source('testSource2', 'nixSource');
-    s3 = s.create_source('testSource3', 'nixSource');
+    s1 = s.createSource('testSource1', 'nixSource');
+    s2 = s.createSource('testSource2', 'nixSource');
+    s3 = s.createSource('testSource3', 'nixSource');
 
-    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(1).name, s1.name));
-    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(2).name, s2.name));
-    assert(strcmp(f.blocks{1}.sources{1}.open_source_idx(3).name, s3.name));
+    assert(strcmp(f.blocks{1}.sources{1}.openSourceIdx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.sources{1}.openSourceIdx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.sources{1}.openSourceIdx(3).name, s3.name));
 end
 
 %% Test: Source count
-function [] = test_source_count( varargin )
+function [] = testSourceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
 
-    assert(s.source_count() == 0);
-    s.create_source('testSource1', 'nixSource');
-    assert(s.source_count() == 1);
-    s.create_source('testSource2', 'nixSource');
+    assert(s.sourceCount() == 0);
+    s.createSource('testSource1', 'nixSource');
+    assert(s.sourceCount() == 1);
+    s.createSource('testSource2', 'nixSource');
 
     clear s b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.sources{1}.source_count() == 2);
+    assert(f.blocks{1}.sources{1}.sourceCount() == 2);
 end
 
 %% Test: Set metadata
-function [] = test_set_metadata ( varargin )
+function [] = testSetMetadata ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     secName1 = 'testSection1';
     secName2 = 'testSection2';
@@ -136,7 +134,7 @@ function [] = test_set_metadata ( varargin )
 end
 
 %% Test: Open metadata
-function [] = test_open_metadata( varargin )
+function [] = testOpenMetadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
@@ -147,34 +145,34 @@ function [] = test_open_metadata( varargin )
 end
 
 %% Test: create source
-function [] = test_create_source ( varargin )
+function [] = testCreateSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
     s = b.createSource('sourcetest', 'nixSource');
     assert(isempty(s.sources));
 
-    createSource = s.create_source('nestedsource', 'nixSource');
+    createSource = s.createSource('nestedsource', 'nixSource');
     assert(~isempty(s.sources));
     assert(strcmp(createSource.name, 'nestedsource'));
     assert(strcmp(createSource.type, 'nixSource'));
 end
 
 %% Test: delete source
-function [] = test_delete_source( varargin )
+function [] = testDeleteSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
     s = b.createSource('sourcetest', 'nixSource');
     assert(isempty(s.sources));
 
-    tmp = s.create_source('nestedsource1', 'nixSource');
-    tmp = s.create_source('nestedsource2', 'nixSource');
-    assert(s.delete_source('nestedsource1'));
-    assert(s.delete_source(s.sources{1}.id));
-    assert(~s.delete_source('I do not exist'));
+    tmp = s.createSource('nestedsource1', 'nixSource');
+    tmp = s.createSource('nestedsource2', 'nixSource');
+    assert(s.deleteSource('nestedsource1'));
+    assert(s.deleteSource(s.sources{1}.id));
+    assert(~s.deleteSource('I do not exist'));
     assert(isempty(s.sources));
 end
 
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
 %% Test: Access Attributes
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'test nixBlock');
@@ -196,97 +194,97 @@ function [] = test_attrs( varargin )
 end
 
 %% Test: nix.Source has nix.Source by ID or name
-function [] = test_has_source( varargin )
+function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'nestedsource';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
     s = b.createSource('sourcetest', 'nixSource');
-    nested = s.create_source(sName, 'nixSource');
+    nested = s.createSource(sName, 'nixSource');
     nestedID = nested.id;
 
-    assert(~s.has_source('I do not exist'));
-    assert(s.has_source(sName));
+    assert(~s.hasSource('I do not exist'));
+    assert(s.hasSource(sName));
 
     clear nested s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.sources{1}.has_source(nestedID));
+    assert(f.blocks{1}.sources{1}.hasSource(nestedID));
 end
 
 %% Test: Get parent source
-function [] = test_parent_source( varargin )
+function [] = testParentSource( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
     sourceName1 = 'testSource1';
     sourceName2 = 'testSource2';
     s1 = b.createSource(sourceName1, 'nixSource');
-    s2 = s1.create_source(sourceName2, 'nixSource');
-    s3 = s2.create_source('testSource3', 'nixSource');
+    s2 = s1.createSource(sourceName2, 'nixSource');
+    s3 = s2.createSource('testSource3', 'nixSource');
 
-    assert(strcmp(s3.parent_source.name, sourceName2));
-    assert(strcmp(s2.parent_source.name, sourceName1));
+    assert(strcmp(s3.parentSource.name, sourceName2));
+    assert(strcmp(s2.parentSource.name, sourceName1));
 end
 
 %% Test: Referring data arrays
-function [] = test_referring_data_arrays( varargin )
+function [] = testReferringDataArrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
 
-    assert(isempty(s.referring_data_arrays));
+    assert(isempty(s.referringDataArrays));
 
     d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d1.add_source(s);
-    assert(~isempty(s.referring_data_arrays));
-    assert(strcmp(s.referring_data_arrays{1}.name, d1.name));
+    assert(~isempty(s.referringDataArrays));
+    assert(strcmp(s.referringDataArrays{1}.name, d1.name));
 
     d2 = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2.add_source(s);
-    assert(size(s.referring_data_arrays, 1) == 2);
+    assert(size(s.referringDataArrays, 1) == 2);
 end
 
 %% Test: Referring tags
-function [] = test_referring_tags( varargin )
+function [] = testReferringTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
 
-    assert(isempty(s.referring_tags));
+    assert(isempty(s.referringTags));
 
     t1 = b.createTag('testTag1', 'nixTag', [1, 2]);
     t1.add_source(s);
-    assert(~isempty(s.referring_tags));
-    assert(strcmp(s.referring_tags{1}.name, t1.name));
+    assert(~isempty(s.referringTags));
+    assert(strcmp(s.referringTags{1}.name, t1.name));
 
     t2 = b.createTag('testTag2', 'nixTag', [1, 2]);
     t2.add_source(s);
-    assert(size(s.referring_tags, 1) == 2);
+    assert(size(s.referringTags, 1) == 2);
 end
 
 %% Test: Referring multi tags
-function [] = test_referring_multi_tags( varargin )
+function [] = testReferringMultiTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     s = b.createSource('testSource', 'nixSource');
 
-    assert(isempty(s.referring_multi_tags));
+    assert(isempty(s.referringMultiTags));
 
     t1 = b.createMultiTag('testMultiTag1', 'nixMultiTag', d);
     t1.add_source(s);
-    assert(~isempty(s.referring_multi_tags));
-    assert(strcmp(s.referring_multi_tags{1}.name, t1.name));
+    assert(~isempty(s.referringMultiTags));
+    assert(strcmp(s.referringMultiTags{1}.name, t1.name));
 
     t2 = b.createMultiTag('testMultiTag2', 'nixMultiTag', d);
     t2.add_source(s);
-    assert(size(s.referring_multi_tags, 1) == 2);
+    assert(size(s.referringMultiTags, 1) == 2);
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare Source entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -302,184 +300,184 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter sources
-function [] = test_filter_source( varargin )
+function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     ms = b.createSource('testSource', 'nixSource');
-    s = ms.create_source(filterName, 'nixSource');
+    s = ms.createSource(filterName, 'nixSource');
     filterID = s.id;
-	s = ms.create_source('testSource1', filterType);
+	s = ms.createSource('testSource1', filterType);
     filterIDs = {filterID, s.id};
-    s = ms.create_source('testSource2', filterType);
+    s = ms.createSource('testSource2', filterType);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.sources{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.sources{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.sources{1}.filter_sources(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.sources{1}.filterSources(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainSource = ms.create_source(mainName, 'nixSource');
+    mainSource = ms.createSource(mainName, 'nixSource');
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.sources{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.sources{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = ms.create_source(mainName, 'nixSource');
+    main = ms.createSource(mainName, 'nixSource');
     mainID = main.id;
     subName = 'testSubSource1';
-    s = main.create_source(subName, 'nixSource');
+    s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.sources{1}.filter_sources(nix.Filter.source, 'Do not exist')));
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.source, subName);
+    assert(isempty(f.blocks{1}.sources{1}.filterSources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.source, subName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, mainID));
 
-    filtered = f.blocks{1}.sources{1}.filter_sources(nix.Filter.source, subID);
+    filtered = f.blocks{1}.sources{1}.filterSources(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: Find source w/o filter
-function [] = test_find_source
+function [] = testFindSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('mainSource', 'nixSource');
-    sl1 = s.create_source('sourceLvl1', 'nixSource');
+    sl1 = s.createSource('sourceLvl1', 'nixSource');
 
-    sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
-    sl22 = sl1.create_source('sourceLvl2_2', 'nixSource');
+    sl21 = sl1.createSource('sourceLvl2_1', 'nixSource');
+    sl22 = sl1.createSource('sourceLvl2_2', 'nixSource');
 
-    sl31 = sl21.create_source('sourceLvl3_1', 'nixSource');
-    sl32 = sl21.create_source('sourceLvl3_2', 'nixSource');
-    sl33 = sl21.create_source('sourceLvl3_3', 'nixSource');
+    sl31 = sl21.createSource('sourceLvl3_1', 'nixSource');
+    sl32 = sl21.createSource('sourceLvl3_2', 'nixSource');
+    sl33 = sl21.createSource('sourceLvl3_3', 'nixSource');
 
-    sl41 = sl31.create_source('sourceLvl4_1', 'nixSource');
-    sl42 = sl31.create_source('sourceLvl4_2', 'nixSource');
-    sl43 = sl31.create_source('sourceLvl4_3', 'nixSource');
-    sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
+    sl41 = sl31.createSource('sourceLvl4_1', 'nixSource');
+    sl42 = sl31.createSource('sourceLvl4_2', 'nixSource');
+    sl43 = sl31.createSource('sourceLvl4_3', 'nixSource');
+    sl44 = sl31.createSource('sourceLvl4_4', 'nixSource');
 
     % Check invalid entry
     err = 'Provide a valid search depth';
     try
-        s.find_sources('hurra');
+        s.findSources('hurra');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % find all
-    filtered = s.find_sources(5);
+    filtered = s.findSources(5);
     assert(size(filtered, 1) == 11);
 
     % find until level 3
-    filtered = s.find_sources(4);
+    filtered = s.findSources(4);
     assert(size(filtered, 1) == 7);
 
     % find until level 2
-    filtered = s.find_sources(3);
+    filtered = s.findSources(3);
     assert(size(filtered, 1) == 4);
 
     % find until level 1
-    filtered = s.find_sources(2);
+    filtered = s.findSources(2);
     assert(size(filtered, 1) == 2);
 
     % find until level 0
-    filtered = s.find_sources(1);
+    filtered = s.findSources(1);
     assert(size(filtered, 1) == 1);
 end
 
 %% Test: Find sources with filters
-function [] = test_find_source_filtered
+function [] = testFilterFindSource( varargin )
     findSource = 'nixFindSource';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('mainSource', 'nixSource');
-    sl1 = s.create_source('sourceLvl1', 'nixSource');
+    sl1 = s.createSource('sourceLvl1', 'nixSource');
 
-    sl21 = sl1.create_source('sourceLvl2_1', 'nixSource');
-    sl22 = sl1.create_source('sourceLvl2_2', findSource);
+    sl21 = sl1.createSource('sourceLvl2_1', 'nixSource');
+    sl22 = sl1.createSource('sourceLvl2_2', findSource);
 
-    sl31 = sl21.create_source('sourceLvl3_1', findSource);
-    sl32 = sl21.create_source('sourceLvl3_2', 'nixSource');
-    sl33 = sl21.create_source('sourceLvl3_3', 'nixSource');
+    sl31 = sl21.createSource('sourceLvl3_1', findSource);
+    sl32 = sl21.createSource('sourceLvl3_2', 'nixSource');
+    sl33 = sl21.createSource('sourceLvl3_3', 'nixSource');
 
-    sl41 = sl31.create_source('sourceLvl4_1', 'nixSource');
-    sl42 = sl31.create_source('sourceLvl4_2', 'nixSource');
-    sl43 = sl31.create_source('sourceLvl4_3', findSource);
-    sl44 = sl31.create_source('sourceLvl4_4', 'nixSource');
+    sl41 = sl31.createSource('sourceLvl4_1', 'nixSource');
+    sl42 = sl31.createSource('sourceLvl4_2', 'nixSource');
+    sl43 = sl31.createSource('sourceLvl4_3', findSource);
+    sl44 = sl31.createSource('sourceLvl4_4', 'nixSource');
 
     % test find by id
-    filtered = s.find_filtered_sources(1, nix.Filter.id, sl41.id);
+    filtered = s.filterFindSources(1, nix.Filter.id, sl41.id);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(5, nix.Filter.id, sl41.id);
+    filtered = s.filterFindSources(5, nix.Filter.id, sl41.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
     filterids = {sl1.id, sl41.id};
-    filtered = s.find_filtered_sources(2, nix.Filter.ids, filterids);
+    filtered = s.filterFindSources(2, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
-    filtered = s.find_filtered_sources(5, nix.Filter.ids, filterids);
+    filtered = s.filterFindSources(5, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 2);
 
     % test find by name
-    filtered = s.find_filtered_sources(1, nix.Filter.name, sl41.name);
+    filtered = s.filterFindSources(1, nix.Filter.name, sl41.name);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(5, nix.Filter.name, sl41.name);
+    filtered = s.filterFindSources(5, nix.Filter.name, sl41.name);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = s.find_filtered_sources(1, nix.Filter.type, findSource);
+    filtered = s.filterFindSources(1, nix.Filter.type, findSource);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(5, nix.Filter.type, findSource);
+    filtered = s.filterFindSources(5, nix.Filter.type, findSource);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSource));
 
     % test nix.Filter.metadata
     sec = f.createSection('testSection', 'nixSection');
     sl43.set_metadata(sec);
-    filtered = s.find_filtered_sources(1, nix.Filter.metadata, sec.id);
+    filtered = s.filterFindSources(1, nix.Filter.metadata, sec.id);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(5, nix.Filter.metadata, sec.id);
+    filtered = s.filterFindSources(5, nix.Filter.metadata, sec.id);
     assert(size(filtered, 1) == 1);
     strcmp(filtered{1}.id, sl43.id);
 
     % test nix.Filter.source
-    filtered = s.find_filtered_sources(1, nix.Filter.source, sl44.id);
+    filtered = s.filterFindSources(1, nix.Filter.source, sl44.id);
     assert(isempty(filtered));
-    filtered = s.find_filtered_sources(5, nix.Filter.source, sl44.id);
+    filtered = s.filterFindSources(5, nix.Filter.source, sl44.id);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, sl31.id));
 end

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -52,11 +52,11 @@ function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
-    s = b.create_source('sourceTest', 'nixSource');
+    s = b.createSource('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    t = b.create_tag('sourcetest', 'nixTag', position);
+    t = b.createTag('sourcetest', 'nixTag', position);
     
     assert(isempty(t.sources));
     assert(isempty(f.blocks{1}.tags{1}.sources));
@@ -75,10 +75,10 @@ function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2]);
-    tmp = b.create_source('testSource1', 'nixSource');
-    tmp = b.create_source('testSource2', 'nixSource');
-    tmp = b.create_source('testSource3', 'nixSource');
+    t = b.createTag('testTag', 'nixTag', [1 2]);
+    tmp = b.createSource('testSource1', 'nixSource');
+    tmp = b.createSource('testSource2', 'nixSource');
+    tmp = b.createSource('testSource3', 'nixSource');
 
     assert(isempty(t.sources));
 
@@ -108,21 +108,21 @@ end
 function [] = test_remove_source ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    getSource = b.create_source('test', 'nixSource');
-    tmp = getSource.create_source('nestedSource1', 'nixSource');
-    tmp = getSource.create_source('nestedSource2', 'nixSource');
+    s = b.createSource('test', 'nixSource');
+    tmp = s.create_source('nestedSource1', 'nixSource');
+    tmp = s.create_source('nestedSource2', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('sourcetest', 'nixTag', position);
-    getTag.add_source(getSource.sources{1}.id);
-    getTag.add_source(getSource.sources{2});
+    getTag = b.createTag('sourcetest', 'nixTag', position);
+    getTag.add_source(s.sources{1}.id);
+    getTag.add_source(s.sources{2});
 
     assert(size(getTag.sources,1) == 2);
-    getTag.remove_source(getSource.sources{2});
+    getTag.remove_source(s.sources{2});
     assert(size(getTag.sources,1) == 1);
-    getTag.remove_source(getSource.sources{1}.id);
+    getTag.remove_source(s.sources{1}.id);
     assert(isempty(getTag.sources));
     assert(getTag.remove_source('I do not exist'));
-    assert(size(getSource.sources,1) == 2);
+    assert(size(s.sources,1) == 2);
 end
 
 %% Test: Add references by entity and id
@@ -130,11 +130,11 @@ function [] = test_add_reference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     position = [1.0 1.2 1.3 15.9];
-    t = b.create_tag('referenceTest', 'nixTag', position);
+    t = b.createTag('referenceTest', 'nixTag', position);
     
     assert(isempty(t.references));
     assert(isempty(f.blocks{1}.tags{1}.references));
@@ -154,10 +154,10 @@ function [] = test_add_references ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2]);
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [3 4]);
+    t = b.createTag('testTag', 'nixTag', [1 2]);
+    tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('referenceTest3', 'nixDataArray', nix.DataType.Double, [3 4]);
 
     assert(isempty(t.references));
 
@@ -187,11 +187,11 @@ end
 function [] = test_remove_reference ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    getRefDA1 = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getRefDA2 = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    getRefDA1 = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    getRefDA2 = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('referenceTest', 'nixTag', position);
+    getTag = b.createTag('referenceTest', 'nixTag', position);
     getTag.add_reference(b.dataArrays{1}.id);
     getTag.add_reference(b.dataArrays{2});
     assert(size(getTag.references, 1) == 2);
@@ -209,14 +209,14 @@ function [] = test_add_feature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array('featureTestDataArray3', 'nixDataArray', nix.DataType.Double, [5 6]);
-    tmp = b.create_data_array('featureTestDataArray4', 'nixDataArray', nix.DataType.Double, [7 8]);
-    tmp = b.create_data_array('featureTestDataArray5', 'nixDataArray', nix.DataType.Double, [9 10]);
-    tmp = b.create_data_array('featureTestDataArray6', 'nixDataArray', nix.DataType.Double, [11 12]);
+    tmp = b.createDataArray('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('featureTestDataArray3', 'nixDataArray', nix.DataType.Double, [5 6]);
+    tmp = b.createDataArray('featureTestDataArray4', 'nixDataArray', nix.DataType.Double, [7 8]);
+    tmp = b.createDataArray('featureTestDataArray5', 'nixDataArray', nix.DataType.Double, [9 10]);
+    tmp = b.createDataArray('featureTestDataArray6', 'nixDataArray', nix.DataType.Double, [11 12]);
     position = [1.0 1.2 1.3 15.9];
-    t = b.create_tag('featureTest', 'nixTag', position);
+    t = b.createTag('featureTest', 'nixTag', position);
     
     assert(isempty(t.features));
     assert(isempty(f.blocks{1}.tags{1}.features));
@@ -238,10 +238,10 @@ end
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('featureTest', 'nixTag', position);
+    getTag = b.createTag('featureTest', 'nixTag', position);
     tmp = getTag.add_feature(b.dataArrays{1}.id, nix.LinkType.Tagged);
     tmp = getTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
 
@@ -257,11 +257,11 @@ end
 function [] = test_fetch_references( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = b.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
+    tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('referenceTest', 'nixTag', position);
+    getTag = b.createTag('referenceTest', 'nixTag', position);
     
     getTag.add_reference(b.dataArrays{1});
     getTag.add_reference(b.dataArrays{2});
@@ -274,12 +274,12 @@ function [] = test_reference_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2]);
+    t = b.createTag('testTag', 'nixTag', [1 2]);
 
     assert(t.reference_count() == 0);
-    t.add_reference(b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
+    t.add_reference(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
     assert(t.reference_count() == 1);
-    t.add_reference(b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
+    t.add_reference(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
     
     clear t b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -290,16 +290,16 @@ end
 function [] = test_fetch_sources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    getSource = b.create_source('test','nixSource');
-    tmp = getSource.create_source('nestedsource1', 'nixSource');
-    tmp = getSource.create_source('nestedsource2', 'nixSource');
-    tmp = getSource.create_source('nestedsource3', 'nixSource');
+    s = b.createSource('test','nixSource');
+    tmp = s.create_source('nestedsource1', 'nixSource');
+    tmp = s.create_source('nestedsource2', 'nixSource');
+    tmp = s.create_source('nestedsource3', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('tagtest', 'nixTag', position);
+    getTag = b.createTag('tagtest', 'nixTag', position);
     
-    getTag.add_source(getSource.sources{1});
-    getTag.add_source(getSource.sources{2});
-    getTag.add_source(getSource.sources{3});
+    getTag.add_source(s.sources{1});
+    getTag.add_source(s.sources{2});
+    getTag.add_source(s.sources{3});
     assert(size(getTag.sources, 1) == 3);
 end
 
@@ -307,10 +307,10 @@ end
 function [] = test_fetch_features( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.createDataArray('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('featureTest', 'nixTag', position);
+    getTag = b.createTag('featureTest', 'nixTag', position);
 
     tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     tmp = getTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
@@ -323,13 +323,13 @@ function [] = test_feature_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2]);
+    t = b.createTag('testTag', 'nixTag', [1 2]);
 
     assert(t.feature_count() == 0);
-    t.add_feature(b.create_data_array('testDataArray1', 'nixDataArray', ...
+    t.add_feature(b.createDataArray('testDataArray1', 'nixDataArray', ...
         nix.DataType.Double, [1 2]), nix.LinkType.Tagged);
     assert(t.feature_count() == 1);
-    t.add_feature(b.create_data_array('testDataArray2', 'nixDataArray', ...
+    t.add_feature(b.createDataArray('testDataArray2', 'nixDataArray', ...
         nix.DataType.Double, [3 4]), nix.LinkType.Tagged);
     
     clear t b f;
@@ -341,12 +341,12 @@ end
 function [] = test_open_source( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
-    getSource = b.create_source('test', 'nixSource');
+    s = b.createSource('test', 'nixSource');
     sourceName = 'nestedsource';
-    createSource = getSource.create_source(sourceName, 'nixSource');
+    createSource = s.create_source(sourceName, 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('tagtest', 'nixTag', position);
-    getTag.add_source(getSource.sources{1});
+    getTag = b.createTag('tagtest', 'nixTag', position);
+    getTag.add_source(s.sources{1});
 
     getSourceByID = getTag.open_source(createSource.id);
     assert(~isempty(getSourceByID));
@@ -363,10 +363,10 @@ function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [2 9]);
-    s1 = b.create_source('testSource1', 'nixSource');
-    s2 = b.create_source('testSource2', 'nixSource');
-    s3 = b.create_source('testSource3', 'nixSource');
+    t = b.createTag('testTag', 'nixTag', [2 9]);
+    s1 = b.createSource('testSource1', 'nixSource');
+    s2 = b.createSource('testSource2', 'nixSource');
+    s3 = b.createSource('testSource3', 'nixSource');
     t.add_source(s1);
     t.add_source(s2);
     t.add_source(s3);
@@ -381,10 +381,10 @@ function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.create_source('sourceTest1', 'nixSource');
+    s = b.createSource('sourceTest1', 'nixSource');
     sID = s.id;
     position = [1.0 1.2 1.3 15.9];
-    t = b.create_tag('tagTest', 'nixTag', position);
+    t = b.createTag('tagTest', 'nixTag', position);
     t.add_source(b.sources{1});
 
     assert(~t.has_source('I do not exist'));
@@ -400,12 +400,12 @@ function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1.0 1.2]);
+    t = b.createTag('testTag', 'nixTag', [1.0 1.2]);
 
     assert(t.source_count() == 0);
-    t.add_source(b.create_source('testSource1', 'nixSource'));
+    t.add_source(b.createSource('testSource1', 'nixSource'));
     assert(t.source_count() == 1);
-    t.add_source(b.create_source('testSource2', 'nixSource'));
+    t.add_source(b.createSource('testSource2', 'nixSource'));
 
     clear t b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
@@ -416,9 +416,9 @@ end
 function [] = test_open_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('featureTest', 'nixTag', position);
+    getTag = b.createTag('featureTest', 'nixTag', position);
     tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
 
     assert(~isempty(getTag.open_feature(getTag.features{1}.id)));
@@ -432,10 +432,10 @@ function [] = test_open_feature_idx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [2 9]);
-    d1 = b.create_data_array('testFeature1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    d2 = b.create_data_array('testFeature2', 'nixDataArray', nix.DataType.Double, [3 2]);
-    d3 = b.create_data_array('testFeature3', 'nixDataArray', nix.DataType.Double, [7 2]);
+    t = b.createTag('testTag', 'nixTag', [2 9]);
+    d1 = b.createDataArray('testFeature1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d2 = b.createDataArray('testFeature2', 'nixDataArray', nix.DataType.Double, [3 2]);
+    d3 = b.createDataArray('testFeature3', 'nixDataArray', nix.DataType.Double, [7 2]);
     t.add_feature(d1, nix.LinkType.Tagged);
     t.add_feature(d2, nix.LinkType.Untagged);
     t.add_feature(d3, nix.LinkType.Indexed);
@@ -449,9 +449,9 @@ end
 function [] = test_open_reference( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    tmp = b.create_data_array('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.createDataArray('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.create_tag('referenceTest', 'nixTag', position);
+    getTag = b.createTag('referenceTest', 'nixTag', position);
     getTag.add_reference(b.dataArrays{1});
 
     getRefByID = getTag.open_reference(getTag.references{1,1}.id);
@@ -469,10 +469,10 @@ function [] = test_open_reference_idx( varargin )
 %% Test Open reference by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [2 9]);
-    d1 = b.create_data_array('testReference1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    d2 = b.create_data_array('testReference2', 'nixDataArray', nix.DataType.Double, [3 2]);
-    d3 = b.create_data_array('testReference3', 'nixDataArray', nix.DataType.Double, [7 2]);
+    t = b.createTag('testTag', 'nixTag', [2 9]);
+    d1 = b.createDataArray('testReference1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    d2 = b.createDataArray('testReference2', 'nixDataArray', nix.DataType.Double, [3 2]);
+    d3 = b.createDataArray('testReference3', 'nixDataArray', nix.DataType.Double, [7 2]);
     t.add_reference(d1);
     t.add_reference(d2);
     t.add_reference(d3);
@@ -492,7 +492,7 @@ function [] = test_set_metadata ( varargin )
     tmp = f.createSection(secName2, 'nixSection');
 
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1, 2, 3, 4]);
+    t = b.createTag('testTag', 'nixTag', [1, 2, 3, 4]);
 
     assert(isempty(t.open_metadata));
     assert(isempty(f.blocks{1}.tags{1}.open_metadata));
@@ -520,7 +520,7 @@ function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1, 2, 3, 4]);
+    t = b.createTag('testTag', 'nixTag', [1, 2, 3, 4]);
 
     t.set_metadata(f.sections{1});
     assert(strcmp(t.open_metadata.name, 'testSection'));
@@ -531,16 +531,16 @@ function [] = test_retrieve_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     tagStartPos = [3];
-    t = b.create_tag('testTag', 'nixTag', tagStartPos);
+    t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
 
     rawName = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     rawID = [11, 12, 13, 14, 15, 16, 17];
-    d = b.create_data_array_from_data('testDataArrayName', 'nixDataArray', rawName);
+    d = b.createDataArrayFromData('testDataArrayName', 'nixDataArray', rawName);
     d.append_sampled_dimension(1);
     t.add_reference(d);
 
-    d = b.create_data_array_from_data('testDataArrayID', 'nixDataArray', rawID);
+    d = b.createDataArrayFromData('testDataArrayID', 'nixDataArray', rawID);
     d.append_sampled_dimension(1);
     t.add_reference(d);
 
@@ -568,11 +568,11 @@ function [] = test_retrieve_data_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-    d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
+    d = b.createDataArrayFromData('testDataArray', 'nixDataArray', raw);
     d.append_sampled_dimension(1);
     % tag positon is used like an index, therfore starts with 0!
     tagStartPos = [3];
-    t = b.create_tag('testTag', 'nixTag', tagStartPos);
+    t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
     t.add_reference(d);
 
@@ -592,10 +592,10 @@ function [] = test_retrieve_feature_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-    d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
+    d = b.createDataArrayFromData('testDataArray', 'nixDataArray', raw);
     d.append_sampled_dimension(1);
     tagStartPos = [3];
-    t = b.create_tag('testTag', 'nixTag', tagStartPos);
+    t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
     t.add_reference(d);
 
@@ -610,14 +610,14 @@ function [] = test_retrieve_feature_data( varargin )
     end
 
     % test retrieve untagged feature data by name
-    df = b.create_data_array_from_data('testUntagged', 'nixDataArray', rawFeature);
+    df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Untagged);
     retData = t.retrieve_feature_data('testUntagged');
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data by id
-    df = b.create_data_array_from_data('testTagged', 'nixDataArray', rawFeature);
+    df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Tagged);
     retData = t.retrieve_feature_data(df.id);
@@ -625,7 +625,7 @@ function [] = test_retrieve_feature_data( varargin )
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
 
     % test retrieve indexed feature data by id
-    df = b.create_data_array_from_data('testIndexed', 'nixDataArray', rawFeature);
+    df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Indexed);
     retData = t.retrieve_feature_data(df.id);
@@ -637,24 +637,24 @@ function [] = test_retrieve_feature_data_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-    d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
+    d = b.createDataArrayFromData('testDataArray', 'nixDataArray', raw);
     d.append_sampled_dimension(1);
     tagStartPos = [3];
-    t = b.create_tag('testTag', 'nixTag', tagStartPos);
+    t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
     t.add_reference(d);
 
     rawFeature = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
 
     % test retrieve untagged feature data 
-    df = b.create_data_array_from_data('testUntagged', 'nixDataArray', rawFeature);
+    df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Untagged);
     retData = t.retrieve_feature_data_idx(1);
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data 
-    df = b.create_data_array_from_data('testTagged', 'nixDataArray', rawFeature);
+    df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Tagged);
     retData = t.retrieve_feature_data_idx(2);
@@ -662,7 +662,7 @@ function [] = test_retrieve_feature_data_idx( varargin )
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
 
     % test retrieve indexed feature data
-    df = b.create_data_array_from_data('testIndexed', 'nixDataArray', rawFeature);
+    df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
     df.append_sampled_dimension(1);
     t.add_feature(df, nix.LinkType.Indexed);
     retData = t.retrieve_feature_data_idx(3);
@@ -681,7 +681,7 @@ function [] = test_attrs( varargin )
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     pos = [1, 2, 3, 4];
-    t1 = b.create_tag('testTag', 'nixTag', pos);
+    t1 = b.createTag('testTag', 'nixTag', pos);
 
     assert(~isempty(t1.id));
     assert(strcmp(t1.name, 'testTag'));
@@ -745,8 +745,8 @@ function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
-    da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_tag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
+    da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createTag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     feature = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
     featureID = feature.id;
 
@@ -764,8 +764,8 @@ function [] = test_has_reference( varargin )
     daName = 'referenceTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
-    da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
-    t = b.create_tag('referenceTest', 'nixTag', [1.0 1.2 1.3 15.9]);
+    da = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createTag('referenceTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     t.add_reference(b.dataArrays{1});
 
     assert(~t.has_reference('I do not exist'));
@@ -781,9 +781,9 @@ function [] = test_compare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
-    t1 = b1.create_tag('testTag1', 'nixTag', [1 2 3]);
-    t2 = b1.create_tag('testTag2', 'nixTag', [1 2 3]);
-    t3 = b2.create_tag('testTag1', 'nixTag', [1 2 3]);
+    t1 = b1.createTag('testTag1', 'nixTag', [1 2 3]);
+    t2 = b1.createTag('testTag2', 'nixTag', [1 2 3]);
+    t3 = b2.createTag('testTag1', 'nixTag', [1 2 3]);
 
     assert(t1.compare(t2) < 0);
     assert(t1.compare(t1) == 0);
@@ -797,14 +797,14 @@ function [] = test_filter_source( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2 3]);
-    s = b.create_source(filterName, 'nixSource');
+    t = b.createTag('testTag', 'nixTag', [1 2 3]);
+    s = b.createSource(filterName, 'nixSource');
     t.add_source(s);
     filterID = s.id;
-	s = b.create_source('testSource1', filterType);
+	s = b.createSource('testSource1', filterType);
     t.add_source(s);
     filterIDs = {filterID, s.id};
-    s = b.create_source('testSource2', filterType);
+    s = b.createSource('testSource2', filterType);
     t.add_source(s);
 
     % test empty id filter
@@ -835,7 +835,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    mainSource = b.create_source(mainName, 'nixSource');
+    mainSource = b.createSource(mainName, 'nixSource');
     t.add_source(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -849,7 +849,7 @@ function [] = test_filter_source( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_source(mainName, 'nixSource');
+    main = b.createSource(mainName, 'nixSource');
     t.add_source(main);
     mainID = main.id;
     subName = 'testSubSource1';
@@ -872,14 +872,14 @@ function [] = test_filter_reference( varargin )
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2 3]);
-    d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createTag('testTag', 'nixTag', [1 2 3]);
+    d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t.add_reference(d);
     filterID = d.id;
-	d = b.create_data_array('testDataArray1', filterType, nix.DataType.Double, [1 2]);
+	d = b.createDataArray('testDataArray1', filterType, nix.DataType.Double, [1 2]);
     t.add_reference(d);
     filterIDs = {filterID, d.id};
-    d = b.create_data_array('testDataArray2', filterType, nix.DataType.Double, [1 2]);
+    d = b.createDataArray('testDataArray2', filterType, nix.DataType.Double, [1 2]);
     t.add_reference(d);
 
     % test empty id filter
@@ -910,7 +910,7 @@ function [] = test_filter_reference( varargin )
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
-    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
@@ -924,11 +924,11 @@ function [] = test_filter_reference( varargin )
 
     % test nix.Filter.source
     mainName = 'testSubSource';
-    main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
+    main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = b.create_source(subName, 'nixSource');
+    s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
@@ -944,11 +944,11 @@ end
 function [] = test_filter_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
-    t = b.create_tag('testTag', 'nixTag', [1 2 3]);
-    d = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    t = b.createTag('testTag', 'nixTag', [1 2 3]);
+    d = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     feat = t.add_feature(d, nix.LinkType.Tagged);
     filterID = feat.id;
-	d = b.create_data_array('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
+	d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
     feat = t.add_feature(d, nix.LinkType.Tagged);
     filterIDs = {filterID, feat.id};
 

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -51,7 +51,7 @@ end
 function [] = test_add_source ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('sourceTest', 'nixBlock');
+    b = f.createBlock('sourceTest', 'nixBlock');
     s = b.create_source('sourceTest', 'nixSource');
     tmp = s.create_source('nestedSource1', 'nixSource');
     tmp = s.create_source('nestedSource2', 'nixSource');
@@ -74,7 +74,7 @@ end
 function [] = test_add_sources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2]);
     tmp = b.create_source('testSource1', 'nixSource');
     tmp = b.create_source('testSource2', 'nixSource');
@@ -106,13 +106,13 @@ end
 
 %% Test: Remove sources by entity and id
 function [] = test_remove_source ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('test', 'nixBlock');
-    getSource = getBlock.create_source('test', 'nixSource');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('test', 'nixBlock');
+    getSource = b.create_source('test', 'nixSource');
     tmp = getSource.create_source('nestedSource1', 'nixSource');
     tmp = getSource.create_source('nestedSource2', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = getBlock.create_tag('sourcetest', 'nixTag', position);
+    getTag = b.create_tag('sourcetest', 'nixTag', position);
     getTag.add_source(getSource.sources{1}.id);
     getTag.add_source(getSource.sources{2});
 
@@ -129,7 +129,7 @@ end
 function [] = test_add_reference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('referenceTest', 'nixBlock');
+    b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
@@ -153,7 +153,7 @@ end
 function [] = test_add_references ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2]);
     tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
@@ -185,30 +185,30 @@ end
 
 %% Test: Remove references by entity and id
 function [] = test_remove_reference ( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('referenceTest', 'nixBlock');
-    getRefDA1 = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    getRefDA2 = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('referenceTest', 'nixBlock');
+    getRefDA1 = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    getRefDA2 = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     position = [1.0 1.2 1.3 15.9];
-    getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
-    getTag.add_reference(getBlock.dataArrays{1}.id);
-    getTag.add_reference(getBlock.dataArrays{2});
+    getTag = b.create_tag('referenceTest', 'nixTag', position);
+    getTag.add_reference(b.dataArrays{1}.id);
+    getTag.add_reference(b.dataArrays{2});
     assert(size(getTag.references, 1) == 2);
 
-    getTag.remove_reference(getBlock.dataArrays{2});
+    getTag.remove_reference(b.dataArrays{2});
     assert(size(getTag.references, 1) == 1);
-    getTag.remove_reference(getBlock.dataArrays{1}.id);
+    getTag.remove_reference(b.dataArrays{1}.id);
     assert(isempty(getTag.references));
     assert(~getTag.remove_reference('I do not exist'));
-    assert(size(getBlock.dataArrays, 1) == 2);
+    assert(size(b.dataArrays, 1) == 2);
 end
 
 %% Test: Add features by entity and id
 function [] = test_add_feature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.create_data_array('featureTestDataArray3', 'nixDataArray', nix.DataType.Double, [5 6]);
@@ -237,7 +237,7 @@ end
 %% Test: Remove features by entity and id
 function [] = test_remove_feature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
@@ -255,17 +255,17 @@ end
 
 %% Test: fetch references
 function [] = test_fetch_references( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('referenceTest', 'nixBlock');
-    tmp = getBlock.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = getBlock.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
-    tmp = getBlock.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('referenceTest', 'nixBlock');
+    tmp = b.create_data_array('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
+    tmp = b.create_data_array('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
+    tmp = b.create_data_array('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
+    getTag = b.create_tag('referenceTest', 'nixTag', position);
     
-    getTag.add_reference(getBlock.dataArrays{1});
-    getTag.add_reference(getBlock.dataArrays{2});
-    getTag.add_reference(getBlock.dataArrays{3});
+    getTag.add_reference(b.dataArrays{1});
+    getTag.add_reference(b.dataArrays{2});
+    getTag.add_reference(b.dataArrays{3});
     assert(size(getTag.references, 1) == 3);
 end
 
@@ -273,7 +273,7 @@ end
 function [] = test_reference_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2]);
 
     assert(t.reference_count() == 0);
@@ -288,14 +288,14 @@ end
 
 %% Test: fetch sources
 function [] = test_fetch_sources( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('test', 'nixBlock');
-    getSource = getBlock.create_source('test','nixSource');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('test', 'nixBlock');
+    getSource = b.create_source('test','nixSource');
     tmp = getSource.create_source('nestedsource1', 'nixSource');
     tmp = getSource.create_source('nestedsource2', 'nixSource');
     tmp = getSource.create_source('nestedsource3', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = getBlock.create_tag('tagtest', 'nixTag', position);
+    getTag = b.create_tag('tagtest', 'nixTag', position);
     
     getTag.add_source(getSource.sources{1});
     getTag.add_source(getSource.sources{2});
@@ -306,7 +306,7 @@ end
 %% Test: fetch features
 function [] = test_fetch_features( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.create_data_array('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
@@ -322,7 +322,7 @@ end
 function [] = test_feature_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2]);
 
     assert(t.feature_count() == 0);
@@ -339,13 +339,13 @@ end
 
 %% Test: Open source by ID or name
 function [] = test_open_source( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('test', 'nixBlock');
-    getSource = getBlock.create_source('test', 'nixSource');
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('test', 'nixBlock');
+    getSource = b.create_source('test', 'nixSource');
     sourceName = 'nestedsource';
     createSource = getSource.create_source(sourceName, 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = getBlock.create_tag('tagtest', 'nixTag', position);
+    getTag = b.create_tag('tagtest', 'nixTag', position);
     getTag.add_source(getSource.sources{1});
 
     getSourceByID = getTag.open_source(createSource.id);
@@ -362,7 +362,7 @@ end
 function [] = test_open_source_idx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [2 9]);
     s1 = b.create_source('testSource1', 'nixSource');
     s2 = b.create_source('testSource2', 'nixSource');
@@ -380,7 +380,7 @@ end
 function [] = test_has_source( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testblock', 'nixBlock');
+    b = f.createBlock('testblock', 'nixBlock');
     s = b.create_source('sourceTest1', 'nixSource');
     sID = s.id;
     position = [1.0 1.2 1.3 15.9];
@@ -399,7 +399,7 @@ end
 function [] = test_source_count( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1.0 1.2]);
 
     assert(t.source_count() == 0);
@@ -415,7 +415,7 @@ end
 %% Test: Open feature by ID
 function [] = test_open_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
     getTag = b.create_tag('featureTest', 'nixTag', position);
@@ -431,7 +431,7 @@ end
 function [] = test_open_feature_idx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [2 9]);
     d1 = b.create_data_array('testFeature1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2 = b.create_data_array('testFeature2', 'nixDataArray', nix.DataType.Double, [3 2]);
@@ -447,12 +447,12 @@ end
 
 %% Test: Open reference by ID or name
 function [] = test_open_reference( varargin )
-    test_file = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    getBlock = test_file.create_block('referenceTest', 'nixBlock');
-    tmp = getBlock.create_data_array('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
+    f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
+    b = f.createBlock('referenceTest', 'nixBlock');
+    tmp = b.create_data_array('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = getBlock.create_tag('referenceTest', 'nixTag', position);
-    getTag.add_reference(getBlock.dataArrays{1});
+    getTag = b.create_tag('referenceTest', 'nixTag', position);
+    getTag.add_reference(b.dataArrays{1});
 
     getRefByID = getTag.open_reference(getTag.references{1,1}.id);
     assert(~isempty(getRefByID));
@@ -468,7 +468,7 @@ end
 function [] = test_open_reference_idx( varargin )
 %% Test Open reference by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [2 9]);
     d1 = b.create_data_array('testReference1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2 = b.create_data_array('testReference2', 'nixDataArray', nix.DataType.Double, [3 2]);
@@ -488,10 +488,10 @@ function [] = test_set_metadata ( varargin )
     secName1 = 'testSection1';
     secName2 = 'testSection2';
     f = nix.File(fileName, nix.FileMode.Overwrite);
-    tmp = f.create_section(secName1, 'nixSection');
-    tmp = f.create_section(secName2, 'nixSection');
+    tmp = f.createSection(secName1, 'nixSection');
+    tmp = f.createSection(secName2, 'nixSection');
 
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1, 2, 3, 4]);
 
     assert(isempty(t.open_metadata));
@@ -518,8 +518,8 @@ end
 %% Test: Open metadata
 function [] = test_open_metadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    tmp = f.create_section('testSection', 'nixSection');
-    b = f.create_block('testBlock', 'nixBlock');
+    tmp = f.createSection('testSection', 'nixSection');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1, 2, 3, 4]);
 
     t.set_metadata(f.sections{1});
@@ -529,7 +529,7 @@ end
 %% Test: Retrieve referenced data by name and id
 function [] = test_retrieve_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     tagStartPos = [3];
     t = b.create_tag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
@@ -566,7 +566,7 @@ end
 %% Test: Retrieve referenced data by index
 function [] = test_retrieve_data_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
     d.append_sampled_dimension(1);
@@ -590,7 +590,7 @@ end
 %% Test: Retrieve feature data by name and id
 function [] = test_retrieve_feature_data( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
     d.append_sampled_dimension(1);
@@ -635,7 +635,7 @@ end
 %% Test: Retrieve feature data by index
 function [] = test_retrieve_feature_data_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     d = b.create_data_array_from_data('testDataArray', 'nixDataArray', raw);
     d.append_sampled_dimension(1);
@@ -679,7 +679,7 @@ end
 function [] = test_attrs( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     pos = [1, 2, 3, 4];
     t1 = b.create_tag('testTag', 'nixTag', pos);
 
@@ -744,7 +744,7 @@ end
 function [] = test_has_feature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('featureTest', 'nixBlock');
+    b = f.createBlock('featureTest', 'nixBlock');
     da = b.create_data_array('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_tag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     feature = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
@@ -763,7 +763,7 @@ function [] = test_has_reference( varargin )
     fileName = 'testRW.h5';
     daName = 'referenceTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
-    b = f.create_block('referenceTest', 'nixBlock');
+    b = f.createBlock('referenceTest', 'nixBlock');
     da = b.create_data_array(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.create_tag('referenceTest', 'nixTag', [1.0 1.2 1.3 15.9]);
     t.add_reference(b.dataArrays{1});
@@ -779,8 +779,8 @@ end
 function [] = test_compare( varargin )
 %% Test: Compare Tag entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b1 = f.create_block('testBlock1', 'nixBlock');
-    b2 = f.create_block('testBlock2', 'nixBlock');
+    b1 = f.createBlock('testBlock1', 'nixBlock');
+    b2 = f.createBlock('testBlock2', 'nixBlock');
     t1 = b1.create_tag('testTag1', 'nixTag', [1 2 3]);
     t2 = b1.create_tag('testTag2', 'nixTag', [1 2 3]);
     t3 = b2.create_tag('testTag1', 'nixTag', [1 2 3]);
@@ -796,7 +796,7 @@ function [] = test_filter_source( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2 3]);
     s = b.create_source(filterName, 'nixSource');
     t.add_source(s);
@@ -838,7 +838,7 @@ function [] = test_filter_source( varargin )
     mainSource = b.create_source(mainName, 'nixSource');
     t.add_source(mainSource);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
@@ -871,7 +871,7 @@ function [] = test_filter_reference( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2 3]);
     d = b.create_data_array(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t.add_reference(d);
@@ -913,7 +913,7 @@ function [] = test_filter_reference( varargin )
     main = b.create_data_array(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
     t.add_reference(main);
     subName = 'testSubSection1';
-    s = f.create_section(subName, 'nixSection');
+    s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
@@ -943,7 +943,7 @@ end
 %% Test: filter features
 function [] = test_filter_feature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
-    b = f.create_block('testBlock', 'nixBlock');
+    b = f.createBlock('testBlock', 'nixBlock');
     t = b.create_tag('testTag', 'nixTag', [1 2 3]);
     d = b.create_data_array('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     feat = t.add_feature(d, nix.LinkType.Tagged);

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -7,54 +7,53 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestTag
-%TESTTag tests for Tag
-%   Detailed explanation goes here
+% TESTTag tests for Tag
 
     funcs = {};
-    funcs{end+1} = @test_add_source;
-    funcs{end+1} = @test_add_sources;
-    funcs{end+1} = @test_remove_source;
-    funcs{end+1} = @test_add_reference;
-    funcs{end+1} = @test_add_references;
-    funcs{end+1} = @test_remove_reference;
-    funcs{end+1} = @test_add_feature;
-    funcs{end+1} = @test_remove_feature;
-    funcs{end+1} = @test_fetch_references;
-    funcs{end+1} = @test_reference_count;
-    funcs{end+1} = @test_fetch_sources;
-    funcs{end+1} = @test_fetch_features;
-    funcs{end+1} = @test_feature_count;
-    funcs{end+1} = @test_open_source;
-    funcs{end+1} = @test_open_source_idx;
-    funcs{end+1} = @test_has_source;
-    funcs{end+1} = @test_source_count;
-    funcs{end+1} = @test_open_feature;
-    funcs{end+1} = @test_open_feature_idx;
-    funcs{end+1} = @test_open_reference;
-    funcs{end+1} = @test_open_reference_idx;
-    funcs{end+1} = @test_set_metadata;
-    funcs{end+1} = @test_open_metadata;
-    funcs{end+1} = @test_retrieve_data;
-    funcs{end+1} = @test_retrieve_data_idx;
-    funcs{end+1} = @test_retrieve_feature_data;
-    funcs{end+1} = @test_retrieve_feature_data_idx;
-    funcs{end+1} = @test_attrs;
-    funcs{end+1} = @test_has_feature;
-    funcs{end+1} = @test_has_reference;
-    funcs{end+1} = @test_compare;
-    funcs{end+1} = @test_filter_source;
-    funcs{end+1} = @test_filter_reference;
-    funcs{end+1} = @test_filter_feature;
+    funcs{end+1} = @testAddSource;
+    funcs{end+1} = @testAddSources;
+    funcs{end+1} = @testRemoveSource;
+    funcs{end+1} = @testAddReference;
+    funcs{end+1} = @testAddReferences;
+    funcs{end+1} = @testRemoveReference;
+    funcs{end+1} = @testAddFeature;
+    funcs{end+1} = @testRemoveFeature;
+    funcs{end+1} = @testFetchReferences;
+    funcs{end+1} = @testReferenceCount;
+    funcs{end+1} = @testFetchSources;
+    funcs{end+1} = @testFetchFeatures;
+    funcs{end+1} = @testFeatureCount;
+    funcs{end+1} = @testOpenSource;
+    funcs{end+1} = @testOpenSourceIdx;
+    funcs{end+1} = @testHasSource;
+    funcs{end+1} = @testSourceCount;
+    funcs{end+1} = @testOpenFeature;
+    funcs{end+1} = @testOpenFeatureIdx;
+    funcs{end+1} = @testOpenReference;
+    funcs{end+1} = @testOpenReference_idx;
+    funcs{end+1} = @testSetMetadata;
+    funcs{end+1} = @testOpenMetadata;
+    funcs{end+1} = @testRetrieveData;
+    funcs{end+1} = @testRetrieveDataIdx;
+    funcs{end+1} = @testRetrieveFeatureData;
+    funcs{end+1} = @testRetrieveFeatureDataIdx;
+    funcs{end+1} = @testAttributes;
+    funcs{end+1} = @testHasFeature;
+    funcs{end+1} = @testHasReference;
+    funcs{end+1} = @testCompare;
+    funcs{end+1} = @testFilterSource;
+    funcs{end+1} = @testFilterReference;
+    funcs{end+1} = @testFilterFeature;
 end
 
 %% Test: Add sources by entity and id
-function [] = test_add_source ( varargin )
+function [] = testAddSource ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
     s = b.createSource('sourceTest', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('sourcetest', 'nixTag', position);
     
@@ -71,7 +70,7 @@ function [] = test_add_source ( varargin )
 end
 
 %% Test: Add sources by entity cell array
-function [] = test_add_sources ( varargin )
+function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -105,28 +104,28 @@ function [] = test_add_sources ( varargin )
 end
 
 %% Test: Remove sources by entity and id
-function [] = test_remove_source ( varargin )
+function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
-    tmp = s.create_source('nestedSource1', 'nixSource');
-    tmp = s.create_source('nestedSource2', 'nixSource');
+    tmp = s.createSource('nestedSource1', 'nixSource');
+    tmp = s.createSource('nestedSource2', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('sourcetest', 'nixTag', position);
-    getTag.add_source(s.sources{1}.id);
-    getTag.add_source(s.sources{2});
+    t = b.createTag('sourcetest', 'nixTag', position);
+    t.add_source(s.sources{1}.id);
+    t.add_source(s.sources{2});
 
-    assert(size(getTag.sources,1) == 2);
-    getTag.remove_source(s.sources{2});
-    assert(size(getTag.sources,1) == 1);
-    getTag.remove_source(s.sources{1}.id);
-    assert(isempty(getTag.sources));
-    assert(getTag.remove_source('I do not exist'));
+    assert(size(t.sources,1) == 2);
+    t.remove_source(s.sources{2});
+    assert(size(t.sources,1) == 1);
+    t.remove_source(s.sources{1}.id);
+    assert(isempty(t.sources));
+    assert(t.remove_source('I do not exist'));
     assert(size(s.sources,1) == 2);
 end
 
 %% Test: Add references by entity and id
-function [] = test_add_reference ( varargin )
+function [] = testAddReference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
@@ -139,8 +138,8 @@ function [] = test_add_reference ( varargin )
     assert(isempty(t.references));
     assert(isempty(f.blocks{1}.tags{1}.references));
 
-    t.add_reference(b.dataArrays{1}.id);
-    t.add_reference(b.dataArrays{2});
+    t.addReference(b.dataArrays{1}.id);
+    t.addReference(b.dataArrays{2});
     assert(size(t.references, 1) == 2);
     assert(size(f.blocks{1}.tags{1}.references, 1) == 2);
 
@@ -150,7 +149,7 @@ function [] = test_add_reference ( varargin )
 end
 
 %% Test: Add references by entity cell array
-function [] = test_add_references ( varargin )
+function [] = testAddReferences ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -162,20 +161,20 @@ function [] = test_add_references ( varargin )
     assert(isempty(t.references));
 
     try
-        t.add_references('hurra');
+        t.addReferences('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(t.references));
 
     try
-        t.add_references({12, 13});
+        t.addReferences({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.DataArray')));
     end;
     assert(isempty(t.references));
 
-    t.add_references(b.dataArrays);
+    t.addReferences(b.dataArrays);
     assert(size(t.references, 1) == 3);
 
     clear t tmp b f;
@@ -184,28 +183,28 @@ function [] = test_add_references ( varargin )
 end
 
 %% Test: Remove references by entity and id
-function [] = test_remove_reference ( varargin )
+function [] = testRemoveReference ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     getRefDA1 = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     getRefDA2 = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('referenceTest', 'nixTag', position);
-    getTag.add_reference(b.dataArrays{1}.id);
-    getTag.add_reference(b.dataArrays{2});
-    assert(size(getTag.references, 1) == 2);
+    t = b.createTag('referenceTest', 'nixTag', position);
+    t.addReference(b.dataArrays{1}.id);
+    t.addReference(b.dataArrays{2});
+    assert(size(t.references, 1) == 2);
 
-    getTag.remove_reference(b.dataArrays{2});
-    assert(size(getTag.references, 1) == 1);
-    getTag.remove_reference(b.dataArrays{1}.id);
-    assert(isempty(getTag.references));
-    assert(~getTag.remove_reference('I do not exist'));
+    t.removeReference(b.dataArrays{2});
+    assert(size(t.references, 1) == 1);
+    t.removeReference(b.dataArrays{1}.id);
+    assert(isempty(t.references));
+    assert(~t.removeReference('I do not exist'));
     assert(size(b.dataArrays, 1) == 2);
 end
 
 %% Test: Add features by entity and id
-function [] = test_add_feature ( varargin )
+function [] = testAddFeature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -220,12 +219,12 @@ function [] = test_add_feature ( varargin )
     
     assert(isempty(t.features));
     assert(isempty(f.blocks{1}.tags{1}.features));
-    tmp = t.add_feature(b.dataArrays{1}.id, nix.LinkType.Tagged);
-    tmp = t.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
-    tmp = t.add_feature(b.dataArrays{3}.id, nix.LinkType.Untagged);
-    tmp = t.add_feature(b.dataArrays{4}, nix.LinkType.Untagged);
-    tmp = t.add_feature(b.dataArrays{5}.id, nix.LinkType.Indexed);
-    tmp = t.add_feature(b.dataArrays{6}, nix.LinkType.Indexed);
+    tmp = t.addFeature(b.dataArrays{1}.id, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{3}.id, nix.LinkType.Untagged);
+    tmp = t.addFeature(b.dataArrays{4}, nix.LinkType.Untagged);
+    tmp = t.addFeature(b.dataArrays{5}.id, nix.LinkType.Indexed);
+    tmp = t.addFeature(b.dataArrays{6}, nix.LinkType.Indexed);
     assert(size(t.features, 1) == 6);
     assert(size(f.blocks{1}.tags{1}.features, 1) == 6);
 
@@ -235,131 +234,131 @@ function [] = test_add_feature ( varargin )
 end
 
 %% Test: Remove features by entity and id
-function [] = test_remove_feature ( varargin )
+function [] = testRemoveFeature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.createDataArray('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('featureTest', 'nixTag', position);
-    tmp = getTag.add_feature(b.dataArrays{1}.id, nix.LinkType.Tagged);
-    tmp = getTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
+    t = b.createTag('featureTest', 'nixTag', position);
+    tmp = t.addFeature(b.dataArrays{1}.id, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
 
-    assert(getTag.remove_feature(getTag.features{2}.id));
-    assert(getTag.remove_feature(getTag.features{1}));
-    assert(isempty(getTag.features));
+    assert(t.removeFeature(t.features{2}.id));
+    assert(t.removeFeature(t.features{1}));
+    assert(isempty(t.features));
 
-    assert(~getTag.remove_feature('I do not exist'));
+    assert(~t.removeFeature('I do not exist'));
     assert(size(b.dataArrays, 1) == 2);
 end
 
 %% Test: fetch references
-function [] = test_fetch_references( varargin )
+function [] = testFetchReferences( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.createDataArray('referenceTest1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.createDataArray('referenceTest2', 'nixDataArray', nix.DataType.Double, [3 4]);
     tmp = b.createDataArray('referenceTest3', 'nixDataArray', nix.DataType.Double, [5 6]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('referenceTest', 'nixTag', position);
+    t = b.createTag('referenceTest', 'nixTag', position);
     
-    getTag.add_reference(b.dataArrays{1});
-    getTag.add_reference(b.dataArrays{2});
-    getTag.add_reference(b.dataArrays{3});
-    assert(size(getTag.references, 1) == 3);
+    t.addReference(b.dataArrays{1});
+    t.addReference(b.dataArrays{2});
+    t.addReference(b.dataArrays{3});
+    assert(size(t.references, 1) == 3);
 end
 
 %% Test: Reference count
-function [] = test_reference_count( varargin )
+function [] = testReferenceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1 2]);
 
-    assert(t.reference_count() == 0);
-    t.add_reference(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
-    assert(t.reference_count() == 1);
-    t.add_reference(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
+    assert(t.referenceCount() == 0);
+    t.addReference(b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]));
+    assert(t.referenceCount() == 1);
+    t.addReference(b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]));
     
     clear t b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tags{1}.reference_count() == 2);
+    assert(f.blocks{1}.tags{1}.referenceCount() == 2);
 end
 
 %% Test: fetch sources
-function [] = test_fetch_sources( varargin )
+function [] = testFetchSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
     s = b.createSource('test','nixSource');
-    tmp = s.create_source('nestedsource1', 'nixSource');
-    tmp = s.create_source('nestedsource2', 'nixSource');
-    tmp = s.create_source('nestedsource3', 'nixSource');
+    tmp = s.createSource('nestedsource1', 'nixSource');
+    tmp = s.createSource('nestedsource2', 'nixSource');
+    tmp = s.createSource('nestedsource3', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('tagtest', 'nixTag', position);
+    t = b.createTag('tagtest', 'nixTag', position);
     
-    getTag.add_source(s.sources{1});
-    getTag.add_source(s.sources{2});
-    getTag.add_source(s.sources{3});
-    assert(size(getTag.sources, 1) == 3);
+    t.add_source(s.sources{1});
+    t.add_source(s.sources{2});
+    t.add_source(s.sources{3});
+    assert(size(t.sources, 1) == 3);
 end
 
 %% Test: fetch features
-function [] = test_fetch_features( varargin )
+function [] = testFetchFeatures( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.createDataArray('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('featureTest', 'nixTag', position);
+    t = b.createTag('featureTest', 'nixTag', position);
 
-    tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
-    tmp = getTag.add_feature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
 
-    assert(size(getTag.features, 1) == 2);
+    assert(size(t.features, 1) == 2);
 end
 
 %% Test: Feature count
-function [] = test_feature_count( varargin )
+function [] = testFeatureCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1 2]);
 
-    assert(t.feature_count() == 0);
-    t.add_feature(b.createDataArray('testDataArray1', 'nixDataArray', ...
+    assert(t.featureCount() == 0);
+    t.addFeature(b.createDataArray('testDataArray1', 'nixDataArray', ...
         nix.DataType.Double, [1 2]), nix.LinkType.Tagged);
-    assert(t.feature_count() == 1);
-    t.add_feature(b.createDataArray('testDataArray2', 'nixDataArray', ...
+    assert(t.featureCount() == 1);
+    t.addFeature(b.createDataArray('testDataArray2', 'nixDataArray', ...
         nix.DataType.Double, [3 4]), nix.LinkType.Tagged);
     
     clear t b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tags{1}.feature_count() == 2);
+    assert(f.blocks{1}.tags{1}.featureCount() == 2);
 end
 
 %% Test: Open source by ID or name
-function [] = test_open_source( varargin )
+function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
     s = b.createSource('test', 'nixSource');
     sourceName = 'nestedsource';
-    createSource = s.create_source(sourceName, 'nixSource');
+    createSource = s.createSource(sourceName, 'nixSource');
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('tagtest', 'nixTag', position);
-    getTag.add_source(s.sources{1});
+    t = b.createTag('tagtest', 'nixTag', position);
+    t.add_source(s.sources{1});
 
-    getSourceByID = getTag.open_source(createSource.id);
+    getSourceByID = t.open_source(createSource.id);
     assert(~isempty(getSourceByID));
     
-    getSourceByName = getTag.open_source(sourceName);
+    getSourceByName = t.open_source(sourceName);
     assert(~isempty(getSourceByName));
     
     %-- test open non existing source
-    getNonSource = getTag.open_source('I do not exist');
+    getNonSource = t.open_source('I do not exist');
     assert(isempty(getNonSource));
 end
 
-function [] = test_open_source_idx( varargin )
+function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -377,7 +376,7 @@ function [] = test_open_source_idx( varargin )
 end
 
 %% Test: nix.Tag has nix.Source by ID or entity
-function [] = test_has_source( varargin )
+function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
@@ -396,7 +395,7 @@ function [] = test_has_source( varargin )
 end
 
 %% Test: Source count
-function [] = test_source_count( varargin )
+function [] = testSourceCount( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -413,22 +412,22 @@ function [] = test_source_count( varargin )
 end
 
 %% Test: Open feature by ID
-function [] = test_open_feature( varargin )
+function [] = testOpenFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('featureTest', 'nixTag', position);
-    tmp = getTag.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    t = b.createTag('featureTest', 'nixTag', position);
+    tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
 
-    assert(~isempty(getTag.open_feature(getTag.features{1}.id)));
+    assert(~isempty(t.openFeature(t.features{1}.id)));
 
     %-- test open non existing feature
-    getFeat = getTag.open_feature('I do not exist');
+    getFeat = t.openFeature('I do not exist');
     assert(isempty(getFeat));
 end
 
-function [] = test_open_feature_idx( varargin )
+function [] = testOpenFeatureIdx( varargin )
 %% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -436,36 +435,36 @@ function [] = test_open_feature_idx( varargin )
     d1 = b.createDataArray('testFeature1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2 = b.createDataArray('testFeature2', 'nixDataArray', nix.DataType.Double, [3 2]);
     d3 = b.createDataArray('testFeature3', 'nixDataArray', nix.DataType.Double, [7 2]);
-    t.add_feature(d1, nix.LinkType.Tagged);
-    t.add_feature(d2, nix.LinkType.Untagged);
-    t.add_feature(d3, nix.LinkType.Indexed);
+    t.addFeature(d1, nix.LinkType.Tagged);
+    t.addFeature(d2, nix.LinkType.Untagged);
+    t.addFeature(d3, nix.LinkType.Indexed);
 
-    assert(f.blocks{1}.tags{1}.open_feature_idx(1).linkType == nix.LinkType.Tagged);
-    assert(f.blocks{1}.tags{1}.open_feature_idx(2).linkType == nix.LinkType.Untagged);
-    assert(f.blocks{1}.tags{1}.open_feature_idx(3).linkType == nix.LinkType.Indexed);
+    assert(f.blocks{1}.tags{1}.openFeatureIdx(1).linkType == nix.LinkType.Tagged);
+    assert(f.blocks{1}.tags{1}.openFeatureIdx(2).linkType == nix.LinkType.Untagged);
+    assert(f.blocks{1}.tags{1}.openFeatureIdx(3).linkType == nix.LinkType.Indexed);
 end
 
 %% Test: Open reference by ID or name
-function [] = test_open_reference( varargin )
+function [] = testOpenReference( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     tmp = b.createDataArray('referenceTest', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
-    getTag = b.createTag('referenceTest', 'nixTag', position);
-    getTag.add_reference(b.dataArrays{1});
+    t = b.createTag('referenceTest', 'nixTag', position);
+    t.addReference(b.dataArrays{1});
 
-    getRefByID = getTag.open_reference(getTag.references{1,1}.id);
+    getRefByID = t.openReference(t.references{1,1}.id);
     assert(~isempty(getRefByID));
     
-    getRefByName = getTag.open_reference(getTag.references{1,1}.name);
+    getRefByName = t.openReference(t.references{1,1}.name);
     assert(~isempty(getRefByName));
     
     %-- test open non existing source
-    getNonRef = getTag.open_reference('I do not exist');
+    getNonRef = t.openReference('I do not exist');
     assert(isempty(getNonRef));
 end
 
-function [] = test_open_reference_idx( varargin )
+function [] = testOpenReference_idx( varargin )
 %% Test Open reference by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -473,17 +472,17 @@ function [] = test_open_reference_idx( varargin )
     d1 = b.createDataArray('testReference1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2 = b.createDataArray('testReference2', 'nixDataArray', nix.DataType.Double, [3 2]);
     d3 = b.createDataArray('testReference3', 'nixDataArray', nix.DataType.Double, [7 2]);
-    t.add_reference(d1);
-    t.add_reference(d2);
-    t.add_reference(d3);
+    t.addReference(d1);
+    t.addReference(d2);
+    t.addReference(d3);
 
-    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(1).name, d1.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(2).name, d2.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_reference_idx(3).name, d3.name));
+    assert(strcmp(f.blocks{1}.tags{1}.openReferenceIdx(1).name, d1.name));
+    assert(strcmp(f.blocks{1}.tags{1}.openReferenceIdx(2).name, d2.name));
+    assert(strcmp(f.blocks{1}.tags{1}.openReferenceIdx(3).name, d3.name));
 end
 
 %% Test: Set metadata
-function [] = test_set_metadata ( varargin )
+function [] = testSetMetadata ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     secName1 = 'testSection1';
     secName2 = 'testSection2';
@@ -516,7 +515,7 @@ function [] = test_set_metadata ( varargin )
 end
 
 %% Test: Open metadata
-function [] = test_open_metadata( varargin )
+function [] = testOpenMetadata( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     tmp = f.createSection('testSection', 'nixSection');
     b = f.createBlock('testBlock', 'nixBlock');
@@ -527,7 +526,7 @@ function [] = test_open_metadata( varargin )
 end
 
 %% Test: Retrieve referenced data by name and id
-function [] = test_retrieve_data( varargin )
+function [] = testRetrieveData( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     tagStartPos = [3];
@@ -538,33 +537,33 @@ function [] = test_retrieve_data( varargin )
     rawID = [11, 12, 13, 14, 15, 16, 17];
     d = b.createDataArrayFromData('testDataArrayName', 'nixDataArray', rawName);
     d.appendSampledDimension(1);
-    t.add_reference(d);
+    t.addReference(d);
 
     d = b.createDataArrayFromData('testDataArrayID', 'nixDataArray', rawID);
     d.appendSampledDimension(1);
-    t.add_reference(d);
+    t.addReference(d);
 
     % test get non existent
     try
-        retData = t.retrieve_data('I do not exist, dont hate me!');
+        retData = t.retrieveData('I do not exist, dont hate me!');
     catch ME
         assert(~isempty(strfind(ME.message, 'no DataArray with the specified name')), ...
             'Non existent check fail');
     end
 
     % test get referenced data by name
-    retData = t.retrieve_data('testDataArrayName');
+    retData = t.retrieveData('testDataArrayName');
     assert(size(retData, 2) == t.extent, 'Get by name extent check fail');
     assert(retData(1) == rawName(t.position + 1), 'Get by name position check fail');
 
     % test get referenced data by id
-    retData = t.retrieve_data(d.id);
+    retData = t.retrieveData(d.id);
     assert(size(retData, 2) == t.extent, 'Get by id extent check fail');
     assert(retData(1) == rawID(t.position + 1), 'Get by id position check fail');
 end
 
 %% Test: Retrieve referenced data by index
-function [] = test_retrieve_data_idx( varargin )
+function [] = testRetrieveDataIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -574,21 +573,21 @@ function [] = test_retrieve_data_idx( varargin )
     tagStartPos = [3];
     t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
-    t.add_reference(d);
+    t.addReference(d);
 
     try
-        t.retrieve_data_idx(12);
+        t.retrieveDataIdx(12);
     catch ME
         assert(~isempty(strfind(ME.message, 'out of bounds')), 'Invalid index failed');
     end
 
-    retData = t.retrieve_data_idx(1);
+    retData = t.retrieveDataIdx(1);
     assert(size(retData, 2) == t.extent, 'Extent check failed');
     assert(retData(1) == raw(t.position + 1), 'Position check failed');
 end
 
 %% Test: Retrieve feature data by name and id
-function [] = test_retrieve_feature_data( varargin )
+function [] = testRetrieveFeatureData( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -597,13 +596,13 @@ function [] = test_retrieve_feature_data( varargin )
     tagStartPos = [3];
     t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
-    t.add_reference(d);
+    t.addReference(d);
 
     rawFeature = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
 
     % test get non existent
     try
-        t.retrieve_data('I do not exist, dont hate me!');
+        t.retrieveData('I do not exist, dont hate me!');
     catch ME
         assert(~isempty(strfind(ME.message, 'no DataArray with the specified name')), ...
             'Non existent check fail');
@@ -612,28 +611,28 @@ function [] = test_retrieve_feature_data( varargin )
     % test retrieve untagged feature data by name
     df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.add_feature(df, nix.LinkType.Untagged);
-    retData = t.retrieve_feature_data('testUntagged');
+    t.addFeature(df, nix.LinkType.Untagged);
+    retData = t.retrieveFeatureData('testUntagged');
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data by id
     df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.add_feature(df, nix.LinkType.Tagged);
-    retData = t.retrieve_feature_data(df.id);
+    t.addFeature(df, nix.LinkType.Tagged);
+    retData = t.retrieveFeatureData(df.id);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
 
     % test retrieve indexed feature data by id
     df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.add_feature(df, nix.LinkType.Indexed);
-    retData = t.retrieve_feature_data(df.id);
+    t.addFeature(df, nix.LinkType.Indexed);
+    retData = t.retrieveFeatureData(df.id);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
 end
 
 %% Test: Retrieve feature data by index
-function [] = test_retrieve_feature_data_idx( varargin )
+function [] = testRetrieveFeatureDataIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -642,41 +641,41 @@ function [] = test_retrieve_feature_data_idx( varargin )
     tagStartPos = [3];
     t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
-    t.add_reference(d);
+    t.addReference(d);
 
     rawFeature = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
 
     % test retrieve untagged feature data 
     df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.add_feature(df, nix.LinkType.Untagged);
-    retData = t.retrieve_feature_data_idx(1);
+    t.addFeature(df, nix.LinkType.Untagged);
+    retData = t.retrieveFeatureDataIdx(1);
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data 
     df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.add_feature(df, nix.LinkType.Tagged);
-    retData = t.retrieve_feature_data_idx(2);
+    t.addFeature(df, nix.LinkType.Tagged);
+    retData = t.retrieveFeatureDataIdx(2);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
 
     % test retrieve indexed feature data
     df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.add_feature(df, nix.LinkType.Indexed);
-    retData = t.retrieve_feature_data_idx(3);
+    t.addFeature(df, nix.LinkType.Indexed);
+    retData = t.retrieveFeatureDataIdx(3);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
 
     try
-        t.retrieve_feature_data_idx(12);
+        t.retrieveFeatureDataIdx(12);
     catch ME
         assert(~isempty(strfind(ME.message, 'out of bounds')), 'Invalid index check fail');
     end
 end
 
 %% Test: Read and write nix.Tag attributes
-function [] = test_attrs( varargin )
+function [] = testAttributes( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -741,42 +740,42 @@ function [] = test_attrs( varargin )
 end
 
 %% Test: nix.Tag has feature by ID
-function [] = test_has_feature( varargin )
+function [] = testHasFeature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createTag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
-    feature = t.add_feature(b.dataArrays{1}, nix.LinkType.Tagged);
+    feature = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     featureID = feature.id;
 
-    assert(~t.has_feature('I do not exist'));
-    assert(t.has_feature(featureID));
+    assert(~t.hasFeature('I do not exist'));
+    assert(t.hasFeature(featureID));
 
     clear tmp t da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tags{1}.has_feature(featureID));
+    assert(f.blocks{1}.tags{1}.hasFeature(featureID));
 end
 
 %% Test: nix.Tag has reference by ID or name
-function [] = test_has_reference( varargin )
+function [] = testHasReference( varargin )
     fileName = 'testRW.h5';
     daName = 'referenceTest';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
     da = b.createDataArray(daName, 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createTag('referenceTest', 'nixTag', [1.0 1.2 1.3 15.9]);
-    t.add_reference(b.dataArrays{1});
+    t.addReference(b.dataArrays{1});
 
-    assert(~t.has_reference('I do not exist'));
-    assert(t.has_reference(da.id));
+    assert(~t.hasReference('I do not exist'));
+    assert(t.hasReference(da.id));
     
     clear t da b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tags{1}.has_reference(daName));
+    assert(f.blocks{1}.tags{1}.hasReference(daName));
 end
 
-function [] = test_compare( varargin )
+function [] = testCompare( varargin )
 %% Test: Compare Tag entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -792,7 +791,7 @@ function [] = test_compare( varargin )
 end
 
 %% Test: filter sources
-function [] = test_filter_source( varargin )
+function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -853,7 +852,7 @@ function [] = test_filter_source( varargin )
     t.add_source(main);
     mainID = main.id;
     subName = 'testSubSource1';
-    s = main.create_source(subName, 'nixSource');
+    s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
     assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, 'Do not exist')));
@@ -867,112 +866,112 @@ function [] = test_filter_source( varargin )
 end
 
 %% Test: filter references
-function [] = test_filter_reference( varargin )
+function [] = testFilterReference( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1 2 3]);
     d = b.createDataArray(filterName, 'nixDataArray', nix.DataType.Double, [1 2]);
-    t.add_reference(d);
+    t.addReference(d);
     filterID = d.id;
 	d = b.createDataArray('testDataArray1', filterType, nix.DataType.Double, [1 2]);
-    t.add_reference(d);
+    t.addReference(d);
     filterIDs = {filterID, d.id};
     d = b.createDataArray('testDataArray2', filterType, nix.DataType.Double, [1 2]);
-    t.add_reference(d);
+    t.addReference(d);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.tags{1}.filter_references(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.tags{1}.filterReferences(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.tags{1}.filter_references(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.tags{1}.filterReferences(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.add_reference(main);
+    t.addReference(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     main.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.tags{1}.filter_references(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.tags{1}.filterReferences(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createDataArray(mainName, 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.add_reference(main);
+    t.addReference(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
     main.add_source(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.tags{1}.filter_references(nix.Filter.source, 'Do not exist')));
+    assert(isempty(f.blocks{1}.tags{1}.filterReferences(nix.Filter.source, 'Do not exist')));
 
     % filter works only for ID, not for name
-    filtered = f.blocks{1}.tags{1}.filter_references(nix.Filter.source, subID);
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
 
 %% Test: filter features
-function [] = test_filter_feature( varargin )
+function [] = testFilterFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1 2 3]);
     d = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.add_feature(d, nix.LinkType.Tagged);
+    feat = t.addFeature(d, nix.LinkType.Tagged);
     filterID = feat.id;
 	d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.add_feature(d, nix.LinkType.Tagged);
+    feat = t.addFeature(d, nix.LinkType.Tagged);
     filterIDs = {filterID, feat.id};
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.tags{1}.filter_features(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.tags{1}.filterFeatures(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.tags{1}.filter_features(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.tags{1}.filterFeatures(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.tags{1}.filter_features(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.tags{1}.filterFeatures(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.tags{1}.filter_features(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.tags{1}.filterFeatures(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
 
     % test fail on nix.Filter.name
     err = 'unknown or unsupported filter';
     try
-        f.blocks{1}.tags{1}.filter_features(nix.Filter.name, 'someName');
+        f.blocks{1}.tags{1}.filterFeatures(nix.Filter.name, 'someName');
     catch ME
         assert(strcmp(ME.message, err));
     end
@@ -980,7 +979,7 @@ function [] = test_filter_feature( varargin )
     % test fail on nix.Filter.type
     err = 'unknown or unsupported filter';
     try
-        f.blocks{1}.tags{1}.filter_features(nix.Filter.type, 'someType');
+        f.blocks{1}.tags{1}.filterFeatures(nix.Filter.type, 'someType');
     catch ME
         assert(strcmp(ME.message, err));
     end
@@ -988,14 +987,14 @@ function [] = test_filter_feature( varargin )
     % test fail on nix.Filter.metadata
     err = 'unknown or unsupported filter';
     try
-        f.blocks{1}.tags{1}.filter_features(nix.Filter.metadata, 'someMetadata');
+        f.blocks{1}.tags{1}.filterFeatures(nix.Filter.metadata, 'someMetadata');
     catch ME
         assert(strcmp(ME.message, err));
     end
 
     % test fail on nix.Filter.source
     try
-        f.blocks{1}.tags{1}.filter_features(nix.Filter.source, 'someSource');
+        f.blocks{1}.tags{1}.filterFeatures(nix.Filter.source, 'someSource');
     catch ME
         assert(strcmp(ME.message, err));
     end

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -537,11 +537,11 @@ function [] = test_retrieve_data( varargin )
     rawName = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     rawID = [11, 12, 13, 14, 15, 16, 17];
     d = b.createDataArrayFromData('testDataArrayName', 'nixDataArray', rawName);
-    d.append_sampled_dimension(1);
+    d.appendSampledDimension(1);
     t.add_reference(d);
 
     d = b.createDataArrayFromData('testDataArrayID', 'nixDataArray', rawID);
-    d.append_sampled_dimension(1);
+    d.appendSampledDimension(1);
     t.add_reference(d);
 
     % test get non existent
@@ -569,7 +569,7 @@ function [] = test_retrieve_data_idx( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     d = b.createDataArrayFromData('testDataArray', 'nixDataArray', raw);
-    d.append_sampled_dimension(1);
+    d.appendSampledDimension(1);
     % tag positon is used like an index, therfore starts with 0!
     tagStartPos = [3];
     t = b.createTag('testTag', 'nixTag', tagStartPos);
@@ -593,7 +593,7 @@ function [] = test_retrieve_feature_data( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     d = b.createDataArrayFromData('testDataArray', 'nixDataArray', raw);
-    d.append_sampled_dimension(1);
+    d.appendSampledDimension(1);
     tagStartPos = [3];
     t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
@@ -611,14 +611,14 @@ function [] = test_retrieve_feature_data( varargin )
 
     % test retrieve untagged feature data by name
     df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
-    df.append_sampled_dimension(1);
+    df.appendSampledDimension(1);
     t.add_feature(df, nix.LinkType.Untagged);
     retData = t.retrieve_feature_data('testUntagged');
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data by id
     df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
-    df.append_sampled_dimension(1);
+    df.appendSampledDimension(1);
     t.add_feature(df, nix.LinkType.Tagged);
     retData = t.retrieve_feature_data(df.id);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
@@ -626,7 +626,7 @@ function [] = test_retrieve_feature_data( varargin )
 
     % test retrieve indexed feature data by id
     df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
-    df.append_sampled_dimension(1);
+    df.appendSampledDimension(1);
     t.add_feature(df, nix.LinkType.Indexed);
     retData = t.retrieve_feature_data(df.id);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
@@ -638,7 +638,7 @@ function [] = test_retrieve_feature_data_idx( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     raw = [1, 2, 3, 4, 5, 6, 7, 8, 9];
     d = b.createDataArrayFromData('testDataArray', 'nixDataArray', raw);
-    d.append_sampled_dimension(1);
+    d.appendSampledDimension(1);
     tagStartPos = [3];
     t = b.createTag('testTag', 'nixTag', tagStartPos);
     t.extent = [3];
@@ -648,14 +648,14 @@ function [] = test_retrieve_feature_data_idx( varargin )
 
     % test retrieve untagged feature data 
     df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
-    df.append_sampled_dimension(1);
+    df.appendSampledDimension(1);
     t.add_feature(df, nix.LinkType.Untagged);
     retData = t.retrieve_feature_data_idx(1);
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data 
     df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
-    df.append_sampled_dimension(1);
+    df.appendSampledDimension(1);
     t.add_feature(df, nix.LinkType.Tagged);
     retData = t.retrieve_feature_data_idx(2);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
@@ -663,7 +663,7 @@ function [] = test_retrieve_feature_data_idx( varargin )
 
     % test retrieve indexed feature data
     df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
-    df.append_sampled_dimension(1);
+    df.appendSampledDimension(1);
     t.add_feature(df, nix.LinkType.Indexed);
     retData = t.retrieve_feature_data_idx(3);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -59,8 +59,8 @@ function [] = testAddSource ( varargin )
     
     assert(isempty(t.sources));
     assert(isempty(f.blocks{1}.tags{1}.sources));
-    t.add_source(s.sources{1}.id);
-    t.add_source(s.sources{2});
+    t.addSource(s.sources{1}.id);
+    t.addSource(s.sources{2});
     assert(size(t.sources, 1) == 2);
     assert(size(f.blocks{1}.tags{1}.sources, 1) == 2);
     
@@ -82,20 +82,20 @@ function [] = testAddSources ( varargin )
     assert(isempty(t.sources));
 
     try
-        t.add_sources('hurra');
+        t.addSources('hurra');
     catch ME
         assert(strcmp(ME.message, 'Expected cell array'));
     end;
     assert(isempty(t.sources));
 
     try
-        t.add_sources({12, 13});
+        t.addSources({12, 13});
     catch ME
         assert(~isempty(strfind(ME.message, 'not a nix.Source')));
     end;
     assert(isempty(t.sources));
 
-    t.add_sources(b.sources());
+    t.addSources(b.sources());
     assert(size(t.sources, 1) == 3);
 
     clear t tmp b f;
@@ -112,15 +112,15 @@ function [] = testRemoveSource ( varargin )
     tmp = s.createSource('nestedSource2', 'nixSource');
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('sourcetest', 'nixTag', position);
-    t.add_source(s.sources{1}.id);
-    t.add_source(s.sources{2});
+    t.addSource(s.sources{1}.id);
+    t.addSource(s.sources{2});
 
     assert(size(t.sources,1) == 2);
-    t.remove_source(s.sources{2});
+    t.removeSource(s.sources{2});
     assert(size(t.sources,1) == 1);
-    t.remove_source(s.sources{1}.id);
+    t.removeSource(s.sources{1}.id);
     assert(isempty(t.sources));
-    assert(t.remove_source('I do not exist'));
+    assert(t.removeSource('I do not exist'));
     assert(size(s.sources,1) == 2);
 end
 
@@ -296,9 +296,9 @@ function [] = testFetchSources( varargin )
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('tagtest', 'nixTag', position);
     
-    t.add_source(s.sources{1});
-    t.add_source(s.sources{2});
-    t.add_source(s.sources{3});
+    t.addSource(s.sources{1});
+    t.addSource(s.sources{2});
+    t.addSource(s.sources{3});
     assert(size(t.sources, 1) == 3);
 end
 
@@ -345,16 +345,16 @@ function [] = testOpenSource( varargin )
     createSource = s.createSource(sourceName, 'nixSource');
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('tagtest', 'nixTag', position);
-    t.add_source(s.sources{1});
+    t.addSource(s.sources{1});
 
-    getSourceByID = t.open_source(createSource.id);
+    getSourceByID = t.openSource(createSource.id);
     assert(~isempty(getSourceByID));
     
-    getSourceByName = t.open_source(sourceName);
+    getSourceByName = t.openSource(sourceName);
     assert(~isempty(getSourceByName));
     
     %-- test open non existing source
-    getNonSource = t.open_source('I do not exist');
+    getNonSource = t.openSource('I do not exist');
     assert(isempty(getNonSource));
 end
 
@@ -366,32 +366,34 @@ function [] = testOpenSourceIdx( varargin )
     s1 = b.createSource('testSource1', 'nixSource');
     s2 = b.createSource('testSource2', 'nixSource');
     s3 = b.createSource('testSource3', 'nixSource');
-    t.add_source(s1);
-    t.add_source(s2);
-    t.add_source(s3);
+    t.addSource(s1);
+    t.addSource(s2);
+    t.addSource(s3);
 
-    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(1).name, s1.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(2).name, s2.name));
-    assert(strcmp(f.blocks{1}.tags{1}.open_source_idx(3).name, s3.name));
+    assert(strcmp(f.blocks{1}.tags{1}.openSourceIdx(1).name, s1.name));
+    assert(strcmp(f.blocks{1}.tags{1}.openSourceIdx(2).name, s2.name));
+    assert(strcmp(f.blocks{1}.tags{1}.openSourceIdx(3).name, s3.name));
 end
 
 %% Test: nix.Tag has nix.Source by ID or entity
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
+    sName = 'sourceTest1';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('testblock', 'nixBlock');
-    s = b.createSource('sourceTest1', 'nixSource');
+    s = b.createSource(sName, 'nixSource');
     sID = s.id;
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('tagTest', 'nixTag', position);
-    t.add_source(b.sources{1});
+    t.addSource(b.sources{1});
 
-    assert(~t.has_source('I do not exist'));
-    assert(t.has_source(s));
+    assert(~t.hasSource('I do not exist'));
+    assert(t.hasSource(s));
 
     clear t s b f;
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tags{1}.has_source(sID));
+    assert(f.blocks{1}.tags{1}.hasSource(sID));
+    assert(~f.blocks{1}.tags{1}.hasSource(sName));
 end
 
 %% Test: Source count
@@ -401,14 +403,14 @@ function [] = testSourceCount( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1.0 1.2]);
 
-    assert(t.source_count() == 0);
-    t.add_source(b.createSource('testSource1', 'nixSource'));
-    assert(t.source_count() == 1);
-    t.add_source(b.createSource('testSource2', 'nixSource'));
+    assert(t.sourceCount() == 0);
+    t.addSource(b.createSource('testSource1', 'nixSource'));
+    assert(t.sourceCount() == 1);
+    t.addSource(b.createSource('testSource2', 'nixSource'));
 
     clear t b f;
     f = nix.File(testFile, nix.FileMode.ReadOnly);
-    assert(f.blocks{1}.tags{1}.source_count() == 2);
+    assert(f.blocks{1}.tags{1}.sourceCount() == 2);
 end
 
 %% Test: Open feature by ID
@@ -423,8 +425,8 @@ function [] = testOpenFeature( varargin )
     assert(~isempty(t.openFeature(t.features{1}.id)));
 
     %-- test open non existing feature
-    getFeat = t.openFeature('I do not exist');
-    assert(isempty(getFeat));
+    feat = t.openFeature('I do not exist');
+    assert(isempty(feat));
 end
 
 function [] = testOpenFeatureIdx( varargin )
@@ -798,69 +800,69 @@ function [] = testFilterSource( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1 2 3]);
     s = b.createSource(filterName, 'nixSource');
-    t.add_source(s);
+    t.addSource(s);
     filterID = s.id;
 	s = b.createSource('testSource1', filterType);
-    t.add_source(s);
+    t.addSource(s);
     filterIDs = {filterID, s.id};
     s = b.createSource('testSource2', filterType);
-    t.add_source(s);
+    t.addSource(s);
 
     % test empty id filter
-    assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.id, 'IdoNotExist')));
+    assert(isempty(f.blocks{1}.tags{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
     % test nix.Filter.accept_all
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.accept_all, '');
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.accept_all, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.id, filterID);
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.id, filterID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, filterID));
 
     % test nix.Filter.ids
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.ids, filterIDs);
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.ids, filterIDs);
     assert(size(filtered, 1) == 2);
     assert(strcmp(filtered{1}.id, filterIDs{1}) || strcmp(filtered{1}.id, filterIDs{2}));
     
     % test nix.Filter.name
-    filtered  = f.blocks{1}.tags{1}.filter_sources(nix.Filter.name, filterName);
+    filtered  = f.blocks{1}.tags{1}.filterSources(nix.Filter.name, filterName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, filterName));
     
     % test nix.Filter.type
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.type, filterType);
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.type, filterType);
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.metadata
     mainName = 'testSubSection';
     mainSource = b.createSource(mainName, 'nixSource');
-    t.add_source(mainSource);
+    t.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
     mainSource.set_metadata(s);
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.metadata, 'Do not exist')));
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.metadata, subID);
+    assert(isempty(f.blocks{1}.tags{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.metadata, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 
     % test nix.Filter.source
     mainName = 'testSubSource';
     main = b.createSource(mainName, 'nixSource');
-    t.add_source(main);
+    t.addSource(main);
     mainID = main.id;
     subName = 'testSubSource1';
     s = main.createSource(subName, 'nixSource');
     subID = s.id;
 
-    assert(isempty(f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, 'Do not exist')));
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, subName);
+    assert(isempty(f.blocks{1}.tags{1}.filterSources(nix.Filter.source, 'Do not exist')));
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.source, subName);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.id, mainID));
 
-    filtered = f.blocks{1}.tags{1}.filter_sources(nix.Filter.source, subID);
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.source, subID);
     assert(size(filtered, 1) == 1);
     assert(strcmp(filtered{1}.name, mainName));
 end
@@ -928,7 +930,7 @@ function [] = testFilterReference( varargin )
     mainID = main.id;
     subName = 'testSubSource1';
     s = b.createSource(subName, 'nixSource');
-    main.add_source(s);
+    main.addSource(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.tags{1}.filterReferences(nix.Filter.source, 'Do not exist')));

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -811,8 +811,8 @@ function [] = testFilterSource( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.tags{1}.filterSources(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.tags{1}.filterSources(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
@@ -886,8 +886,8 @@ function [] = testFilterReference( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.tags{1}.filterReferences(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.tags{1}.filterReferences(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 3);
 
     % test nix.Filter.id
@@ -956,8 +956,8 @@ function [] = testFilterFeature( varargin )
     % test empty id filter
     assert(isempty(f.blocks{1}.tags{1}.filterFeatures(nix.Filter.id, 'IdoNotExist')));
 
-    % test nix.Filter.accept_all
-    filtered = f.blocks{1}.tags{1}.filterFeatures(nix.Filter.accept_all, '');
+    % test nix.Filter.acceptall
+    filtered = f.blocks{1}.tags{1}.filterFeatures(nix.Filter.acceptall, '');
     assert(size(filtered, 1) == 2);
 
     % test nix.Filter.id

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -495,25 +495,25 @@ function [] = testSetMetadata ( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1, 2, 3, 4]);
 
-    assert(isempty(t.open_metadata));
-    assert(isempty(f.blocks{1}.tags{1}.open_metadata));
+    assert(isempty(t.openMetadata));
+    assert(isempty(f.blocks{1}.tags{1}.openMetadata));
     
-    t.set_metadata(f.sections{1});
-    assert(strcmp(t.open_metadata.name, secName1));
-    assert(strcmp(f.blocks{1}.tags{1}.open_metadata.name, secName1));
+    t.setMetadata(f.sections{1});
+    assert(strcmp(t.openMetadata.name, secName1));
+    assert(strcmp(f.blocks{1}.tags{1}.openMetadata.name, secName1));
     
-    t.set_metadata(f.sections{2});
-    assert(strcmp(t.open_metadata.name, secName2));
-    assert(strcmp(f.blocks{1}.tags{1}.open_metadata.name, secName2));
+    t.setMetadata(f.sections{2});
+    assert(strcmp(t.openMetadata.name, secName2));
+    assert(strcmp(f.blocks{1}.tags{1}.openMetadata.name, secName2));
     
-    t.set_metadata('');
-    assert(isempty(t.open_metadata));
-    assert(isempty(f.blocks{1}.tags{1}.open_metadata));
+    t.setMetadata('');
+    assert(isempty(t.openMetadata));
+    assert(isempty(f.blocks{1}.tags{1}.openMetadata));
     
-    t.set_metadata(f.sections{2});
+    t.setMetadata(f.sections{2});
     clear tmp b f;
     f = nix.File(fileName, nix.FileMode.ReadOnly);
-    assert(strcmp(f.blocks{1}.tags{1}.open_metadata.name, secName2));
+    assert(strcmp(f.blocks{1}.tags{1}.openMetadata.name, secName2));
 end
 
 %% Test: Open metadata
@@ -523,8 +523,8 @@ function [] = testOpenMetadata( varargin )
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1, 2, 3, 4]);
 
-    t.set_metadata(f.sections{1});
-    assert(strcmp(t.open_metadata.name, 'testSection'));
+    t.setMetadata(f.sections{1});
+    assert(strcmp(t.openMetadata.name, 'testSection'));
 end
 
 %% Test: Retrieve referenced data by name and id
@@ -840,7 +840,7 @@ function [] = testFilterSource( varargin )
     t.addSource(mainSource);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    mainSource.set_metadata(s);
+    mainSource.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.tags{1}.filterSources(nix.Filter.metadata, 'Do not exist')));
@@ -915,7 +915,7 @@ function [] = testFilterReference( varargin )
     t.addReference(main);
     subName = 'testSubSection1';
     s = f.createSection(subName, 'nixSection');
-    main.set_metadata(s);
+    main.setMetadata(s);
     subID = s.id;
 
     assert(isempty(f.blocks{1}.tags{1}.filterReferences(nix.Filter.metadata, 'Do not exist')));


### PR DESCRIPTION
We often talked about it, now it is here:

This PR is the third in a series of refactor PRs and adds a common code style mainly to the Matlab side of the bindings and in turn renames all method names and variables from snake_case to CamelCase.

Regarding the code style the main points are:
- Adhere to the MATLAB Style Guidelines 2.0 as suggested by Richard Johnson.
- Furthermore, adhere to these additional guidelines for the nix-mx project:
-- keep line length at 90 max.
-- use `r` as return variable name of simple (2-3 line) functions.
-- always use ';' to terminate proper statements, never for terminating control structures.
-- Structure names should start with a capital letter.
-- Structure field names should be camel case and start with a lower case letter.

This PR includes the following changes:
- Adds a Contributing and style guide file.
- Refactors all files according to the style described above.
- Removes obsolete name/value mapping of child entities from `addGetChildEntities` in `nix.Dynamic`.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).