### PR TITLE
Add Documentation

### DIFF
--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -14,6 +14,9 @@
 %                         entity and expose it to search methods in a broader context.
 %   definition (char):  read-write, optional description of the entity.
 %
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
+%
 % nix.Block dynamic child entity properties:
 %   groups       access to all nix.Group child entities.
 %   dataArrays   access to all nix.DataArray child entities.
@@ -35,7 +38,7 @@
 classdef Block < nix.NamedEntity & nix.MetadataMixIn
 
     properties (Hidden)
-        alias = 'Block'  % nix-mx namespace to access Block specific nix backend functions.
+        alias = 'Block'  % namespace for Block nix backend function access.
     end
 
     methods

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -20,7 +20,6 @@
 %   sources      access to all first level nix.Source child entities.
 %   tags         access to all nix.Tag child entities.
 %   multiTags    access to all nix.MultiTag child entities.
-%   sections     access to all first level nix.Section child entities.
 %
 % See also nix.DataArray, nix.Source, nix.Group, nix.Tag, nix.MultiTag, nix.Section.
 %

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -1,3 +1,30 @@
+% nix.Block class for basic grouping of further data entities.
+%
+% The Block entity is a top-level, summarizing element that allows to group the other 
+% data entities belonging for example to the same recording session. It is
+% the main entity to create nix.DataArrays, nix.Tags and nix.MultiTags.
+%
+% Please note that when a Block is deleted, all child entities will be 
+% permanently deleted from the file as well.
+%
+% nix.Block dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, optional description of the entity.
+%
+% nix.Block dynamic child entity properties:
+%   groups       access to all nix.Group child entities.
+%   dataArrays   access to all nix.DataArray child entities.
+%   sources      access to all first level nix.Source child entities.
+%   tags         access to all nix.Tag child entities.
+%   multiTags    access to all nix.MultiTag child entities.
+%   sections     access to all first level nix.Section child entities.
+%
+% See also nix.DataArray, nix.Source, nix.Group, nix.Tag, nix.MultiTag, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +34,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Block < nix.NamedEntity & nix.MetadataMixIn
-    % Block nix Block object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Block'
+        alias = 'Block'  % nix-mx namespace to access Block specific nix backend functions.
     end
 
     methods
@@ -19,7 +44,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             obj@nix.NamedEntity(h);
             obj@nix.MetadataMixIn();
 
-            % assign relations
+            % assign child entities
             nix.Dynamic.addGetChildEntities(obj, 'groups', @nix.Group);
             nix.Dynamic.addGetChildEntities(obj, 'dataArrays', @nix.DataArray);
             nix.Dynamic.addGetChildEntities(obj, 'sources', @nix.Source);
@@ -32,33 +57,114 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = groupCount(obj)
+            % Get the number of direct child nix.Groups.
+            %
+            % Returns:  (uint) The number of child (non nested) Groups.
+            %
+            % Example:  gc = currBlock.groupCount();
+            %
+            % See also nix.Group.
+
             r = nix.Utils.fetchEntityCount(obj, 'groupCount');
         end
 
-        function r = createGroup(obj, name, nixtype)
+        function r = createGroup(obj, name, type)
+            % Create a new nix.Group entity associated with the invoking Block.
+            %
+            %   name (char):  The name of the Group, has to be unique within the file.
+            %   type (char):  The type of the Group.
+            %
+            %   Returns:  (nix.Group) The newly created Group.
+            %
+            %   Example:  newGroup = currBlock.createGroup('subTrial2', 'ephys');
+            %
+            % See also nix.Group.
+
             fname = strcat(obj.alias, '::createGroup');
-            h = nix_mx(fname, obj.nixhandle, name, nixtype);
+            h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Group);
         end
 
         function r = hasGroup(obj, idName)
+            % Check if a nix.Group exists as a direct child of the Block.
+            %
+            % idName (char):  Name or ID of the Group.
+            %
+            % Returns:  (logical) True if the Group exists, false otherwise.
+            %
+            % Example:  check = currBlock.hasGroup('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.hasGroup('subTrial2');
+            %
+            % See also nix.Group.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasGroup', idName);
         end
 
         function r = openGroup(obj, idName)
+            % Retrieves an existing Group from the invoking Block.
+            %
+            % idName (char):  Name or ID of the Group.
+            %
+            % Returns:  (nix.Group) The nix.Group or an empty cell, 
+            %                       if the Group was not found.
+            %
+            % Example:  getGroup = currBlock.openGroup('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getGroup = currFile.blocks{1}.openGroup('subTrial2');
+            %
+            % See also nix.Group.
+
             r = nix.Utils.openEntity(obj, 'getGroup', idName, @nix.Group);
         end
 
         function r = openGroupIdx(obj, index)
+            % Retrieves an existing nix.Group from the invoking Block, accessed by index.
+            %
+            % index (double):  The index of the Group to read.
+            %
+            % Returns:  (nix.Group) The Group at the given index.
+            %
+            % Example:  getGroup = currBlock.openGroupIdx(1);
+            %
+            % See also nix.Group.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openGroupIdx', idx, @nix.Group);
         end
 
         function r = deleteGroup(obj, idNameEntity)
+            % Deletes a nix.Group from the invoking Block.
+            %
+            % When a Group is deleted, all its content (DataArray, Tags, Sources, etc)
+            % will be deleted from the Block as well.
+            %
+            % idNameEntity (char/nix.Group):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Group has been removed, false otherwise.
+            %
+            % Example:  check = currBlock.deleteGroup('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currBlock.deleteGroup('trial1');
+            %           check = currFile.blocks{1}.deleteGroup(newGroup);
+            %
+            % See also nix.Group.
+
             r = nix.Utils.deleteEntity(obj, 'deleteGroup', idNameEntity, 'nix.Group');
         end
 
         function r = filterGroups(obj, filter, val)
+            % Get a filtered cell array of all child Groups of the invoking Block.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Group]) A cell array of Groups filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getGroups = currBlock.filterGroups(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Group, nix.Filter.
+
             r = nix.Utils.filter(obj, 'groupsFiltered', filter, val, @nix.Group);
         end
 
@@ -67,19 +173,67 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = dataArrayCount(obj)
+            % Get the number of child nix.DataArrays.
+            %
+            % Returns:  (uint) The number of child DataArrays.
+            %
+            % Example:  dc = currBlock.dataArrayCount();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchEntityCount(obj, 'dataArrayCount');
         end
 
         function r = openDataArray(obj, idName)
+            % Retrieves an existing DataArray from the invoking Block.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (nix.DataArray) The nix.DataArray or an empty cell, 
+            %                       if the DataArray was not found.
+            %
+            % Example:  getDA = currBlock.openDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getDA = currFile.blocks{1}.openDataArray('subTrial2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.openEntity(obj, 'openDataArray', idName, @nix.DataArray);
         end
 
         function r = openDataArrayIdx(obj, index)
+            % Retrieves an existing nix.DataArray from the invoking Block, accessed by index.
+            %
+            % index (double):  The index of the DataArray to read.
+            %
+            % Returns:  (nix.DataArray) The DataArray at the given index.
+            %
+            % Example:  getDA = currBlock.openDataArrayIdx(1);
+            %
+            % See also nix.DataArray.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
-        function r = createDataArray(obj, name, nixtype, datatype, shape)
+        function r = createDataArray(obj, name, type, datatype, shape)
+            % Create a new nix.DataArray entity associated with the invoking Block.
+            %
+            %   name (char):  The name of the DataArray, has to be unique within the file.
+            %   type (char):  The type of the DataArray.
+            %   datatype (nix.DataType):  Provides the datatype of the data that the 
+            %                             DataArray will contain. It has to be a valid
+            %                             nix.DataType.
+            %   shape (double):  The dimensionality of the data that the DataArray will 
+            %                    contain.
+            %
+            %   Returns:  (nix.DataArray) The newly created DataArray.
+            %
+            %   Example:  newDataArray = currBlock.createDataArray('sessionData1', ...
+            %                               'epyhs_data', nix.DataType.Double, [12 15]);
+            %             % allocates space for a 12x15 array of datatype double.
+            %
+            % See also nix.DataArray, nix.DataType.
+
             %-- Quick fix to enable alias range dimension with
             %-- 1D data arrays created with this function.
             %-- e.g. size([1 2 3]) returns shape [1 3], which would not
@@ -97,12 +251,30 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 error(err);
             else
                 fname = strcat(obj.alias, '::createDataArray');
-                h = nix_mx(fname, obj.nixhandle, name, nixtype, lower(datatype.char), shape);
+                h = nix_mx(fname, obj.nixhandle, name, type, lower(datatype.char), shape);
                 r = nix.Utils.createEntity(h, @nix.DataArray);
             end
         end
 
-        function r = createDataArrayFromData(obj, name, nixtype, data)
+        function r = createDataArrayFromData(obj, name, type, data)
+            % Create a new nix.DataArray entity associated with the invoking Block 
+            % from existing data.
+            %
+            % Create a DataArray with shape and type inferred from data. After
+            % successful creation, the contents of data will be written to the
+            % DataArray.
+            %
+            %   name (char):  The name of the DataArray, has to be unique within the file.
+            %   type (char):  The type of the DataArray, required.
+            %   data (var):   Raw data the DataArray is supposed to contain.
+            %
+            %   Returns:  (nix.DataArray) The newly created DataArray.
+            %
+            %   Example:  newDataArray = currBlock.createDataArray('sessionData2', ...
+            %                               'epyhs_data', rawDataVariable);
+            %
+            % See also nix.DataArray, nix.DataType.
+
             shape = size(data);
             %-- Quick fix to enable alias range dimension with
             %-- 1D data arrays created with this function.
@@ -125,19 +297,59 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
                 error(err);
             end
 
-            r = obj.createDataArray(name, nixtype, dtype, shape);
+            r = obj.createDataArray(name, type, dtype, shape);
             r.writeAllData(data);
         end
 
         function r = hasDataArray(obj, idName)
+            % Check if a nix.DataArray exists as a child of the Block.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (logical) True if the DataArray exists, false otherwise.
+            %
+            % Example:  check = currBlock.hasDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.hasDataArray('sessionData2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', idName);
         end
 
-        function r = deleteDataArray(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteDataArray', del, 'nix.DataArray');
+        function r = deleteDataArray(obj, idNameEntity)
+            % Deletes a nix.DataArray from the invoking Block.
+            %
+            % When a DataArray is deleted, all its data content and
+            % referenced Dimensions will be deleted from the Block as well.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the DataArray has been removed, false otherwise.
+            %
+            % Example:  check = currBlock.deleteDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currBlock.deleteDataArray('sessionData2');
+            %           check = currFile.blocks{1}.deleteDataArray(newDataArray);
+            %
+            % See also nix.DataArray.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteDataArray', idNameEntity, 'nix.DataArray');
         end
 
         function r = filterDataArrays(obj, filter, val)
+            % Get a filtered cell array of all DataArrays of the invoking Block.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.DataArray]) A cell array of DataArrays filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getDAs = currBlock.filterDataArrays(nix.Filter.type, 'ephys_data');
+            %
+            % See also nix.DataArray, nix.Filter.
+
             r = nix.Utils.filter(obj, 'dataArraysFiltered', filter, val, @nix.DataArray);
         end
 
@@ -146,43 +358,155 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = sourceCount(obj)
+            % Get the number of direct child Sources.
+            %
+            % Returns:  (uint) The number of child (non nested) Sources.
+            %
+            % Example:  sc = currBlock.sourceCount();
+            %
+            % See also nix.Source.
+
             r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
         function r = createSource(obj, name, type)
+            % Create a new nix.Source entity associated with the invoking Block.
+            %
+            %   name (char):  The name of the Source, has to be unique within the file.
+            %   type (char):  The type of the Source.
+            %
+            %   Returns:  (nix.Source) The newly created Source.
+            %
+            %   Example:  newSource = currBlock.createSource('cell5', 'pyramidal');
+            %
+            % See also nix.Source.
+
             fname = strcat(obj.alias, '::createSource');
             h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Source);
         end
 
         function r = hasSource(obj, idName)
+            % Check if a nix.Source exists as a direct child of the Block.
+            %
+            % idName (char):  Name or ID of the Source.
+            %
+            % Returns:  (logical) True if the Source exists, false otherwise.
+            %
+            % Example:  check = currBlock.hasSource('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.hasSource('cell5');
+            %
+            % See also nix.Source.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasSource', idName);
         end
 
-        function r = deleteSource(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteSource', del, 'nix.Source');
+        function r = deleteSource(obj, idNameEntity)
+            % Deletes a nix.Source from the invoking Block.
+            %
+            % When a Source is deleted, all its child Sources will be deleted as well.
+            %
+            % idNameEntity (char/nix.Source):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Source has been removed, false otherwise.
+            %
+            % Example:  check = currBlock.deleteSource('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currBlock.deleteSource('cell5');
+            %           check = currFile.blocks{1}.deleteSource(newSource);
+            %
+            % See also nix.Group.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteSource', idNameEntity, 'nix.Source');
         end
 
         function r = openSource(obj, idName)
+            % Retrieves an existing direct Source from the invoking Block.
+            %
+            % idName (char):  Name or ID of the Source.
+            %
+            % Returns:  (nix.Source) The nix.Source or an empty cell, 
+            %                       if the Source was not found.
+            %
+            % Example:  getSource = currBlock.openSource('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getSource = currFile.blocks{1}.openSource('cell5');
+            %
+            % See also nix.Source.
+
             r = nix.Utils.openEntity(obj, 'openSource', idName, @nix.Source);
         end
 
         function r = openSourceIdx(obj, index)
+            % Retrieves an existing nix.Source from the invoking Block, accessed by index.
+            %
+            % index (double):  The index of the Source to read.
+            %
+            % Returns:  (nix.Source) The Source at the given index.
+            %
+            % Example:  getSource = currBlock.openSourceIdx(1);
+            %
+            % See also nix.Source.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = filterSources(obj, filter, val)
+            % Get a filtered cell array of all child Sources of the invoking Block.
+            %
+            % filter (nix.Filter):  the nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Source]) A cell array of Sources filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getSources = currBlock.filterSources(nix.Filter.type, 'pyramidal');
+            %
+            % See also nix.Source, nix.Filter.
+
             r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
 
-        % maxdepth is an index
         function r = findSources(obj, maxDepth)
+            % Get all Sources and their child Sources in the invoking Block recursively.
+            %
+            % This method traverses the trees of all Sources in the Block and adds all
+            % Sources to the resulting cell array, until the maximum depth of the nested
+            % Sources has been reached. The traversal is accomplished via breadth first 
+            % and adds the Sources accordingly.
+            %
+            % maxDepth (double):  The maximum depth of traversal to retrieve nested 
+            %                     Sources. Should be handled like an index.
+            %
+            % Example:  allSources = currBlock.findSources(2);
+            %           % will add all Sources until including the 2nd layer of Sources.
+            %
+            % See also nix.Section.
+
             r = obj.filterFindSources(maxDepth, nix.Filter.acceptall, '');
         end
 
-        % maxdepth is an index
         function r = filterFindSources(obj, maxDepth, filter, val)
+            % Get all Sources and their child Sources in the invoking Block recursively.
+            %
+            % This method traverses the trees of all Sources in the Block. The traversal
+            % is accomplished via breadth first and can be limited in depth. On each 
+            % node or Source a nix.Filter is applied. If the filter returns true, the 
+            % respective Source will be added to the result list.
+            %
+            % maxDepth (double):    The maximum depth of traversal to retrieve nested 
+            %                       Sources. Should be handled like an index.
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       the filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Example:  allSources = f.filterFindSources(2, nix.Filter.type, 'ephys');
+            %
+            % See also nix.Source, nix.Filter.
+
             r = nix.Utils.find(obj, 'findSources', maxDepth, filter, val, @nix.Source);
         end
 
@@ -191,33 +515,118 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = tagCount(obj)
+            % Get the number of child nix.Tags.
+            %
+            % Returns:  (uint) The number of child Tags.
+            %
+            % Example:  tc = currBlock.tagCount();
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.fetchEntityCount(obj, 'tagCount');
         end
 
         function r = hasTag(obj, idName)
+            % Check if a nix.Tag exists as a child of the Block.
+            %
+            % idName (char):  Name or ID of the Tag.
+            %
+            % Returns:  (logical) True if the Tag exists, false otherwise.
+            %
+            % Example:  check = currBlock.hasTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.hasTag('roi_1');
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasTag', idName);
         end
 
         function r = openTag(obj, idName)
+            % Retrieves an existing Tag from the invoking Block.
+            %
+            % idName (char):  Name or ID of the Tag.
+            %
+            % Returns:  (nix.Tag) The nix.Tag or an empty cell, 
+            %                       if the Tag was not found.
+            %
+            % Example:  getTag = currBlock.openTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getTag = currFile.blocks{1}.openTag('roi_1');
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.openEntity(obj, 'openTag', idName, @nix.Tag);
         end
 
         function r = openTagIdx(obj, index)
+            % Retrieves an existing nix.Tag from the invoking Block, accessed by index.
+            %
+            % index (double):  The index of the Tag to read.
+            %
+            % Returns:  (nix.Tag) The Tag at the given index.
+            %
+            % Example:  getTag = currBlock.openTagIdx(1);
+            %
+            % See also nix.Tag.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
         function r = createTag(obj, name, type, position)
+            % Create a new nix.Tag entity associated with the invoking Block.
+            %
+            %   name (char):        The name of the Tag, has to be unique within the file.
+            %   type (char):        The type of the Tag.
+            %   position (double):  Start position of the Tag. Position has to match 
+            %                       the referenced data. If e.g. the referenced data is 
+            %                       2D, the start position has to provide two coordinates
+            %                       as well.
+            %
+            %   Returns:  (nix.Tag) The newly created Tag.
+            %
+            %   Example:  newTag = currBlock.createTag('roi_1', 'ephys', [12, 15]);
+            %
+            % See also nix.Tag.
+
             fname = strcat(obj.alias, '::createTag');
             h = nix_mx(fname, obj.nixhandle, name, type, position);
             r = nix.Utils.createEntity(h, @nix.Tag);
         end
 
-        function r = deleteTag(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteTag', del, 'nix.Tag');
+        function r = deleteTag(obj, idNameEntity)
+            % Deletes a nix.Tag from the invoking Block.
+            %
+            % When a Tag is deleted, all its Features will be deleted 
+            % from the Block as well.
+            %
+            % idNameEntity (char/nix.Tag):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Tag has been removed, false otherwise.
+            %
+            % Example:  check = currBlock.deleteTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currBlock.deleteTag('roi_1');
+            %           check = currFile.blocks{1}.deleteTag(newTag);
+            %
+            % See also nix.Tag.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteTag', idNameEntity, 'nix.Tag');
         end
 
         function r = filterTags(obj, filter, val)
+            % Get a filtered cell array of all Tags of the invoking Block.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Tag]) A cell array of Tags filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getTags = currBlock.filterTags(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Tag, nix.Filter.
+
             r = nix.Utils.filter(obj, 'tagsFiltered', filter, val, @nix.Tag);
         end
 
@@ -226,35 +635,117 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         % -----------------
 
         function r = multiTagCount(obj)
+            % Get the number of child nix.MultiTags.
+            %
+            % Returns:  (uint) The number of child MultiTags.
+            %
+            % Example:  mtc = currBlock.multiTagCount();
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.fetchEntityCount(obj, 'multiTagCount');
         end
 
         function r = hasMultiTag(obj, idName)
+            % Check if a nix.MultiTag exists as a child of the Block.
+            %
+            % idName (char):  Name or ID of the MultiTag.
+            %
+            % Returns:  (logical) True if the MultiTag exists, false otherwise.
+            %
+            % Example:  check = currBlock.hasMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.hasMultiTag('roi_2');
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', idName);
         end
 
         function r = openMultiTag(obj, idName)
+            % Retrieves an existing MultiTag from the invoking Block.
+            %
+            % idName (char):  Name or ID of the MultiTag.
+            %
+            % Returns:  (nix.MultiTag) The nix.MultiTag or an empty cell, 
+            %                       if the MultiTag was not found.
+            %
+            % Example:  getMT = currBlock.openMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getMT = currFile.blocks{1}.openMultiTag('roi_2');
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.openEntity(obj, 'openMultiTag', idName, @nix.MultiTag);
         end
 
         function r = openMultiTagIdx(obj, index)
+            % Retrieves an existing nix.MultiTag from the invoking Block, accessed by index.
+            %
+            % index (double):  The index of the MultiTag to read.
+            %
+            % Returns:  (nix.MultiTag) The MultiTag at the given index.
+            %
+            % Example:  getMT = currBlock.openMultiTagIdx(1);
+            %
+            % See also nix.MultiTag.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
-        %-- Creating a multitag requires an already existing data array
         function r = createMultiTag(obj, name, type, refDataArray)
+            % Create a new nix.MultiTag entity associated with the invoking Block.
+            %
+            %   name (char):  The name of the MultiTag, has to be unique within the file.
+            %   type (char):  The type of the MultiTag.
+            %   refDataArray (nix.DataArray):  An existing DataArray, that will be 
+            %                                  referenced by the created MultiTag.
+            %
+            %   Returns:  (nix.MultiTag) The newly created MultiTag.
+            %
+            %   Example:  newMultiTag = currBlock.createMultiTag('roi_2', 'ephys', refDA);
+            %
+            % See also nix.MultiTag.
+
             fname = strcat(obj.alias, '::createMultiTag');
             id = nix.Utils.parseEntityId(refDataArray, 'nix.DataArray');
             h = nix_mx(fname, obj.nixhandle, name, type, id);
             r = nix.Utils.createEntity(h, @nix.MultiTag);
         end
 
-        function r = deleteMultiTag(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteMultiTag', del, 'nix.MultiTag');
+        function r = deleteMultiTag(obj, idNameEntity)
+            % Deletes a nix.MultiTag from the invoking Block.
+            %
+            % When a MultiTag is deleted, all its Features will be deleted 
+            % from the Block as well.
+            %
+            % idNameEntity (char/nix.MultiTag):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the MultiTag has been removed, false otherwise.
+            %
+            % Example:  check = currBlock.deleteMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currBlock.deleteMultiTag('roi_2');
+            %           check = currFile.blocks{1}.deleteMultiTag(newMultiTag);
+            %
+            % See also nix.MultiTag.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteMultiTag', idNameEntity, 'nix.MultiTag');
         end
 
         function r = filterMultiTags(obj, filter, val)
+            % Get a filtered cell array of all MultiTags of the invoking Block.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.MultiTag]) A cell array of MultiTags filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getMultiTags = currBlock.filterMultiTags(nix.Filter.type, 'ephys');
+            %
+            % See also nix.MultiTag, nix.Filter.
+
             r = nix.Utils.filter(obj, 'multiTagsFiltered', filter, val, @nix.MultiTag);
         end
     end

--- a/+nix/Block.m
+++ b/+nix/Block.m
@@ -70,12 +70,12 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function r = createGroup(obj, name, type)
             % Create a new nix.Group entity associated with the invoking Block.
             %
-            %   name (char):  The name of the Group, has to be unique within the file.
-            %   type (char):  The type of the Group.
+            % name (char):  The name of the Group, has to be unique within the file.
+            % type (char):  The type of the Group.
             %
-            %   Returns:  (nix.Group) The newly created Group.
+            % Returns:  (nix.Group) The newly created Group.
             %
-            %   Example:  newGroup = currBlock.createGroup('subTrial2', 'ephys');
+            % Example:  newGroup = currBlock.createGroup('subTrial2', 'ephys');
             %
             % See also nix.Group.
 
@@ -217,18 +217,18 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function r = createDataArray(obj, name, type, datatype, shape)
             % Create a new nix.DataArray entity associated with the invoking Block.
             %
-            %   name (char):  The name of the DataArray, has to be unique within the file.
-            %   type (char):  The type of the DataArray.
-            %   datatype (nix.DataType):  Provides the datatype of the data that the 
-            %                             DataArray will contain. It has to be a valid
-            %                             nix.DataType.
-            %   shape (double):  The dimensionality of the data that the DataArray will 
+            % name (char):  The name of the DataArray, has to be unique within the file.
+            % type (char):  The type of the DataArray.
+            % datatype (nix.DataType):  Provides the datatype of the data that the 
+            %                           DataArray will contain. It has to be a valid
+            %                           nix.DataType.
+            % shape (double):  The dimensionality of the data that the DataArray will 
             %                    contain.
             %
-            %   Returns:  (nix.DataArray) The newly created DataArray.
+            % Returns:  (nix.DataArray) The newly created DataArray.
             %
-            %   Example:  newDataArray = currBlock.createDataArray('sessionData1', ...
-            %                               'epyhs_data', nix.DataType.Double, [12 15]);
+            % Example:  newDataArray = currBlock.createDataArray('sessionData1', ...
+            %                             'epyhs_data', nix.DataType.Double, [12 15]);
             %             % allocates space for a 12x15 array of datatype double.
             %
             % See also nix.DataArray, nix.DataType.
@@ -263,13 +263,13 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             % successful creation, the contents of data will be written to the
             % DataArray.
             %
-            %   name (char):  The name of the DataArray, has to be unique within the file.
-            %   type (char):  The type of the DataArray, required.
-            %   data (var):   Raw data the DataArray is supposed to contain.
+            % name (char):  The name of the DataArray, has to be unique within the file.
+            % type (char):  The type of the DataArray, required.
+            % data (var):   Raw data the DataArray is supposed to contain.
             %
-            %   Returns:  (nix.DataArray) The newly created DataArray.
+            % Returns:  (nix.DataArray) The newly created DataArray.
             %
-            %   Example:  newDataArray = currBlock.createDataArray('sessionData2', ...
+            % Example:  newDataArray = currBlock.createDataArray('sessionData2', ...
             %                               'epyhs_data', rawDataVariable);
             %
             % See also nix.DataArray, nix.DataType.
@@ -371,12 +371,12 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
         function r = createSource(obj, name, type)
             % Create a new nix.Source entity associated with the invoking Block.
             %
-            %   name (char):  The name of the Source, has to be unique within the file.
-            %   type (char):  The type of the Source.
+            % name (char):  The name of the Source, has to be unique within the file.
+            % type (char):  The type of the Source.
             %
-            %   Returns:  (nix.Source) The newly created Source.
+            % Returns:  (nix.Source) The newly created Source.
             %
-            %   Example:  newSource = currBlock.createSource('cell5', 'pyramidal');
+            % Example:  newSource = currBlock.createSource('cell5', 'pyramidal');
             %
             % See also nix.Source.
 
@@ -481,7 +481,7 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             % Example:  allSources = currBlock.findSources(2);
             %           % will add all Sources until including the 2nd layer of Sources.
             %
-            % See also nix.Section.
+            % See also nix.Source.
 
             r = obj.filterFindSources(maxDepth, nix.Filter.acceptall, '');
         end
@@ -502,7 +502,8 @@ classdef Block < nix.NamedEntity & nix.MetadataMixIn
             % val (char):           Value that is applied with the selected
             %                       filter.
             %
-            % Example:  allSources = f.filterFindSources(2, nix.Filter.type, 'ephys');
+            % Example:  allSources = currBlock.filterFindSources(...
+            %                               2, nix.Filter.type, 'ephys');
             %
             % See also nix.Source, nix.Filter.
 

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -44,6 +44,9 @@
 %                                  e.g. a 2D array must always remain a 2D array, but 
 %                                  can be modified in either of the two dimensions.
 %
+%   info (struct):  Entity property summary. The values in this structure are detached
+%                   from the entity, changes will not be persisted to the file.
+%
 % nix.DataArray dynamic child entity properties:
 %   dimensions   access to all dimensions associated with a DataArray.
 %   sources      access to all first level nix.Source child entities.
@@ -62,7 +65,7 @@
 classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
     properties (Hidden)
-        alias = 'DataArray'  % nix-mx namespace to access DataArray specific nix backend functions.
+        alias = 'DataArray'  % namespace for DataArray nix backend function access.
     end
 
     properties (Dependent)

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -1,3 +1,57 @@
+% nix.DataArray class that can store arbitrary n-dimensional data
+% along with further information.
+%
+% The DataArray is the core entity of the NIX data model, its purpose is to store 
+% arbitrary n-dimensional data. In addition to the common fields id, name, type, 
+% and definition the DataArray stores sufficient information to understand the 
+% physical nature of the stored data.
+%
+% A guiding principle of the data model is to provide enough information to create a 
+% plot of the stored data. In order to do so, the DataArray defines a property dataType 
+% which provides the physical type of the stored data (for example 16 bit integer or 
+% double precision IEEE floatingpoint number). The property unit specifies the SI unit 
+% of the values stored in the DataArray whereas the label defines what is given in this 
+% units. Together, both specify what corresponds to the the y-axis of a plot.
+%
+% In some cases it is much more efficient or convenient to store data not as floating 
+% point numbers but rather as (16 bit) integer values as, for example, read from a data 
+% acquisition board. In order to convert such data to the correct values, we follow the 
+% approach taken by the comedi data-acquisition library (http://www.comedi.org) and 
+% provide polynomCoefficients and an expansionOrigin.
+%
+% A DataArray can only be created from a Block entity. Do not use the
+% DataArray constructor.
+%
+% DataArray supports only the storage of numeric and logical data.
+%
+% nix.DataArray dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                          entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, optional description of the entity.
+%   label (char):       read-write, optional label of the raw data for plotting.
+%   unit (char):        read-write, optional unit of the raw data.
+%                          Supports only SI units.
+%   expansionOrigin (double):      read-write, the expansion origin of the 
+%                                     calibration polynom. 0.0 by default.
+%   polynomCoefficients (double):  read-write, The polynom coefficients for the 
+%                                     calibration. By default this is set to a 
+%                                  {0.0, 1.0} for a linear calibration with zero offset.
+%   dataExtent ([double]):         read-write, the size of the raw data.
+%                                     The size of a DataArray can be changed with this 
+%                                  property, but only within the original dimensionality, 
+%                                  e.g. a 2D array must always remain a 2D array, but 
+%                                  can be modified in either of the two dimensions.
+%
+% nix.DataArray dynamic child entity properties:
+%   dimensions   access to all dimensions associated with a DataArray.
+%   sources      access to all first level nix.Source child entities.
+%   sections     access to all first level nix.Section child entities.
+%
+% See also nix.Source, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,15 +61,13 @@
 % LICENSE file in the root of the Project.
 
 classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    %DataArray nix DataArray object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'DataArray'
+        alias = 'DataArray'  % nix-mx namespace to access DataArray specific nix backend functions.
     end
 
     properties (Dependent)
-        dimensions % should not be dynamic due to complex set operation
+        dimensions % should not be dynamic due to complex set operation.
     end
 
     methods
@@ -37,6 +89,14 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function dimensions = get.dimensions(obj)
+            % Get all Dimensions associated with this DataArray.
+            %
+            % Returns:  ([nix.Dimension]) A list of all associated Dimensions.
+            %
+            % Example:  dims = currDataArray.dimensions;
+            %
+            % See also nix.RangeDimension, nix.SampledDimension, nix.SetDimension.
+
             dimensions = {};
             fname = strcat(obj.alias, '::dimensions');
             currList = nix_mx(fname, obj.nixhandle);
@@ -58,32 +118,93 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = appendSetDimension(obj)
+            % Append a new SetDimension as last entry to the list of existing 
+            % dimension descriptors of the invoking DataArray.
+            %
+            % Used to provide labels for dimensionless data e.g. when stacking 
+            % different signals. In the example the first dimension would
+            % describe the measured unit, the section dimension the time,
+            % the third dimension would provide labels for three different
+            % signals measured within the same experiment and packed into
+            % the same 3D DataArray.
+            %
+            % Returns:  (nix.SetDimension) The newly created SetDimension.
+            %
+            % Example:  dim = currDataArray.appendSetDimension();
+            %
+            % See also nix.SetDimension.
+
             fname = strcat(obj.alias, '::appendSetDimension');
             h = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.createEntity(h, @nix.SetDimension);
         end
 
         function r = appendSampledDimension(obj, interval)
+            % Append a new SampledDimension as last entry to the list of 
+            % existing dimension descriptors of the invoking DataArray.
+            %
+            % Used to describe the regularly sampled dimension of data.
+            %
+            % interval (double):  The sampling interval of the Dimension to create.
+            %
+            % Returns:  (nix.SampledDimension) The newly created SampledDimension.
+            %
+            % Example:  stepSize = 5;
+            %           dim = currDataArray.appendSampledDimension(stepSize);
+            %
+            % See also nix.SampledDimension.
+
             fname = strcat(obj.alias, '::appendSampledDimension');
             h = nix_mx(fname, obj.nixhandle, interval);
             r = nix.Utils.createEntity(h, @nix.SampledDimension);
         end
 
         function r = appendRangeDimension(obj, ticks)
+            % Append a new SampledDimension as last entry to the list of 
+            % existing dimension descriptors of the invoking DataArray.
+            %
+            % Used to describe the irregularly sampled dimension of data.
+            %
+            % ticks ([double]):  The ticks of the RangeDimension.
+            %
+            % Returns:  (nix.RangeDimension) The newly created RangeDimension.
+            %
+            % Example:  dim = currDataArray.appendRangeDimension([1 10 21 15]);
+            %
+            % See also nix.SampledDimension.
+
             fname = strcat(obj.alias, '::appendRangeDimension');
             h = nix_mx(fname, obj.nixhandle, ticks);
             r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
         function r = appendAliasRangeDimension(obj)
+            % Append a new RangeDimension that uses the data stored in the invoking 
+            % DataArray as ticks.
+            % This works only(!) if the DataArray is 1D and the stored data is numeric.
+            %
+            % Returns:  (nix.RangeDimension) The newly created RangeDimension.
+            %
+            % Example:  dim = currDataArray.appendAliasRangeDimension();
+            %
+            % See also nix.RangeDimension.
+
             fname = strcat(obj.alias, '::appendAliasRangeDimension');
             h = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.createEntity(h, @nix.RangeDimension);
         end
 
         function r = openDimensionIdx(obj, idx)
-        % Getting the dimension by index starts with 1
-        % instead of 0 compared to all other index functions.
+            % Returns the Dimension entity for the specified dimension of the data.
+            %
+            % idx (double):  The index of the respective Dimension.
+            %
+            % Returns:  (nix.Dimension) The corresonding Dimension.
+            %
+            % Example:  dim = currDataArray.openDimensionIdx(2);
+            %
+            % See also nix.RangeDimension, nix.SampledDimension, nix.SetDimension.
+
             fname = strcat(obj.alias, '::openDimensionIdx');
             dim = nix_mx(fname, obj.nixhandle, idx);
             switch (dim.dimensionType)
@@ -97,11 +218,24 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = deleteDimensions(obj)
+            % Remove all Dimensions from the invoking DataArray.
+            %
+            % Returns:  (logical) True if the Dimensions were removed,
+            %                       False otherwise.
+            %
+            % Example:  check = currDataArray.deleteDimensions();
+
             fname = strcat(obj.alias, '::deleteDimensions');
             r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = dimensionCount(obj)
+            % Get the number of nix.Dimensions associated with the invoking DataArray.
+            %
+            % Returns:  (uint) The number of Dimensions.
+            %
+            % Example:  dc = currDataArray.dimensionCount();
+
             r = nix.Utils.fetchEntityCount(obj, 'dimensionCount');
         end
 
@@ -110,6 +244,15 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function r = readAllData(obj)
+            % Returns an array with the complete raw data stored in the 
+            % DataArray.
+            %
+            % The returned data is read-only, changes will not be written to file.
+            %
+            % Returns:  (var) The complete raw data.
+            %
+            % Example:  data = currDataArray.readAllData();
+
             fname = strcat(obj.alias, '::readAll');
             data = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.transposeArray(data);
@@ -119,6 +262,14 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         %-- If a DataArray has been created as boolean or numeric,
         %-- provide that only values of the proper DataType can be written.
         function [] = writeAllData(obj, data)
+            % Writes raw data to the invoking DataArray.
+            %
+            % DataType and extent of the written data has to 
+            % match the invoking DataArray.
+            %
+            % Example:  dataSet = ones(15, 15, 15);
+            %           currDataArray.writeAllData(dataSet);
+
             if (isinteger(obj.readAllData) && isfloat(data))
                 disp('Warning: Writing Float data to an Integer DataArray');
             end
@@ -147,20 +298,31 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = datatype(obj)
+            % Returns the datatype of the data stored by the invoking DataArray.
+            %
+            % Example:  dt = currDataArray.datatype;
+
             fname = strcat(obj.alias, '::dataType');
             r = nix_mx(fname, obj.nixhandle);
         end
 
-        % Set data extent enables to increase the original size 
-        % of a data array within the same dimensions.
-        % e.g. increase the size of a 2D array [5 10] to another
-        % 2D array [5 11]. Changing the dimensions is not possible
-        % e.g. changing from a 2D array to a 3D array.
-        % Furthermore if the extent shrinks the size of an array
-        % or remodels the size of an array to a completely different
-        % shape, existing data that does not fit into the new shape
-        % will be lost!
         function [] = setDataExtent(obj, extent)
+            % Change the shape of the invoking DataArray.
+            %
+            % Set data extent enables to increase the original size 
+            % of a DataArray within the same dimensions.
+            % e.g. increase the size of a 2D array [5 10] to another
+            % 2D array [5 11]. Changing the dimensions is not possible
+            % e.g. changing from a 2D array to a 3D array.
+            % Furthermore if the extent shrinks the size of an array
+            % or remodels the size of an array to a completely different
+            % shape, existing data that does not fit into the new shape
+            % will be lost!
+            %
+            % extent ([double]):  shape of the DataArray.
+            %
+            % Example:  currDataArray.setDataExtent([12 15]);
+
             fname = strcat(obj.alias, '::setDataExtent');
             nix_mx(fname, obj.nixhandle, extent);
         end

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -47,7 +47,6 @@
 % nix.DataArray dynamic child entity properties:
 %   dimensions   access to all dimensions associated with a DataArray.
 %   sources      access to all first level nix.Source child entities.
-%   sections     access to all first level nix.Section child entities.
 %
 % See also nix.Source, nix.Section.
 %

--- a/+nix/DataArray.m
+++ b/+nix/DataArray.m
@@ -122,7 +122,7 @@ classdef DataArray < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             %
             % Used to provide labels for dimensionless data e.g. when stacking 
             % different signals. In the example the first dimension would
-            % describe the measured unit, the section dimension the time,
+            % describe the measured unit, the second dimension the time,
             % the third dimension would provide labels for three different
             % signals measured within the same experiment and packed into
             % the same 3D DataArray.

--- a/+nix/DataType.m
+++ b/+nix/DataType.m
@@ -1,3 +1,5 @@
+% nix.DataTypes provides access to the DataTypes supported by NIX.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,7 +9,6 @@
 % LICENSE file in the root of the Project.
 
 classdef DataType
-    % DataTypes supported by nix.
 
     enumeration
         Bool;

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -1,4 +1,4 @@
-% Dynamic class implements methods to dynamically assign properties.
+% Class implements methods to dynamically assign properties.
 %
 % Utility class, do not use out of context.
 %

--- a/+nix/Dynamic.m
+++ b/+nix/Dynamic.m
@@ -1,3 +1,8 @@
+% Dynamic class implements methods to dynamically assign properties.
+%
+% Utility class, do not use out of context.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +12,6 @@
 % LICENSE file in the root of the Project.
 
 classdef Dynamic
-    % Dynamic class (with static methods hehe)
-    % implements methods to dynamically assigns properties 
 
     methods (Static)
         function addProperty(obj, prop, mode)

--- a/+nix/Entity.m
+++ b/+nix/Entity.m
@@ -1,3 +1,11 @@
+% Entity base class for nix entities.
+%
+% Class provides access to the info property and handles the lifetime
+% of a nix entitiy.
+%
+% Utility class, do not use out of context.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +15,6 @@
 % LICENSE file in the root of the Project.
 
 classdef Entity < dynamicprops
-    % Entity base class for nix entities
-    %   handles object lifetime
 
     properties (Hidden)
         nixhandle
@@ -32,6 +38,8 @@ classdef Entity < dynamicprops
         end
 
         function r = updatedAt(obj)
+            % Provides the time the entity was last updated.
+
             r = nix_mx('Entity::updatedAt', obj.nixhandle);
         end
 

--- a/+nix/Entity.m
+++ b/+nix/Entity.m
@@ -1,4 +1,4 @@
-% Entity base class for nix entities.
+% Base class for nix entities.
 %
 % Class provides access to the info property and handles the lifetime
 % of a nix entitiy.

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -1,3 +1,35 @@
+% nix.Feature class provides additional functionality to nix.Tag and nix.MultiTag.
+%
+% Features are created from a nix.Tag or a nix.MultiTag, linking these to an
+% additional nix.DataArray. The way how data from the respective DataArray
+% and the Tag/MultiTag are connected, is specified by the nix.LinkType of
+% the associated nix.Feature.
+%
+% nix.Property properties:
+%   id (char):                read-only, automatically created id of the entity.
+%   linkType (nix.LinkType):  see nix.LinkType description below.
+%
+% nix.LinkType.Tagged
+%   This LinkType indicates, that the position and extent will be applied also 
+%   to the data stored via the Feature when it is fetched via the Tag/MultiTag.
+%
+% nix.LinkType.Untagged
+%   This implies that the whole data stored in the linked DataArray belongs to
+%   the Feature.
+%
+% nix.LinkType.Indexed
+%   This LinkType is only valid for MultiTags where it indicates that the data linked 
+%   via this Feature has to be accessed according to the index in the respective 
+%   MulitTag position entry.
+%
+% Examples:  %-- Returns the Features LinkType.
+%            lt = currFeature.linkType();
+%            %-- Sets the Feature LinkType. Has to be a valid nix.LinkType.
+%            currFeature.linkType(nix.LinkType.Tagged);
+%
+% See also nix.LinkType, nix.DataArray, nix.Tag, nix.MultiTag.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +39,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Feature < nix.Entity
-    % Feature nix Feature object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Feature'
+        alias = 'Feature'  % nix-mx namespace to access Feature specific nix backend functions.
     end
 
     properties (Dependent)
@@ -39,15 +69,38 @@ classdef Feature < nix.Entity
         end
 
         function r = openData(obj)
+            % Returns the DataArray referenced by the invoking Feature.
+            %
+            % Returns:  (nix.DataArray) The unmodified DataArray entity
+            %                           referenced by the invoking Feature.
+            %
+            % Example: getDataArray = currFeature.openData();
+            %
+            % See also nix.DataArray.
+
             fname = strcat(obj.alias, '::openData');
             h = nix_mx(fname, obj.nixhandle);
             r = nix.Utils.createEntity(h, @nix.DataArray);
         end
 
-        function [] = setData(obj, data)
-            id = nix.Utils.parseEntityId(data, 'nix.DataArray');
+        function [] = setData(obj, idNameEntity)
+            % Sets the DataArray referenced by the invoking Feature.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the DataArray to be set 
+            %                                     or the DataArray itself. Sets the 
+            %                                     reference to the DataArray associated 
+            %                                     with the invoking Feature. Will replace
+            %                                     any previous set reference.
+            %
+            % Example:  currFeature.setData('some-data-array-id');
+            %           currFeature.setData('sessionData1');
+            %           currFeature.setData(dataArrayEntity);
+            %
+            % See also nix.DataArray.
+
+            parsed = nix.Utils.parseEntityId(idNameEntity, 'nix.DataArray');
             fname = strcat(obj.alias, '::setData');
-            nix_mx(fname, obj.nixhandle, id);
+            nix_mx(fname, obj.nixhandle, parsed);
         end
     end
 

--- a/+nix/Feature.m
+++ b/+nix/Feature.m
@@ -9,6 +9,9 @@
 %   id (char):                read-only, automatically created id of the entity.
 %   linkType (nix.LinkType):  see nix.LinkType description below.
 %
+%   info (struct):  Entity property summary. The values in this structure are detached
+%                   from the entity, changes will not be persisted to the file.
+%
 % nix.LinkType.Tagged
 %   This LinkType indicates, that the position and extent will be applied also 
 %   to the data stored via the Feature when it is fetched via the Tag/MultiTag.
@@ -41,7 +44,7 @@
 classdef Feature < nix.Entity
 
     properties (Hidden)
-        alias = 'Feature'  % nix-mx namespace to access Feature specific nix backend functions.
+        alias = 'Feature'  % namespace for Feature nix backend function access.
     end
 
     properties (Dependent)

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -1,3 +1,19 @@
+% nix.File class grants access to all NIX operations.
+%
+% A File represents a specific data source of a NIX back-end for example an NIX HDF5 file.
+% All entities of the nix data model (except the Value entity) must exist in the context 
+% of an open File object. Therefore NIX entities cannot be initialized via their 
+% constructors but only through the factory methods of their respective parent entity.
+%
+% When a file variable is cleared, the handle to the file will be automatically closed.
+%
+% nix.File properties:
+%   blocks      access to all nix.Block child entities.
+%   sections    access to all first level nix.Section child entities.
+%
+% See also nix.Block, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,38 +23,63 @@
 % LICENSE file in the root of the Project.
 
 classdef File < nix.Entity
-    % File nix File object
 
-    properties(Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'File'
+    properties (Hidden)
+        alias = 'File'  % nix-mx namespace to access File specific nix backend functions.
     end
 
     methods
         function obj = File(path, mode)
+            % File constructor used to open or create a nix.File.
+            %
+            % path (char):  path to a file to open or create.
+            % mode (char):  requires a valid nix.FileMode. Defaults to 
+            %                 nix.FileMode.ReadWrite if no FileMode is provided.
+            %
+            % Returns: (nix.File).
+            %
+            % See also nix.FileMode.
+
             if (~exist('mode', 'var'))
-                mode = nix.FileMode.ReadWrite; %default to ReadWrite
+                mode = nix.FileMode.ReadWrite; % default to ReadWrite
             end
             h = nix_mx('File::open', path, mode); 
             obj@nix.Entity(h);
 
-            % assign relations
+            % assign child entites
             nix.Dynamic.addGetChildEntities(obj, 'blocks', @nix.Block);
             nix.Dynamic.addGetChildEntities(obj, 'sections', @nix.Section);
         end
 
         % braindead...
         function r = isOpen(obj)
+            % Check if the file is currently open.
+            %
+            % Returns:  (logical) True if the file is open, False otherwise.
+
             fname = strcat(obj.alias, '::isOpen');
             r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = fileMode(obj)
+            % Get the mode in which the file has been opened.
+            %
+            % Returns: (nix.FileMode).
+            %
+            % See also nix.FileMode.
+
             fname = strcat(obj.alias, '::fileMode');
             r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = validate(obj)
+            % Runs a backend validator over all contained entities and returns a
+            % custom struct with warnings and error messages, if the current content
+            % of the file violates the NIX datamodel as well as the ids of the 
+            % offending entities.
+            %
+            % Returns:  (struct) Custom warning/error struct.
+
             fname = strcat(obj.alias, '::validate');
             r = nix_mx(fname, obj.nixhandle);
         end
@@ -48,33 +89,120 @@ classdef File < nix.Entity
         % ----------------
 
         function r = createBlock(obj, name, type)
+            % Create a new nix.Block entity, that is immediately persisted to the file.
+            %
+            %   name (char):  the name of the Block, has to be unique within the file.
+            %                 read only Block property.
+            %   type (char):  the type of the Block, required.
+            %                 Type can be used to give semantic meaning to an entity
+            %                 and expose it to search methods in a broader context.
+            %                 read/write Block property.
+            %
+            %   Returns:  (nix.Block) The newly created Block.
+            %
+            %   Example:  newBlock = f.createBlock('trial1', 'ephys');
+            %
+            % See also nix.Block.
+
             fname = strcat(obj.alias, '::createBlock');
             h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Block);
         end
 
         function r = blockCount(obj)
+            % Get the number of Blocks in the file.
+            %
+            % Returns:  (uint) The number of Blocks.
+            %
+            % Example:  bc = f.blockCount();
+            %
+            % See also nix.Block.
+
             r = nix.Utils.fetchEntityCount(obj, 'blockCount');
         end
 
         function r = hasBlock(obj, idName)
+            % Check if a Block exists in the file.
+            %
+            % idName (char):  Name or ID of the Block.
+            %
+            % Returns:  (logical) True if the Block exists, false otherwise.
+            %
+            % Example:  check = f.hasBlock('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = f.hasBlock('trial1');
+            %
+            % See also nix.Block.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasBlock', idName);
         end
 
         function r = openBlock(obj, idName)
+            % Retrieves an existing Block from the file.
+            %
+            % idName (char):  Name or ID of the Block.
+            %
+            % Returns:  (nix.Block) The nix.Block or an empty cell, 
+            %                       if the Block was not found.
+            %
+            % Example:  getBlock = f.openBlock('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getBlock = f.openBlock('trial1');
+            %
+            % See also nix.Block.
+
             r = nix.Utils.openEntity(obj, 'openBlock', idName, @nix.Block);
         end
 
         function r = openBlockIdx(obj, index)
+            % Retrieves an existing Block from the file, accessed by index.
+            %
+            % index (double):  The index of the Block to read.
+            %
+            % Returns:  (nix.Block) The Block at the given index.
+            %
+            % Example:  getBlock = f.openBlockIdx(1);
+            %
+            % See also nix.Block.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openBlockIdx', idx, @nix.Block);
         end
 
-        function r = deleteBlock(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteBlock', del, 'nix.Block');
+        function r = deleteBlock(obj, idNameEntity)
+            % Deletes a Block from the file.
+            %
+            % When a Block is deleted, all its content (DataArray, Tags, Sources, etc)
+            % will be deleted from the file as well.
+            %
+            % idNameEntity (char/nix.Block):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Block has been removed, false otherwise.
+            %
+            % Example:  check = f.deleteBlock('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = f.deleteBlock('trial1');
+            %           check = f.deleteBlock(newBlock);
+            %
+            % See also nix.Block.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteBlock', idNameEntity, 'nix.Block');
         end
 
         function r = filterBlocks(obj, filter, val)
+            % Get a filtered cell array of all Blocks within this file.
+            %
+            % filter (nix.Filter):  the nix.Filter to be applied. Supports
+            %                       the filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Block]) A cell array of Blocks filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getBlocks = f.filterBlocks(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Block, nix.Filter.
+
             r = nix.Utils.filter(obj, 'blocksFiltered', filter, val, @nix.Block);
         end
 
@@ -83,43 +211,162 @@ classdef File < nix.Entity
         % ----------------
 
         function r = createSection(obj, name, type)
+            % Create a new nix.Section entity, that is immediately persisted to the file.
+            %
+            %   name (char):  the name of the Section, has to be unique within the file.
+            %                 read only Section property.
+            %   type (char):  the type of the Section, required.
+            %                 Type can be used to give semantic meaning to an entity
+            %                 and expose it to search methods in a broader context.
+            %                 read/write Section property.
+            %
+            %   Returns:  (nix.Section) The newly created Section.
+            %
+            %   Example:  newSec = f.createSection('settings1', 'ephys');
+            %
+            % See also nix.Section.
+
             fname = strcat(obj.alias, '::createSection');
             h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Section);
         end
 
         function r = sectionCount(obj)
+            % Get the number of root Sections in the file.
+            %
+            % Returns:  (uint) The number of root (non nested) Sections.
+            %
+            % Example:  sc = f.sectionCount();
+            %
+            % See also nix.Section.
+
             r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
         function r = hasSection(obj, idName)
+            % Check if a Section exists as a direct child of the file.
+            %
+            % idName (char):  Name or ID of the Section.
+            %
+            % Returns:  (logical) True if the Section exists, false otherwise.
+            %
+            % Example:  check = f.hasSection('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = f.hasSection('settings1');
+            %
+            % See also nix.Section.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasSection', idName);
         end
 
         function r = openSection(obj, idName)
+            % Retrieves an existing Section from the file.
+            %
+            % idName (char):  Name or ID of the Section.
+            %
+            % Returns:  (nix.Section) The nix.Section or an empty cell, 
+            %                       if the Section was not found.
+            %
+            % Example:  getSec = f.openSection('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getSec = f.openSection('settings1');
+            %
+            % See also nix.Section.
+
             r = nix.Utils.openEntity(obj, 'openSection', idName, @nix.Section);
         end
 
         function r = openSectionIdx(obj, index)
+            % Retrieves an existing Section from the file, accessed by index.
+            %
+            % index (double):  The index of the Section to read.
+            %
+            % Returns:  (nix.Section) The Section at the given index.
+            %
+            % Example:  getSec = f.openSectionIdx(1);
+            %
+            % See also nix.Section.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
-        function r = deleteSection(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteSection', del, 'nix.Section');
+        function r = deleteSection(obj, idNameEntity)
+            % Deletes a Section from the file.
+            %
+            % When a Section is deleted, all of its child Sections, Properties and 
+            % Values will be deleted from the file as well.
+            %
+            % idNameEntity (char/nix.Section):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Section has been removed, false otherwise.
+            %
+            % Example:  check = f.deleteSection('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = f.deleteSection('settings1');
+            %           check = f.deleteSection(newSec);
+            %
+            % See also nix.Section.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteSection', idNameEntity, 'nix.Section');
         end
 
         function r = filterSections(obj, filter, val)
+            % Get a filtered cell array of all root Sections within this file.
+            %
+            % filter (nix.Filter):  the nix.Filter to be applied. Supports
+            %                       the filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Section]) A cell array of Sections filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getSecs = f.filterSections(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Section, nix.Filter.
+
             r = nix.Utils.filter(obj, 'sectionsFiltered', filter, val, @nix.Section);
         end
 
-        % maxdepth is an index
         function r = findSections(obj, maxDepth)
+            % Get all Sections and their child Sections in this file recursively.
+            %
+            % This method traverses the trees of all Sections in the file and adds all
+            % Sections to the resulting cell array, until the maximum depth of the nested
+            % Sections has been reached. The traversal is accomplished via breadth first 
+            % and adds the Sections accordingly.
+            %
+            % maxDepth (double):  The maximum depth of traversal to retrieve nested 
+            %                     Sections. Should be handled like an index.
+            %
+            % Example:  allSec = f.findSections(2);
+            %           % will add all Sections until including the 2nd layer of Sections.
+            %
+            % See also nix.Section.
+
             r = obj.filterFindSections(maxDepth, nix.Filter.acceptall, '');
         end
 
-        % maxdepth is an index
         function r = filterFindSections(obj, maxDepth, filter, val)
+            % Get all Sections in this file recursively.
+            %
+            % This method traverses the trees of all Sections in the file. The traversal
+            % is accomplished via breadth first and can be limited in depth. On each 
+            % node or Section a nix.Filter is applied. If the filter returns true, the 
+            % respective Section will be added to the result list.
+            %
+            % maxDepth (double):    The maximum depth of traversal to retrieve nested 
+            %                       Sections. Should be handled like an index.
+            % filter (nix.Filter):  the nix.Filter to be applied. Supports
+            %                       the filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Example:  allSec = f.filterFindSections(2, nix.Filter.type, 'ephys');
+            %
+            % See also nix.Section, nix.Filter.
+
             r = nix.Utils.find(obj, 'findSections', maxDepth, filter, val, @nix.Section);
         end
     end

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -11,6 +11,9 @@
 %   blocks      access to all nix.Block child entities.
 %   sections    access to all first level nix.Section child entities.
 %
+% Example opening a NIX file:
+%   getFileAccess = nix.File('/path/to/file', nix.FileMode.ReadWrite);
+%
 % See also nix.Block, nix.Section.
 %
 %
@@ -32,11 +35,13 @@ classdef File < nix.Entity
         function obj = File(path, mode)
             % File constructor used to open or create a nix.File.
             %
-            % path (char):  path to a file to open or create.
-            % mode (char):  requires a valid nix.FileMode. Defaults to 
-            %                 nix.FileMode.ReadWrite if no FileMode is provided.
+            % path (char):  Path to a file to open or create.
+            % mode (char):  Requires a valid nix.FileMode. Defaults to 
+            %               nix.FileMode.ReadWrite if no FileMode is provided.
             %
             % Returns: (nix.File).
+            %
+            % Example:  getFileAccess = nix.File('/path/to/file', nix.FileMode.ReadWrite);
             %
             % See also nix.FileMode.
 
@@ -56,6 +61,8 @@ classdef File < nix.Entity
             % Check if the file is currently open.
             %
             % Returns:  (logical) True if the file is open, False otherwise.
+            %
+            % Example:  check = currFile.isOpen();
 
             fname = strcat(obj.alias, '::isOpen');
             r = nix_mx(fname, obj.nixhandle);
@@ -65,6 +72,8 @@ classdef File < nix.Entity
             % Get the mode in which the file has been opened.
             %
             % Returns: (nix.FileMode).
+            %
+            % Example:  getFileMode = currFile.fileMode();
             %
             % See also nix.FileMode.
 
@@ -79,6 +88,8 @@ classdef File < nix.Entity
             % offending entities.
             %
             % Returns:  (struct) Custom warning/error struct.
+            %
+            % Example: checkFile = currFile.validate();
 
             fname = strcat(obj.alias, '::validate');
             r = nix_mx(fname, obj.nixhandle);
@@ -91,16 +102,14 @@ classdef File < nix.Entity
         function r = createBlock(obj, name, type)
             % Create a new nix.Block entity, that is immediately persisted to the file.
             %
-            %   name (char):  the name of the Block, has to be unique within the file.
-            %                 read only Block property.
-            %   type (char):  the type of the Block, required.
-            %                 Type can be used to give semantic meaning to an entity
-            %                 and expose it to search methods in a broader context.
-            %                 read/write Block property.
+            % name (char):  The name of the Block, has to be unique within the file.
+            % type (char):  The type of the Block, required.
+            %               Type can be used to give semantic meaning to an entity
+            %               and expose it to search methods in a broader context.
             %
-            %   Returns:  (nix.Block) The newly created Block.
+            % Returns:  (nix.Block) The newly created Block.
             %
-            %   Example:  newBlock = f.createBlock('trial1', 'ephys');
+            % Example:  newBlock = f.createBlock('trial1', 'ephys');
             %
             % See also nix.Block.
 
@@ -174,7 +183,7 @@ classdef File < nix.Entity
             % will be deleted from the file as well.
             %
             % idNameEntity (char/nix.Block):  Name or id of the entity to
-            %                                   be deleted or the entity itself.
+            %                                 be deleted or the entity itself.
             %
             % Returns:  (logical) True if the Block has been removed, false otherwise.
             %
@@ -190,14 +199,14 @@ classdef File < nix.Entity
         function r = filterBlocks(obj, filter, val)
             % Get a filtered cell array of all Blocks within this file.
             %
-            % filter (nix.Filter):  the nix.Filter to be applied. Supports
-            %                       the filters 'acceptall', 'id', 'ids',
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       The filters 'acceptall', 'id', 'ids',
             %                       'name' and 'type'.
             % val (char):           Value that is applied with the selected
             %                       filter.
             %
             % Returns:  ([nix.Block]) A cell array of Blocks filtered according
-            %                           to the applied nix.Filter.
+            %                         to the applied nix.Filter.
             %
             % Example:  getBlocks = f.filterBlocks(nix.Filter.type, 'ephys');
             %
@@ -213,16 +222,14 @@ classdef File < nix.Entity
         function r = createSection(obj, name, type)
             % Create a new nix.Section entity, that is immediately persisted to the file.
             %
-            %   name (char):  the name of the Section, has to be unique within the file.
-            %                 read only Section property.
-            %   type (char):  the type of the Section, required.
-            %                 Type can be used to give semantic meaning to an entity
-            %                 and expose it to search methods in a broader context.
-            %                 read/write Section property.
+            % name (char):  The name of the Section, has to be unique within the file.
+            % type (char):  The type of the Section, required.
+            %               Type can be used to give semantic meaning to an entity
+            %               and expose it to search methods in a broader context.
             %
-            %   Returns:  (nix.Section) The newly created Section.
+            % Returns:  (nix.Section) The newly created Section.
             %
-            %   Example:  newSec = f.createSection('settings1', 'ephys');
+            % Example:  newSec = f.createSection('settings1', 'ephys');
             %
             % See also nix.Section.
 
@@ -232,9 +239,9 @@ classdef File < nix.Entity
         end
 
         function r = sectionCount(obj)
-            % Get the number of root Sections in the file.
+            % Get the number of direct child Sections in the file.
             %
-            % Returns:  (uint) The number of root (non nested) Sections.
+            % Returns:  (uint) The number of direct child (non nested) Sections.
             %
             % Example:  sc = f.sectionCount();
             %
@@ -264,7 +271,7 @@ classdef File < nix.Entity
             % idName (char):  Name or ID of the Section.
             %
             % Returns:  (nix.Section) The nix.Section or an empty cell, 
-            %                       if the Section was not found.
+            %                         if the Section was not found.
             %
             % Example:  getSec = f.openSection('23bb8a99-1812-4bc6-a52c-45e96864756b');
             %           getSec = f.openSection('settings1');
@@ -275,7 +282,7 @@ classdef File < nix.Entity
         end
 
         function r = openSectionIdx(obj, index)
-            % Retrieves an existing Section from the file, accessed by index.
+            % Retrieves an Section from the file, accessed by index.
             %
             % index (double):  The index of the Section to read.
             %
@@ -312,8 +319,8 @@ classdef File < nix.Entity
         function r = filterSections(obj, filter, val)
             % Get a filtered cell array of all root Sections within this file.
             %
-            % filter (nix.Filter):  the nix.Filter to be applied. Supports
-            %                       the filters 'acceptall', 'id', 'ids',
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       The filters 'acceptall', 'id', 'ids',
             %                       'name' and 'type'.
             % val (char):           Value that is applied with the selected
             %                       filter.
@@ -357,11 +364,9 @@ classdef File < nix.Entity
             %
             % maxDepth (double):    The maximum depth of traversal to retrieve nested 
             %                       Sections. Should be handled like an index.
-            % filter (nix.Filter):  the nix.Filter to be applied. Supports
-            %                       the filters 'acceptall', 'id', 'ids',
-            %                       'name' and 'type'.
-            % val (char):           Value that is applied with the selected
-            %                       filter.
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports the filters 
+            %                       'acceptall', 'id', 'ids', 'name' and 'type'.
+            % val (char):           Value that is applied with the selected filter.
             %
             % Example:  allSec = f.filterFindSections(2, nix.Filter.type, 'ephys');
             %

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -8,6 +8,10 @@
 % When a file variable is cleared, the handle to the file will be automatically closed.
 %
 % nix.File dynamic properties:
+%   info (struct):  Entity property summary. The values in this structure are detached
+%                   from the entity, changes will not be persisted to the file.
+%
+% nix.File dynamic child entity properties:
 %   blocks      access to all nix.Block child entities.
 %   sections    access to all first level nix.Section child entities.
 %
@@ -28,7 +32,7 @@
 classdef File < nix.Entity
 
     properties (Hidden)
-        alias = 'File'  % nix-mx namespace to access File specific nix backend functions.
+        alias = 'File'  % namespace for File nix backend function access.
     end
 
     methods

--- a/+nix/File.m
+++ b/+nix/File.m
@@ -7,7 +7,7 @@
 %
 % When a file variable is cleared, the handle to the file will be automatically closed.
 %
-% nix.File properties:
+% nix.File dynamic properties:
 %   blocks      access to all nix.Block child entities.
 %   sections    access to all first level nix.Section child entities.
 %

--- a/+nix/FileMode.m
+++ b/+nix/FileMode.m
@@ -1,3 +1,5 @@
+% nix.FileMode provides access to the Modes a NIX file can be opened.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,7 +9,6 @@
 % LICENSE file in the root of the Project.
 
 classdef FileMode
-    % FILEMODE nix file open modes
 
     properties (Constant)
         ReadOnly = uint8(0);

--- a/+nix/Filter.m
+++ b/+nix/Filter.m
@@ -1,5 +1,29 @@
+% nix.Filter provides access to all filters supported by nix filter functions.
+%
+% 'acceptall'  returns an unfiltered result; requires an empty value.
+% 'id'         returns all entities matching the provided id string.
+% 'ids'        returns all entities matching the provided ids. id strings
+%                have to be provided as a cell array.
+% 'type'       returns all entities where their type matches the provided string.
+% 'name'       returns all entities where their name matches the provided string.
+% 'metadata'   returns all entities which link to a Section with the
+%                provided id string.
+% 'source'     returns all entities which link to a Source with the
+%                provided id or name string.
+%
+% Please note, that not all filter functions support every filter listed
+% here. Consult the documentation for every filter function for details.
+%
+%
+% Copyright (c) 2017, German Neuroinformatics Node (G-Node)
+%
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted under the terms of the BSD License. See
+% LICENSE file in the root of the Project.
+
 classdef Filter < uint8
-    % FILTER available nix custom filters
 
     enumeration
         acceptall (0); % requires an empty value

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -15,6 +15,9 @@
 %                         entity and expose it to search methods in a broader context.
 %   definition (char):  read-write, additional description of the entity.
 %
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
+%
 % nix.Group dynamic child entity properties:
 %   dataArrays   access to all nix.DataArray child entities.
 %   tags         access to all nix.Tag child entities.
@@ -35,7 +38,7 @@
 classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
     properties (Hidden)
-        alias = 'Group'  % nix-mx namespace to access Group specific nix backend functions.
+        alias = 'Group'  % namespace for Group nix backend function access.
     end
 
     methods

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -20,7 +20,6 @@
 %   tags         access to all nix.Tag child entities.
 %   multiTags    access to all nix.MultiTag child entities.
 %   sources      access to all first level nix.Source child entities.
-%   sections     access to all first level nix.Section child entities.
 %
 % See also nix.DataArray, nix.Tag, nix.MultiTag, nix.Source, nix.Section.
 %

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -1,3 +1,30 @@
+% nix.Group class for basic grouping of further data entities.
+%
+% nix.Groups establish a simple way of grouping entities that in some way belong 
+% together. The Group exists inside a Block and can contain (link) DataArrays, Tags, 
+% and MultiTags. As any other nix-entity, the Group is named, has a type, and a 
+% definition property. Additionally, it contains DataArray, Tag, and MultiTag 
+% lists. As indicated before, a Group does only link the entities. Thus, deleting 
+% elements from a Group element does not remove them from file, it merely removes the link 
+% from the Group.
+%
+% nix.Group dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, additional description of the entity.
+%
+% nix.Group dynamic child entity properties:
+%   dataArrays   access to all nix.DataArray child entities.
+%   tags         access to all nix.Tag child entities.
+%   multiTags    access to all nix.MultiTag child entities.
+%   sources      access to all first level nix.Source child entities.
+%   sections     access to all first level nix.Section child entities.
+%
+% See also nix.DataArray, nix.Tag, nix.MultiTag, nix.Source, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +34,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    % Group nix Group object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Group'
+        alias = 'Group'  % nix-mx namespace to access Group specific nix backend functions.
     end
 
     methods
@@ -20,7 +45,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             obj@nix.MetadataMixIn();
             obj@nix.SourcesMixIn();
 
-            % assign relations
+            % assign child entities
             nix.Dynamic.addGetChildEntities(obj, 'dataArrays', @nix.DataArray);
             nix.Dynamic.addGetChildEntities(obj, 'tags', @nix.Tag);
             nix.Dynamic.addGetChildEntities(obj, 'multiTags', @nix.MultiTag);
@@ -31,35 +56,129 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % -----------------
 
         function r = dataArrayCount(obj)
+            % Get the number of child nix.DataArrays.
+            %
+            % Returns:  (uint) The number of child DataArrays.
+            %
+            % Example:  dc = currGroup.dataArrayCount();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchEntityCount(obj, 'dataArrayCount');
         end
 
         function r = hasDataArray(obj, idName)
+            % Check if a nix.DataArray exists as a child of the Group.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (logical) True if the DataArray exists, false otherwise.
+            %
+            % Example:  check = currGroup.hasDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.groups{1}.hasDataArray('sessionData2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasDataArray', idName);
         end
 
-        function r = getDataArray(obj, idName)
+        function r = openDataArray(obj, idName)
+            % Retrieves an existing DataArray from the invoking Group.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (nix.DataArray) The nix.DataArray or an empty cell, 
+            %                       if the DataArray was not found.
+            %
+            % Example:  getDA = currGroup.openDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getDA = currFile.blocks{1}.groups{1}.openDataArray('subTrial2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.openEntity(obj, 'getDataArray', idName, @nix.DataArray);
         end
 
         function r = openDataArrayIdx(obj, index)
+            % Retrieves an existing nix.DataArray from the invoking Group, 
+            % accessed by index.
+            %
+            % index (double):  The index of the DataArray to read.
+            %
+            % Returns:  (nix.DataArray) The DataArray at the given index.
+            %
+            % Example:  getDA = currGroup.openDataArrayIdx(1);
+            %
+            % See also nix.DataArray.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openDataArrayIdx', idx, @nix.DataArray);
         end
 
-        function [] = addDataArray(obj, entity)
-            nix.Utils.addEntity(obj, 'addDataArray', entity, 'nix.DataArray');
+        function [] = addDataArray(obj, idNameEntity)
+            % Add a nix.DataArray to referenced list of the invoking Group.
+            %
+            % idNameEntity (char/nix.DataArray):  The id or name of an existing DataArray,
+            %                                     or a valid nix.DataArray entity.
+            %
+            % Example:  currGroup.addDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currGroup.addDataArray('subTrial2');
+            %           currFile.blocks{1}.groups{1}.addDataArray(currDataArrayEntity);
+            %
+            % See also nix.DataArray.
+
+            nix.Utils.addEntity(obj, 'addDataArray', idNameEntity, 'nix.DataArray');
         end
 
         function [] = addDataArrays(obj, entityArray)
+            % Set the list of referenced DataArrays for the invoking Group.
+            %
+            % Previously referenced DataArrays that are not in the
+            % references cell array will be removed.
+            %
+            % entityArray ([nix.DataArray]):  A cell array of nix.DataArrays.
+            %
+            % Example:  currGroup.addDataArrays({dataArray1, dataArray2});
+            %
+            % See also nix.DataArray.
+
             nix.Utils.addEntityArray(obj, 'addDataArrays', entityArray, 'nix.DataArray');
         end
 
-        function r = removeDataArray(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'removeDataArray', del, 'nix.DataArray');
+        function r = removeDataArray(obj, idNameEntity)
+            % Removes the reference to a nix.DataArray from the invoking Group.
+            %
+            % This method removes the association between the DataArray and the
+            % Group, the DataArray itself will not be removed from the file.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the reference to the DataArray 
+            %                     has been removed, false otherwise.
+            %
+            % Example:  check = currGroup.removeDataArray('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currGroup.removeDataArray('sessionData2');
+            %           check = currFile.blocks{1}.groups{1}.removeDataArray(newDataArray);
+            %
+            % See also nix.DataArray.
+
+            r = nix.Utils.deleteEntity(obj, 'removeDataArray', idNameEntity, 'nix.DataArray');
         end
 
         function r = filterDataArrays(obj, filter, val)
+            % Get a filtered cell array of all DataArrays referenced by the invoking Group.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.DataArray]) A cell array of DataArrays filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getDAs = currGroup.filterDataArrays(nix.Filter.type, 'ephys_data');
+            %
+            % See also nix.DataArray, nix.Filter.
+
             r = nix.Utils.filter(obj, 'dataArraysFiltered', filter, val, @nix.DataArray);
         end
 
@@ -67,36 +186,130 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Tags methods
         % -----------------
 
-        function [] = addTag(obj, entity)
-            nix.Utils.addEntity(obj, 'addTag', entity, 'nix.Tag');
+        function [] = addTag(obj, idNameEntity)
+            % Add a nix.Tag to the referenced list of the invoking Group.
+            %
+            % idNameEntity (char/nix.Tag):  The id or name of an existing Tag,
+            %                                     or a valid nix.Tag entity.
+            %
+            % Example:  currGroup.addTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currGroup.addTag('roi_1');
+            %           currFile.blocks{1}.groups{1}.addTag(currTagEntity);
+            %
+            % See also nix.Tag.
+
+            nix.Utils.addEntity(obj, 'addTag', idNameEntity, 'nix.Tag');
         end
 
         function [] = addTags(obj, entityArray)
+            % Set the list of referenced Tags for the invoking Group.
+            %
+            % Previously referenced Tags that are not in the
+            % references cell array will be removed.
+            %
+            % entityArray ([nix.Tag]):  A cell array of nix.Tags.
+            %
+            % Example:  currGroup.addTags({tag1, tag2});
+            %
+            % See also nix.Tag.
+
             nix.Utils.addEntityArray(obj, 'addTags', entityArray, 'nix.Tag');
         end
 
         function r = hasTag(obj, idName)
+            % Check if a nix.Tag exists as a child of the Group.
+            %
+            % idName (char):  Name or ID of the Tag.
+            %
+            % Returns:  (logical) True if the Tag exists, false otherwise.
+            %
+            % Example:  check = currGroup.hasTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.groups{1}.hasTag('roi_1');
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasTag', idName);
         end
 
-        function r = getTag(obj, idName)
+        function r = openTag(obj, idName)
+            % Retrieves an existing Tag from the invoking Group.
+            %
+            % idName (char):  Name or ID of the Tag.
+            %
+            % Returns:  (nix.Tag) The nix.Tag or an empty cell, 
+            %                       if the Tag was not found.
+            %
+            % Example:  getTag = currGroup.openTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getTag = currFile.blocks{1}.groups{1}.openTag('roi_1');
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.openEntity(obj, 'getTag', idName, @nix.Tag);
         end
 
         function r = openTagIdx(obj, index)
+            % Retrieves an existing nix.Tag from the invoking Group, 
+            % accessed by index.
+            %
+            % index (double):  The index of the Tag to read.
+            %
+            % Returns:  (nix.Tag) The Tag at the given index.
+            %
+            % Example:  getTag = currGroup.openTagIdx(1);
+            %
+            % See also nix.Tag.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openTagIdx', idx, @nix.Tag);
         end
 
-        function r = removeTag(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'removeTag', del, 'nix.Tag');
+        function r = removeTag(obj, idNameEntity)
+            % Removes the reference to a nix.Tag from the invoking Group.
+            %
+            % This method removes the association between the Tag and the
+            % Group, the Tag itself will not be removed from the file.
+            %
+            % idNameEntity (char/nix.Tag):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the reference to the Tag 
+            %                     has been removed, false otherwise.
+            %
+            % Example:  check = currGroup.removeTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currGroup.removeTag('roi_1');
+            %           check = currFile.blocks{1}.groups{1}.removeTag(newTag);
+            %
+            % See also nix.Tag.
+
+            r = nix.Utils.deleteEntity(obj, 'removeTag', idNameEntity, 'nix.Tag');
         end
 
         function r = tagCount(obj)
+            % Get the number of child nix.Tags.
+            %
+            % Returns:  (uint) The number of child Tags.
+            %
+            % Example:  tc = currGroup.tagCount();
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.fetchEntityCount(obj, 'tagCount');
         end
 
         function r = filterTags(obj, filter, val)
+            % Get a filtered cell array of all Tags referenced by the invoking Group.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Tag]) A cell array of Tags filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getTags = currGroup.filterTags(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Tag, nix.Filter.
+
             r = nix.Utils.filter(obj, 'tagsFiltered', filter, val, @nix.Tag);
         end
 
@@ -104,36 +317,130 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % MultiTag methods
         % -----------------
 
-        function [] = addMultiTag(obj, entity)
-            nix.Utils.addEntity(obj, 'addMultiTag', entity, 'nix.MultiTag');
+        function [] = addMultiTag(obj, idNameEntity)
+            % Add a nix.MultiTag to the referenced list of the invoking Group.
+            %
+            % idNameEntity (char/nix.MultiTag):  The id or name of an existing MultiTag,
+            %                                     or a valid nix.MultiTag entity.
+            %
+            % Example:  currGroup.addMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currGroup.addMultiTag('roi_2');
+            %           currFile.blocks{1}.groups{1}.addMultiTag(currMultiTagEntity);
+            %
+            % See also nix.MultiTag.
+
+            nix.Utils.addEntity(obj, 'addMultiTag', idNameEntity, 'nix.MultiTag');
         end
 
         function [] = addMultiTags(obj, entityArray)
+            % Set the list of referenced MultiTags for the invoking Group.
+            %
+            % Previously referenced MultiTags that are not in the
+            % references cell array will be removed.
+            %
+            % entityArray ([nix.MultiTag]):  A cell array of nix.MultiTags.
+            %
+            % Example:  currGroup.addMultiTags({multiTag1, multiTag2});
+            %
+            % See also nix.MultiTag.
+
             nix.Utils.addEntityArray(obj, 'addMultiTags', entityArray, 'nix.MultiTag');
         end
 
         function r = hasMultiTag(obj, idName)
+            % Check if a nix.MultiTag is referenced by the Group.
+            %
+            % idName (char):  Name or ID of the MultiTag.
+            %
+            % Returns:  (logical) True if the MultiTag exists, false otherwise.
+            %
+            % Example:  check = currGroup.hasMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.groups{1}.hasMultiTag('roi_2');
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasMultiTag', idName);
         end
 
-        function r = getMultiTag(obj, idName)
+        function r = openMultiTag(obj, idName)
+            % Retrieves an existing MultiTag from the invoking Group.
+            %
+            % idName (char):  Name or ID of the MultiTag.
+            %
+            % Returns:  (nix.MultiTag) The nix.MultiTag or an empty cell, 
+            %                       if the MultiTag was not found.
+            %
+            % Example:  getMT = currGroup.openMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getMT = currFile.blocks{1}.groups{1}.openMultiTag('roi_2');
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.openEntity(obj, 'getMultiTag', idName, @nix.MultiTag);
         end
 
         function r = openMultiTagIdx(obj, index)
+            % Retrieves an existing nix.MultiTag from the invoking Group, 
+            % accessed by index.
+            %
+            % index (double):  The index of the MultiTag to read.
+            %
+            % Returns:  (nix.MultiTag) The MultiTag at the given index.
+            %
+            % Example:  getMultiTag = currGroup.openMultiTagIdx(1);
+            %
+            % See also nix.MultiTag.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openMultiTagIdx', idx, @nix.MultiTag);
         end
 
-        function r = removeMultiTag(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'removeMultiTag', del, 'nix.MultiTag');
+        function r = removeMultiTag(obj, idNameEntity)
+            % Removes the reference to a nix.MultiTag from the invoking Group.
+            %
+            % This method removes the association between the MultiTag and the
+            % Group, the MultiTag itself will not be removed from the file.
+            %
+            % idNameEntity (char/nix.MultiTag):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the reference to the MultiTag 
+            %                     has been removed, false otherwise.
+            %
+            % Example:  check = currGroup.removeMultiTag('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currGroup.removeMultiTag('roi_2');
+            %           check = currFile.blocks{1}.groups{1}.removeMultiTag(newMultiTag);
+            %
+            % See also nix.MultiTag.
+
+            r = nix.Utils.deleteEntity(obj, 'removeMultiTag', idNameEntity, 'nix.MultiTag');
         end
 
         function r = multiTagCount(obj)
+            % Get the number of child nix.MultiTags.
+            %
+            % Returns:  (uint) The number of child MultiTags.
+            %
+            % Example:  mtc = currGroup.multiTagCount();
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.fetchEntityCount(obj, 'multiTagCount');
         end
 
         function r = filterMultiTags(obj, filter, val)
+            % Get a filtered cell array of all MultiTags referenced by the invoking Group.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.MultiTag]) A cell array of MultiTags filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getMultiTags = currGroup.filterMultiTags(nix.Filter.type, 'ephys');
+            %
+            % See also nix.MultiTag, nix.Filter.
+
             r = nix.Utils.filter(obj, 'multiTagsFiltered', filter, val, @nix.MultiTag);
         end
     end

--- a/+nix/Group.m
+++ b/+nix/Group.m
@@ -115,7 +115,7 @@ classdef Group < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function [] = addDataArray(obj, idNameEntity)
-            % Add a nix.DataArray to referenced list of the invoking Group.
+            % Add a nix.DataArray to the referenced list of the invoking Group.
             %
             % idNameEntity (char/nix.DataArray):  The id or name of an existing DataArray,
             %                                     or a valid nix.DataArray entity.

--- a/+nix/LinkType.m
+++ b/+nix/LinkType.m
@@ -1,3 +1,8 @@
+% nix.LinkType class providing constant tyoes available for nix.Features
+%
+% See also nix.Feature.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,7 +12,6 @@
 % LICENSE file in the root of the Project.
 
 classdef LinkType
-    % LINKTYPE nix link types
 
     properties (Constant)
         Tagged = uint8(0);

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -31,7 +31,7 @@ classdef MetadataMixIn < handle
             % Retrieves the referenced nix.Section from the invoking nix.Entity.
             %
             % Returns:  (nix.Section) The Section or an empty cell, 
-            %                       if the Section was not found.
+            %                         if no Section was referenced.
             %
             % Example:  getSec = currEntity.openMetadata();
             %
@@ -55,7 +55,7 @@ classdef MetadataMixIn < handle
             %
             % Example:  currEntity.setMetadata('some-section-id');
             %           currEntity.setMetadata(currFile.sections{1});
-            %           currEntity.setMetadata(''); % remove reference to section
+            %           currEntity.setMetadata('');  %-- remove reference to Section.
             %
             % See also nix.Section.
 

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -7,7 +7,7 @@
 % to one nix.Section entity and therefore makes it possible to annotate the entities 
 % with additional metadata.
 %
-% Depends on nix.Entity.
+% Depends on nix.Entity; Utility class, do not use out of context.
 %
 % See also nix.Section, nix.Block, nix.Group, nix.DataArray, nix.Tag, nix.MultiTag, nix.Source, nix.Entity.
 %

--- a/+nix/MetadataMixIn.m
+++ b/+nix/MetadataMixIn.m
@@ -1,3 +1,17 @@
+% Mixin Class for entities that can be associated with additional metadata.
+%
+% The data part of the NIX data model consists of six main elements which all inherit 
+% from the MetadataMixin Class: nix.Block, nix.Group, nix.DataArray, nix.Tag,
+% nix.MultiTag and nix.Source.
+% Common to all those entities is an optional property sections which  provides a link 
+% to one nix.Section entity and therefore makes it possible to annotate the entities 
+% with additional metadata.
+%
+% Depends on nix.Entity.
+%
+% See also nix.Section, nix.Block, nix.Group, nix.DataArray, nix.Tag, nix.MultiTag, nix.Source, nix.Entity.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,10 +21,6 @@
 % LICENSE file in the root of the Project.
 
 classdef MetadataMixIn < handle
-    %MetadataMixIn
-    % mixin class for nix entities with metadata
-    % depends on 
-    % - nix.Entity
 
     properties (Abstract, Hidden)
         alias
@@ -18,15 +28,42 @@ classdef MetadataMixIn < handle
 
     methods
         function r = openMetadata(obj)
+            % Retrieves the referenced nix.Section from the invoking nix.Entity.
+            %
+            % Returns:  (nix.Section) The Section or an empty cell, 
+            %                       if the Section was not found.
+            %
+            % Example:  getSec = currEntity.openMetadata();
+            %
+            % See also nix.Section.
+
             r = nix.Utils.fetchObj(obj, 'openMetadataSection', @nix.Section);
         end
 
-        function [] = setMetadata(obj, val)
-            if (isempty(val))
+        function [] = setMetadata(obj, idEntity)
+            % Set a nix.Section as metadata of the invoking nix.Entity.
+            %
+            % If metadata was already set, using this method again will
+            % replace the reference to the previous Section with a reference
+            % to the provided Section.
+            %
+            % The link to a Section can be removed by handing an empty string 
+            % to the method. The referenced Section itself will not be removed.
+            %
+            % idEntity (char/nix.Section):  The id of an existing Section,
+            %                                 or a valid nix.Section entity.
+            %
+            % Example:  currEntity.setMetadata('some-section-id');
+            %           currEntity.setMetadata(currFile.sections{1});
+            %           currEntity.setMetadata(''); % remove reference to section
+            %
+            % See also nix.Section.
+
+            if (isempty(idEntity))
                 fname = strcat(obj.alias, '::setNoneMetadata');
-                nix_mx(fname, obj.nixhandle, val);
+                nix_mx(fname, obj.nixhandle, idEntity);
             else
-                nix.Utils.addEntity(obj, 'setMetadata', val, 'nix.Section');
+                nix.Utils.addEntity(obj, 'setMetadata', idEntity, 'nix.Section');
             end
         end
     end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -24,9 +24,12 @@
 %   type (char):        read-write, type can be used to give semantic meaning to an 
 %                         entity and expose it to search methods in a broader context.
 %   definition (char):  read-write, optional description of the entity.
-%   unit ([char]):     read-write, the array of units is applied to all values for 
-%                        position and extent in order to calculate the right position
-%                        vectors in referenced DataArrays.
+%   unit ([char]):      read-write, the array of units is applied to all values for 
+%                         position and extent in order to calculate the right position
+%                         vectors in referenced DataArrays.
+%
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
 %
 % nix.MultiTag dynamic child entity properties:
 %   references   access to all nix.DataArray child entities referenced by the MultiTag.
@@ -47,7 +50,7 @@
 classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
     properties (Hidden)
-        alias = 'MultiTag'  % nix-mx namespace to access MultiTag specific nix backend functions.
+        alias = 'MultiTag'  % namespace for MultiTag nix backend function access.
     end
 
     methods

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -1,3 +1,42 @@
+% nix.MultiTag class to annotate ('tag') multiple regions of interrest in DataArrays.
+%
+% Besides the DataArray the Tag entities can be considered as the other core entities 
+% of the data model. They are meant to attach annotations directly to the data and to 
+% establish meaningful links between different kinds of stored data. Most importantly 
+% Tags allow the definition of points or regions of interest in data that is stored in 
+% other DataArray entities. The DataArray entities the Tag applies to are defined by 
+% its property references. One Tag can reference data in multiple DataArrays.
+%
+% Further the referenced data is defined by an origin DataArray called position and an 
+% optional extent DataArray that defines its size. Therefore position and extent of a Tag, 
+% together with the references field defines a group of points or regions of interest 
+% collected from a subset of all available DataArray entities.
+%
+% Further Tags have a field called nix.Features which makes it possible to associate other 
+% data with the Tag. Semantically a Feature of a Tag is some additional data that 
+% contains additional information about the points of hyperslabs defined by the Tag. 
+% This could be for example data that represents a stimulus (e.g. an image or a signal) 
+% that was applied in a certain interval during the recording.
+%
+% nix.MultiTag dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, optional description of the entity.
+%   unit ([char]):     read-write, the array of units is applied to all values for 
+%                        position and extent in order to calculate the right position
+%                        vectors in referenced DataArrays.
+%
+% nix.MultiTag dynamic child entity properties:
+%   references   access to all nix.DataArray child entities referenced by the MultiTag.
+%   features     access to all nix.Features child entities referenced by the MultiTag.
+%   sources      access to all first level nix.Source child entities.
+%   sections     access to all first level nix.Section child entities.
+%
+% See also nix.DataArray, nix.Feature, nix.Source, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +46,9 @@
 % LICENSE file in the root of the Project.
 
 classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    % MultiTag nix MultiTag object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'MultiTag'
+        alias = 'MultiTag'  % nix-mx namespace to access MultiTag specific nix backend functions.
     end
 
     methods
@@ -23,7 +60,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             % assign dynamic properties
             nix.Dynamic.addProperty(obj, 'units', 'rw');
 
-            % assign relations
+            % assign child entities
             nix.Dynamic.addGetChildEntities(obj, 'references', @nix.DataArray);
             nix.Dynamic.addGetChildEntities(obj, 'features', @nix.Feature);
         end
@@ -32,32 +69,120 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % References methods
         % ------------------
 
-        function [] = addReference(obj, entity)
-            nix.Utils.addEntity(obj, 'addReference', entity, 'nix.DataArray');
+        function [] = addReference(obj, idNameEntity)
+            % Add a nix.DataArray to the referenced list of the invoking MultiTag.
+            %
+            % idNameEntity (char/nix.DataArray):  The id or name of an existing DataArray,
+            %                                     or a valid nix.DataArray entity.
+            %
+            % Example:  currMultiTag.addReferences('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currMultiTag.addReferences('subTrial2');
+            %           currFile.blocks{1}.multiTags{1}.addReferences(currDataArrayEntity);
+            %
+            % See also nix.DataArray.
+
+            nix.Utils.addEntity(obj, 'addReference', idNameEntity, 'nix.DataArray');
         end
 
         function [] = addReferences(obj, entityArray)
+            % Set the list of referenced DataArrays for the invoking MultiTag.
+            %
+            % Previously referenced DataArrays that are not in the
+            % references cell array will be removed.
+            %
+            % entityArray ([nix.DataArray]):  A cell array of nix.DataArrays.
+            %
+            % Example:  currMultiTag.addReferences({dataArray1, dataArray2});
+            %
+            % See also nix.DataArray.
+
             nix.Utils.addEntityArray(obj, 'addReferences', entityArray, 'nix.DataArray');
         end
 
         function r = hasReference(obj, idName)
+            % Check if a nix.DataArray is referenced by the invoking MultiTag.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (logical) True if the DataArray exists, false otherwise.
+            %
+            % Example:  check = currMultiTag.hasReference('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.multiTags{1}.hasReference('sessionData2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasReference', idName);
         end
 
-        function r = removeReference(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'removeReference', del, 'nix.DataArray');
+        function r = removeReference(obj, idNameEntity)
+            % Removes the reference to a nix.DataArray from the invoking MultiTag.
+            %
+            % This method removes the association between the DataArray and the
+            % MultiTag, the DataArray itself will not be removed from the file.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the reference to the DataArray 
+            %                     has been removed, false otherwise.
+            %
+            % Example:  check = currMultiTag.removeReference('some-id');
+            %           check = currMultiTag.removeReference('sessionData2');
+            %           check = currFile.blocks{1}.multiTags{1}.removeReference(newDataArray);
+            %
+            % See also nix.DataArray.
+
+            r = nix.Utils.deleteEntity(obj, 'removeReference', idNameEntity, 'nix.DataArray');
         end
 
         function r = openReference(obj, idName)
+            % Retrieves a referenced DataArray from the invoking MultiTag.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (nix.DataArray) The nix.DataArray or an empty cell, 
+            %                       if the DataArray was not found.
+            %
+            % Example:  getDA = currMultiTag.openReference('some-id');
+            %           getDA = currFile.blocks{1}.multiTags{1}.openReference('subTrial2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.openEntity(obj, 'openReferences', idName, @nix.DataArray);
         end
 
         function r = openReferenceIdx(obj, index)
+            % Retrieves a referenced nix.DataArray from the invoking MultiTag, 
+            % accessed by index.
+            %
+            % index (double):  The index of the DataArray to read.
+            %
+            % Returns:  (nix.DataArray) The DataArray at the given index.
+            %
+            % Example:  getDA = currMultiTag.openReferenceIdx(1);
+            %
+            % See also nix.DataArray.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
         function r = retrieveData(obj, positionIdx, idName)
+            % Returns the data from a DataArray tagged by a certain position and extent
+            % of a certain reference by the invoking MultiTag.
+            %
+            % positionIdx (double):  The index of the requested position.
+            % idName (char):         Name or ID of the requested DataArray.
+            %
+            % Returns:  (var) Data of the DataArray referenced by the MultiTag.
+            %                   The Data is detached from the nix.File,
+            %                   changes to this data will not be saved to the file.
+            %
+            % Example:  data = currMultiTag.retriveData(2, 'some-id');
+            %           data = currFile.blocks{1}.multiTags{1}.retrieveData(1, 'subTrial2');
+            %
+            % See also nix.DataArray
+
             posIdx = nix.Utils.handleIndex(positionIdx);
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nixhandle, posIdx, idName);
@@ -65,6 +190,21 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = retrieveDataIdx(obj, positionIdx, referenceIdx)
+            % Returns the data from a DataArray tagged by a certain position and extent
+            % of a certain reference by the invoking MultiTag.
+            %
+            % positionIdx (double):   The index of the requested position.
+            % referenceIdx (double):  The index of the referenced DataArray.
+            %
+            % Returns:  (var) Data of the DataArray referenced by the MultiTag.
+            %                   The Data is detached from the nix.File,
+            %                   changes to this data will not be saved to the file.
+            %
+            % Example:  data = currMultiTag.retriveDataIdx(2, 1);
+            %           data = currFile.blocks{1}.multiTags{1}.retrieveDataIdx(1, 3);
+            %
+            % See also nix.DataArray
+
             posIdx = nix.Utils.handleIndex(positionIdx);
             refIdx = nix.Utils.handleIndex(referenceIdx);
             fname = strcat(obj.alias, '::retrieveDataIdx');
@@ -73,10 +213,32 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = referenceCount(obj)
+            % Get the number nix.DataArrays referenced by the invoking MultiTag.
+            %
+            % Returns:  (uint) The number of referenced DataArrays.
+            %
+            % Example:  dc = currMultiTag.referenceCount();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchEntityCount(obj, 'referenceCount');
         end
 
         function r = filterReferences(obj, filter, val)
+            % Get a filtered cell array of all DataArrays referenced by the 
+            % invoking MultiTag.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.DataArray]) A cell array of DataArrays filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getDAs = currMultiTag.filterReferences(nix.Filter.type, 'ephys_data');
+            %
+            % See also nix.DataArray, nix.Filter.
+
             r = nix.Utils.filter(obj, 'referencesFiltered', filter, val, @nix.DataArray);
         end
 
@@ -84,31 +246,111 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Features methods
         % ------------------
 
-        function r = addFeature(obj, entity, linkType)
-            addId = nix.Utils.parseEntityId(entity, 'nix.DataArray');
+        function r = createFeature(obj, idNameEntity, linkType)
+            % Create a new nix.Feature entity associated with a nix.DataArray,
+            % that is used by the invoking MultiTag.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the DataArray to be
+            %                                     used or the DataArray itself.
+            % linkType (nix.LinkType):  nix.LinkType describing how the DataArray is 
+            %                           used by the MultiTag.
+            %
+            % Returns:  (nix.Feature) The newly created Feature.
+            %
+            % Example:  newFeat = currMultiTag.createFeature('subTrial2', nix.LinkType.Untagged);
+            %
+            % See also nix.Feature, nix.LinkType.
+
+            id = nix.Utils.parseEntityId(idNameEntity, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
-            h = nix_mx(fname, obj.nixhandle, addId, linkType);
+            h = nix_mx(fname, obj.nixhandle, id, linkType);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
-        function r = hasFeature(obj, idName)
-            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', idName);
+        function r = hasFeature(obj, id)
+            % Check if a nix.Feature is associated with the invoking MultiTag.
+            %
+            % id (char):  ID of the Feature.
+            %
+            % Returns:  (logical) True if the Feature exists, false otherwise.
+            %
+            % Example:  check = currMultiTag.hasFeature('some-id-2345-and-bla');
+            %
+            % See also nix.Feature.
+
+            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', id);
         end
 
-        function r = removeFeature(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteFeature', del, 'nix.Feature');
+        function r = deleteFeature(obj, idEntity)
+            % Deletes a nix.Feature from the invoking MultiTag.
+            %
+            % This method deletes a Feature from the invoking MultiTag, the DataArray 
+            % referenced by this Feature will not be removed from the file.
+            %
+            % idEntity (char/nix.Feature):  id of the Feature to be deleted
+            %                                 or the Feature itself.
+            %
+            % Returns:  (logical) True if the Feature has been removed, false otherwise.
+            %
+            % Example:  check = currMultiTag.deleteFeature('some-feat-id-blub');
+            %           check = currFile.blocks{1}.multiTags{1}.deleteFeature(newFeature);
+            %
+            % See also nix.Feature, nix.DataArray.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteFeature', idEntity, 'nix.Feature');
         end
 
-        function r = openFeature(obj, idName)
-            r = nix.Utils.openEntity(obj, 'openFeature', idName, @nix.Feature);
+        function r = openFeature(obj, id)
+            % Retrieves an associated Feature from the invoking MultiTag.
+            %
+            % id (char):  ID of the Feature.
+            %
+            % Returns:  (nix.Feature) The Feature or an empty cell, 
+            %                         if the Feature was not found.
+            %
+            % Example:  getFeat = currMultiTag.openFeature('some-feat-id-2378');
+            %
+            % See also nix.Feature.
+
+            r = nix.Utils.openEntity(obj, 'openFeature', id, @nix.Feature);
         end
 
         function r = openFeatureIdx(obj, index)
+            % Retrieves an associated nix.Feature from the invoking MultiTag, 
+            % accessed by index.
+            %
+            % index (double):  The index of the Feature to retrieve.
+            %
+            % Returns:  (nix.Feature) The Feature at the given index.
+            %
+            % Example:  getFeat = currMultiTag.openFeatureIdx(1);
+            %
+            % See also nix.Feature.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
         function r = retrieveFeatureData(obj, positionIdx, idName)
+            % Returns the raw data from the DataArray attached to the 
+            % Feature associated with the invoking MultiTag related to a certain
+            % position of this MultiTag.
+            %
+            % Depending on the nix.LinkType used by the Feature,
+            % only the requested sections of the DataArray will be returned.
+            % 
+            % positionIdx (double):  The index of the requested position.
+            % idName (char):         ID or name of the Feature.
+            %
+            % Returns:  (var) Data from the referenced DataArray, 
+            %                 modified by LinkType of the Feature.
+            %
+            % Example:  getFeatData = currMultiTag.retrieveFeatureData(1, 'some-id');
+            %           gFD = currFile.blocks{1}.multiTags{1}.retrieveFeatureData(...
+            %                                                       2, 'multiTagName');
+            %
+            % See also nix.Feature, nix.LinkType.
+
             posIdx = nix.Utils.handleIndex(positionIdx);
             fname = strcat(obj.alias, '::featureRetrieveData');
             data = nix_mx(fname, obj.nixhandle, posIdx, idName);
@@ -116,6 +358,24 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = retrieveFeatureDataIdx(obj, positionIdx, featureIdx)
+            % Returns the raw data from the DataArray attached to the 
+            % Feature associated with the invoking MultiTag related to a certain
+            % position of this MultiTag.
+            %
+            % Depending on the nix.LinkType used by the Feature,
+            % only the requested sections of the DataArray will be returned.
+            % 
+            % positionIdx (double):  The index of the requested position.
+            % featureIdx (double):   The index of the requested Feature.
+            %
+            % Returns:  (var) Data from the referenced DataArray, 
+            %                 modified by LinkType of the Feature.
+            %
+            % Example:  getFeatData = currMultiTag.retrieveFeatureDataIdx(1, 3);
+            %           gFD = currFile.blocks{1}.multiTags{1}.retrieveFeatureDataIdx(2, 1);
+            %
+            % See also nix.Feature, nix.LinkType.
+
             posIdx = nix.Utils.handleIndex(positionIdx);
             featIdx = nix.Utils.handleIndex(featureIdx);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
@@ -124,10 +384,34 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = featureCount(obj)
+            % Get the number nix.Features associated with the invoking MultiTag.
+            %
+            % Returns:  (uint) The number of associated Features.
+            %
+            % Example:  fc = currMultiTag.featureCount();
+            %
+            % See also nix.Feature.
+
             r = nix.Utils.fetchEntityCount(obj, 'featureCount');
         end
 
         function r = filterFeatures(obj, filter, val)
+            % Get a filtered cell array of all Features associated with the 
+            % invoking MultiTag.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied. The filters 
+            %                       nix.Filter.acceptall, nix.Filter.id and
+            %                       nix.Filter.ids are supported.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Feature]) A cell array of Features filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getFeatures = currMultiTag.filterFeatures(nix.Filter.id, 'some-fancy-id');
+            %
+            % See also nix.Feature, nix.Filter.
+
             r = nix.Utils.filter(obj, 'featuresFiltered', filter, val, @nix.Feature);
         end
 
@@ -136,16 +420,50 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = hasPositions(obj)
+            % Check if the invoking MultiTag has a positions DataArray.
+            %
+            % Returns:  (logical) True if the positions are set, false otherwise.
+            %
+            % Example:  check = currMultiTag.hasPositions();
+            %
+            % See also nix.DataArray.
+
             fname = strcat(obj.alias, '::hasPositions');
             r = nix_mx(fname, obj.nixhandle);
         end
 
         function r = openPositions(obj)
+            % The positions of a MultiTag are defined in a DataArray. This DataArray 
+            % has to define a set of origin vectors, each defining a point inside the 
+            % referenced data or the beginning of a region of interest.
+            %
+            % Returns: (nix.DataArray) The DataArray defining the regions of
+            %                           interest referenced by this MultiTag.
+            %
+            % Example:  posDA = currMultiTag.openPositions();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchObj(obj, 'openPositions', @nix.DataArray);
         end
 
-        function [] = addPositions(obj, entity)
-            nix.Utils.addEntity(obj, 'addPositions', entity, 'nix.DataArray');
+        function [] = setPositions(obj, idNameEntity)
+            % Set a nix.DataArray as the positions data of the invoking Tag.
+            %
+            % If positions were already set, using this method again will
+            % replace the reference to the old DataArray with a reference
+            % to the current one.
+            %
+            % idNameEntity (char/nix.DataArray):  The id or name of an existing DataArray,
+            %                                     or a valid nix.DataArray entity.
+            %
+            % Example:  currMultiTag.setPositions('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currMultiTag.setPositions('subTrial2');
+            %           currFile.blocks{1}.multiTags{1}.setPositions(currDataArrayEntity);
+            %
+            % See also nix.DataArray.
+
+            nix.Utils.addEntity(obj, 'addPositions', idNameEntity, 'nix.DataArray');
         end
 
         % ------------------
@@ -153,15 +471,44 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % ------------------
 
         function r = openExtents(obj)
+            % Returns the extents of the invoking MultiTag.
+            %
+            % The extents of a MultiTag are defined in an associated DataArray. 
+            % This array has to define a set of extent vectors, each defining the 
+            % size of the corresponding region of interest.
+            %
+            % Returns:  (nix.DataArray) The defined extents of the invoking MultiTag.
+            %
+            % Example:  extentsDA = currMultiTag.openExtents();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchObj(obj, 'openExtents', @nix.DataArray);
         end
 
-        function [] = setExtents(obj, entity)
-            if (isempty(entity))
+        function [] = setExtents(obj, idNameEntity)
+            % Set a nix.DataArray as the extents data of the invoking Tag.
+            %
+            % If extents were already set, using this method again will
+            % replace the reference to the old DataArray with a reference
+            % to the current one.
+            %
+            % extents can be removed by handing an empty string to the method.
+            %
+            % idNameEntity (char/nix.DataArray):  The id or name of an existing DataArray,
+            %                                     or a valid nix.DataArray entity.
+            %
+            % Example:  currMultiTag.setExtents('some-data-array-id');
+            %           currMultiTag.setExtents('subTrial2');
+            %           currFile.blocks{1}.multiTags{1}.setExtents(currDataArrayEntity);
+            %
+            % See also nix.DataArray.
+
+            if (isempty(idNameEntity))
                 fname = strcat(obj.alias, '::setNoneExtents');
                 nix_mx(fname, obj.nixhandle, 0);
             else
-                nix.Utils.addEntity(obj, 'setExtents', entity, 'nix.DataArray');
+                nix.Utils.addEntity(obj, 'setExtents', idNameEntity, 'nix.DataArray');
             end
         end
     end

--- a/+nix/MultiTag.m
+++ b/+nix/MultiTag.m
@@ -32,7 +32,6 @@
 %   references   access to all nix.DataArray child entities referenced by the MultiTag.
 %   features     access to all nix.Features child entities referenced by the MultiTag.
 %   sources      access to all first level nix.Source child entities.
-%   sections     access to all first level nix.Section child entities.
 %
 % See also nix.DataArray, nix.Feature, nix.Source, nix.Section.
 %
@@ -487,7 +486,7 @@ classdef MultiTag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function [] = setExtents(obj, idNameEntity)
-            % Set a nix.DataArray as the extents data of the invoking Tag.
+            % Set a nix.DataArray as the extents data of the invoking MultiTag.
             %
             % If extents were already set, using this method again will
             % replace the reference to the old DataArray with a reference

--- a/+nix/NamedEntity.m
+++ b/+nix/NamedEntity.m
@@ -1,3 +1,26 @@
+% MixIn class for NIX entites with basic dynamic properties.
+%
+% In addition to the properties defined by nix.Entity most entities of the NIX data model
+% further provide the properties id, name, type and definition.
+%
+% The id property of an entity is automatically assigned and serves as a machine readable 
+% unique identifier. The name property of an entity serves as a human readable identifier 
+% and can be set at the creation of an entity. The type property is used to allow the 
+% specification of additional semantic meaning for an entity and therefore can introduce 
+% domain-specificity into the generic data model. The optional definition property allows 
+% the user to add a freely assignable textual definition to the entity.
+%
+% Dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, additional description of the entity.
+%
+% See also: nix.Block, nix.Group, nix.DataArray, nix.Source, nix.Tag,
+% nix.MultiTag, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +30,6 @@
 % LICENSE file in the root of the Project.
 
 classdef NamedEntity < nix.Entity
-    % NamedEntity
-    % base class for nix entities with name/type/definition
 
     methods
         function obj = NamedEntity(h)
@@ -22,8 +43,16 @@ classdef NamedEntity < nix.Entity
         end
 
         function r = compare(obj, entity)
-        % Compares first name and second id, return > 0 if the entity 
-        % is larger than the other, 0 if both are equal, and < 0 otherwise.
+            % Checks two NIX entities of the same class for equality.
+            %
+            % The name property is the first comparison. If they are the same, 
+            % the ids of the entities will be compared.
+            %
+            % Returns:  (double)  0 if both entities are equal.
+            %                     > or < 0 if the entities are different.
+            %
+            % Example:  check = currSource.compare(otherSource);
+
             if (~isa(obj, class(entity)))
                 err.identifier = 'NIXMX:InvalidArgument';
                 err.message = 'Only entities of the same class can be compared.';

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -5,9 +5,12 @@
 %   name (char):        read-only, name of the entity.      
 %   definition (char):  read-write, additional description of the entity.
 %   unit (char):        read-write, unit of the values associated with a Property.
-%                       The provided unit has to be an SI unit.
+%                         The provided unit has to be an SI unit.
 %   datatype (char):    read-only, provides the datatype of the values associated 
-%                       with a Property. Attribute is set when the Property is created.
+%                         with a Property. Attribute is set when the Property is created.
+%
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
 %
 % nix.Property dynamic child entity properties:
 %   values     access to all value child entities.
@@ -47,7 +50,7 @@
 classdef Property < nix.NamedEntity
 
     properties (Hidden)
-        alias = 'Property'  % nix-mx namespace to access Property specific nix backend functions.
+        alias = 'Property'  % namespace for Property nix backend function access.
     end
 
     properties (Dependent)

--- a/+nix/Property.m
+++ b/+nix/Property.m
@@ -1,3 +1,41 @@
+% nix.Property class contains the concrete values associated with metadata.
+%
+% nix.Property dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   definition (char):  read-write, additional description of the entity.
+%   unit (char):        read-write, unit of the values associated with a Property.
+%                       The provided unit has to be an SI unit.
+%   datatype (char):    read-only, provides the datatype of the values associated 
+%                       with a Property. Attribute is set when the Property is created.
+%
+% nix.Property dynamic child entity properties:
+%   values     access to all value child entities.
+%
+% Property values can be set via the dynamic child entity property. When 
+% values are set, they replace any previously stored values. The new values
+% always have to be of a datatype supported by the Property.
+%
+% Example:  currProperty.values = {'last name', 'first name'};
+%
+% The values themselves have two properties: value and uncertainty which
+% can be accessed and updated individually.
+%
+% Individual values can be accessed and set by their value property. A set
+% value has to match the datatype of the Property.
+%
+% Example:  currProperty.values{1}.value                 %-- get first value of Property.
+%           currProperty.values{2}.value = 'some value'  %-- set second value of Property.
+%
+% Each value comes with its own uncertainty property which can be accessed
+% and set. NOTE: this will probably change in the near future, moving the
+% uncertainty from the individual value to the level of the Property.
+%
+% Example:  %-- get uncertainty of first property value.
+%           currProperty.values{1}.uncertainty
+%           %-- set uncertainty of second property value.
+%           currProperty.values{1}.uncertainty = 0.1
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,12 +45,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Property < nix.NamedEntity
-    % PROPERTY Metadata Property class
-    %   NIX metadata property
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Property'
+        alias = 'Property'  % nix-mx namespace to access Property specific nix backend functions.
     end
 
     properties (Dependent)
@@ -58,10 +93,20 @@ classdef Property < nix.NamedEntity
         end
 
         function r = valueCount(obj)
+            % Get the number of the child values of the invoking Property.
+            %
+            % Returns:  (uint) The number of child values.
+            %
+            % Example:  vc = currProperty.valueCount();
+
             r = nix.Utils.fetchEntityCount(obj, 'valueCount');
         end
 
         function [] = deleteValues(obj)
+            % Deletes all values from the invoking Property.
+            %
+            % Example:  check = currProperty.deleteValues();
+
             fname = strcat(obj.alias, '::deleteValues');
             nix_mx(fname, obj.nixhandle);
         end

--- a/+nix/RangeDimension.m
+++ b/+nix/RangeDimension.m
@@ -1,3 +1,42 @@
+% nix.RangeDimension class provides access to the RangeDimension properties.
+%
+% The RangeDimension covers cases when indexes of a dimension are mapped to other values
+% in a non-regular fashion. A use-case for this would be for example irregularly sampled
+% time-series or certain kinds of histograms. To achieve the mapping of the indexes an
+% array of mapping values must be provided. Those values are stored in the dimensions
+% ticks property. In analogy to the SampledDimension a unit and a label can be defined.
+%
+% An AliasRangeDimension is a special case of a RangeDimension that uses the data 
+% stored in the invoking DataArray as ticks. This works only(!) if the DataArray 
+% is 1D and the stored data is numeric.
+%
+% nix.RangeDimension dynamic properties
+%   dimensionType (char):  read-only, returns type of the dimension as string.
+%   label (char):          read-write, gets and sets the label of the dimension.
+%   unit (char):           read-write, gets and sets the unit of the dimension.
+%                            Only SI units are supported.
+%   ticks ([double]):      read-write, gets and sets the ticks of the dimension.
+%                            The ticks map the index of the data at the respective 
+%                            dimension to other values. This can be used to store data 
+%                            that is sampled at irregular intervals.
+%                            Note: Ticks must be ordered in ascending order.
+%   isAlias (logical):     read-only, returns True if the current Dimension is an 
+%                            AliasRangeDimension, False otherwise.
+%
+%  Examples:    dt = currDataArray.dimensions{1}.dimensionType;
+%
+%               getLabel = currDimension.label;
+%               currDimension.dimensions{2}.label = 'Time';
+%
+%               getUnit = currDimension.unit;
+%               currDimension.unit = 'ms';
+%
+%               getTicks = currDimension.ticks;
+%               currDimension.ticks = [2 12 36 292];
+%
+% See also nix.DataArray.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +46,9 @@
 % LICENSE file in the root of the Project.
 
 classdef RangeDimension < nix.Entity
-    % RangeDimension nix RangeDimension object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'RangeDimension'
+        alias = 'RangeDimension'  % nix-mx namespace to access RangeDimension specific nix backend functions.
     end
 
     methods
@@ -27,17 +64,51 @@ classdef RangeDimension < nix.Entity
         end
 
         function r = tickAt(obj, index)
+            % Returns the entry of the RangeDimension at a given index.
+            %
+            % index (double):  The index of interest.
+            %
+            % Returns:  (double) The tick value at the given index or an
+            %                    error if the index is out of range of the
+            %                    dimensions tick array.
+            %
+            % Example:  getTickValue = currDimension.tickAt(101);
+
             index = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::tickAt');
             r = nix_mx(fname, obj.nixhandle, index);
         end
 
         function r = indexOf(obj, position)
+            % Returns the index of the requested position or tick value.
+            %
+            % If the provided position is not a value in the tick array, the
+            % method will return the index of the next tick larger than 
+            % the provided value.
+            %
+            % position (double):  Tick value of the requested index.
+            %
+            % Returns:  (double) The index of the provided position.
+            %
+            % Example:  getIndexOfTick = currDimension.indexOf(12);
+
             fname = strcat(obj.alias, '::indexOf');
-            r = nix_mx(fname, obj.nixhandle, position);
+            idx = nix_mx(fname, obj.nixhandle, position);
+            r = double(idx + 1); % convert index from c++ to Matlab style.
         end
 
         function r = axis(obj, count, startIndex)
+            % Returns an array of values for axis labeling.
+            %
+            % count (double):       Number of tick values to be returned.
+            % startIndex (double):  Starting index for the returned tick values.
+            %
+            % Returns:  ([double]) Axis labeling values array.
+            %
+            % Example:  currDimension.ticks = [4 8 15 16 23 42];
+            %           getAxis = currDimension.axis(1, 5);   %-- returns [23]
+            %           getAxis = currDimension.axis(3, 2);   %-- returns [8 15 16]
+
             if (nargin < 3)
                 startIndex = 1;
             end

--- a/+nix/SampledDimension.m
+++ b/+nix/SampledDimension.m
@@ -1,3 +1,40 @@
+% nix.SampledDimension class provides access to the SampledDimension properties.
+%
+% Instances of the SampledDimension class are used to describe a dimension of data in
+% a DataArray that has been sampled in regular intervals. For example this can be 
+% a time axis.
+% SampledDimensions are characterized by the label for the dimension, the unit in 
+% which the sampling interval is given. If not specified otherwise the dimension 
+% starts with zero offset.
+%
+% nix.SampledDimension dynamic properties
+%   dimensionType (char):  read-only, returns type of the dimension as string.
+%   label (char):          read-write, gets and sets the label of the dimension.
+%   unit (char):           read-write, gets and sets the unit of the dimension and its 
+%                          sampling interval. Only SI units are supported.
+%   samplingInterval (double):  read-write, gets and sets the sampling interval
+%                               of the dimension.
+%   offset (double):        read-write, The offset defines at which position the sampling
+%                           was started. The offset is interpreted in the same unit as
+%                           the sampling interval.
+%
+%  Examples:    dt = currDataArray.dimensions{1}.dimensionType;
+%
+%               getLabel = currDimension.label;
+%               currDimension.dimensions{2}.label = 'Frequency';
+%
+%               getUnit = currDimension.unit;
+%               currDimension.unit = 'Hz';
+%
+%               getSampling = currDimension.samplingInterval;
+%               currDimension.samplingInterval = 200;
+%
+%               getOffset = currDimension.offset;
+%               currDimension.offset = 8;
+%
+% See also nix.DataArray.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +44,9 @@
 % LICENSE file in the root of the Project.
 
 classdef SampledDimension < nix.Entity
-    % SampledDimension nix SampledDimension object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'SampledDimension'
+        alias = 'SampledDimension'  % nix-mx namespace to access SampledDimension specific nix backend functions.
     end
 
     methods
@@ -27,17 +62,55 @@ classdef SampledDimension < nix.Entity
         end
 
         function r = indexOf(obj, position)
+            % Returns the index of the given position (data point).
+            %
+            % This method returns the index of the given position. Use this method for
+            % example to find out which data point (index) relates to a given time.
+            % Note: This method does not check if the position is within the
+            % extent of the data!
+            %
+            % position (double):  A data value e.g. a time.
+            %
+            % Returns:  (double) The corresponding index.
+            %
+            % Example:  getIndex = currDimension.indexOf(12);
+
             fname = strcat(obj.alias, '::indexOf');
-            r = nix_mx(fname, obj.nixhandle, position);
+            idx = nix_mx(fname, obj.nixhandle, position);
+            r = double(idx + 1); % convert index from c++ to Matlab style.
         end
 
         function r = positionAt(obj, index)
+            % Returns the position of this dimension at a given index.
+            %
+            % This method returns the position at a given index. Use this method for
+            % example to find the position that relates to a certain index. Note: This
+            % method does not check if the index is the extent of the data!
+            %
+            % index (double):  Index of interest.
+            %
+            % Returns:  (double) The respective position e.g. a time.
+            %
+            % Example:  getPosition = currDimension.positionAt(236);
+
             index = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::positionAt');
             r = nix_mx(fname, obj.nixhandle, index);
         end
 
         function r = axis(obj, count, startIndex)
+            % Returns an array of values for axis labeling, calculated by
+            % the dimensions sampling interval.
+            %
+            % count (double):       Number of values to be returned.
+            % startIndex (double):  Starting index for the returned values.
+            %
+            % Returns:  ([double]) Axis labeling values array.
+            %
+            % Example:  currDimension.samplingInterval = 200;
+            %           getAxis = currDimension.axis(3, 1);   %-- returns [0 200 400]
+            %           getAxis = currDimension.axis(3, 5);   %-- returns [800 1000 1200]
+
             if (nargin < 3)
                 startIndex = 1;
             end

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -27,6 +27,9 @@
 %                         repository where the semantic definition of the current 
 %                         Section can be found.
 %
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
+%
 % nix.Section dynamic child entity properties:
 %   sections     access to all direct nix.Section child entities.
 %   properties   access to all nix.Property child entities.
@@ -46,7 +49,7 @@
 classdef Section < nix.NamedEntity
 
     properties (Hidden)
-        alias = 'Section'  % nix-mx namespace to access Section specific nix backend functions.
+        alias = 'Section'  % namespace for Section nix backend function access.
     end
 
     methods

--- a/+nix/Section.m
+++ b/+nix/Section.m
@@ -1,3 +1,40 @@
+% nix.Section class provides the elaborate connection of data with metadata
+% e.g. background information about the experiment that produced the data 
+% stored in a nix.DataArray.
+%
+% Almost all entities allow to attach arbitray metadata. The basic concept of the 
+% metadata model is that Properties are organized in Sections which in turn can be 
+% nested to represent hierarchical structures. The Sections basically act like Python 
+% dictionaries.
+%
+% Sections can be nested to create a metadata tree to reflect and document
+% even complicated experimental settings. Each of the NIX entities nix.Block,
+% nix.Group, nix.DataArray, nix.Source, nix.Tag and nix.MultiTag can
+% reference one nix.Section to connect data to metadata and provide
+% detailed provenance for experimental settings.
+%
+% Nested nix.Sections are used to reflect experimental settings as an abstract tree
+% like structure, while the concrete information is stored in nix.Properties
+% as children of the individual nix.Sections.
+%
+% nix.Section dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, additional description of the entity.
+%   repository (char):  read-write, repository can be used to provide a uri to a 
+%                         repository where the semantic definition of the current 
+%                         Section can be found.
+%
+% nix.Section dynamic child entity properties:
+%   sections     access to all direct nix.Section child entities.
+%   properties   access to all nix.Property child entities.
+%
+% See also nix.Property, nix.Block, nix.Group, nix.DataArray, nix.Source, 
+% nix.Tag, nix.MultiTag.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,12 +44,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Section < nix.NamedEntity
-    % SECTION Metadata Section class
-    %   NIX metadata section
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Section'
+        alias = 'Section'  % nix-mx namespace to access Section specific nix backend functions.
     end
 
     methods
@@ -22,12 +56,19 @@ classdef Section < nix.NamedEntity
             % assign dynamic properties
             nix.Dynamic.addProperty(obj, 'repository', 'rw');
 
-            % assign relations
+            % assign child entities
             nix.Dynamic.addGetChildEntities(obj, 'sections', @nix.Section);
             nix.Dynamic.addGetChildEntities(obj, 'properties', @nix.Property);
         end
 
         function r = parent(obj)
+            % Returns the parent Section of the invoking Section.
+            %
+            % Returns:  (nix.Section) The parent Section if there is any, 
+            %                         an empty cell array otherwise.
+            %
+            % Example:  getSection = currSection.parent();
+
             r = nix.Utils.fetchObj(obj, 'parent', @nix.Section);
         end
 
@@ -35,20 +76,57 @@ classdef Section < nix.NamedEntity
         % Link methods
         % ----------------
 
-        function [] = setLink(obj, val)
-            if (isempty(val))
+        function [] = setLink(obj, idEntity)
+            % Establish a link between another Section and the invoking Section.
+            %
+            % The linking Section inherits the Properties defined in the linked Section.
+            % Properties of the same name are overridden.
+            %
+            % The link to a Section can be removed by handing an empty string 
+            % to the method. The linked Section itself will not be removed.
+            %
+            % idEntity (char/nix.Section):  The id of an existing Section,
+            %                                 or a valid nix.Section entity.  
+            %
+            % Example:  currSection.setLink('some-section-id');
+            %           currFile.sections{1}.setLink(otherSectionEntity);
+            %           currSection.setLink('');  %-- remove Section link.
+            %
+            % See also nix.Property.
+
+            if (isempty(idEntity))
                 fname = strcat(obj.alias, '::setNoneLink');
                 nix_mx(fname, obj.nixhandle);
             else
-                nix.Utils.addEntity(obj, 'setLink', val, 'nix.Section');
+                nix.Utils.addEntity(obj, 'setLink', idEntity, 'nix.Section');
             end
         end
 
         function r = openLink(obj)
+            % Retrieves the linked nix.Section from the invoking Section.
+            %
+            % Returns:  (nix.Section) The linked Section or an empty cell, 
+            %                         if no Section was linked.
+            %
+            % Example:  getSection = currSection.openLink();
+
             r = nix.Utils.fetchObj(obj, 'openLink', @nix.Section);
         end
 
         function r = inheritedProperties(obj)
+            % Returns all nix.Properties that the invoking Section has
+            % inherited from another linked Section.
+            %
+            % This list may include Properties that are locally overridden.
+            %
+            % Returns:  ([nix.Property]) Cell array of all Properties inherited from 
+            %                            one other Section that is linked to the
+            %                            invoking Section.
+            %
+            % Example:  getProperties = currSection.inheritedProperties();
+            %
+            % See also nix.Property.
+
             r = nix.Utils.fetchObjList(obj, 'inheritedProperties', @nix.Property);
         end
 
@@ -57,51 +135,171 @@ classdef Section < nix.NamedEntity
         % ----------------
 
         function r = createSection(obj, name, type)
+            % Create a new nix.Section entity as child of the invoking Section.
+            %
+            % name (char):  The name of the Section, has to be unique within the file.
+            % type (char):  The type of the Section, required.
+            %               Type can be used to give semantic meaning to an entity
+            %               and expose it to search methods in a broader context.
+            %
+            % Returns:  (nix.Section) The newly created Section.
+            %
+            % Example:  newSection = currSection.createSection(...
+            %                                       'electrode_array', 'electrode');
+
             fname = strcat(obj.alias, '::createSection');
             h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Section);
         end
 
-        function r = deleteSection(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteSection', del, 'nix.Section');
+        function r = deleteSection(obj, idNameEntity)
+            % Deletes a Section from the invoking Section.
+            %
+            % When a Section is deleted, all of its child Sections, Properties and 
+            % Values will be deleted from the file as well.
+            %
+            % idNameEntity (char/nix.Section):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Section has been removed, false otherwise.
+            %
+            % Example:  check = currSection.deleteSection('23bb8a99-1812-4bc6-a52c');
+            %           check = currSection.deleteSection('electrode_array');
+            %           check = currFile.sections{1}.deleteSection(newSectionEntity);
+
+            r = nix.Utils.deleteEntity(obj, 'deleteSection', idNameEntity, 'nix.Section');
         end
 
         function r = openSection(obj, idName)
+            % Retrieves an existing direct child Section from the invoking Section.
+            %
+            % idName (char):  Name or ID of the Section.
+            %
+            % Returns:  (nix.Section) The nix.Section or an empty cell, 
+            %                         if the Section was not found.
+            %
+            % Example:  getSec = currSection.openSection('some-section-id');
+            %           getSec = currFile.sections{1}.openSection('electrode_array');
+
             r = nix.Utils.openEntity(obj, 'openSection', idName, @nix.Section);
         end
 
         function r = openSectionIdx(obj, index)
+            % Retrieves an Section from the invoking Section, accessed by index.
+            %
+            % index (double):  The index of the Section to read.
+            %
+            % Returns:  (nix.Section) The Section at the given index.
+            %
+            % Example:  getSec = currSection.openSectionIdx(1);
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openSectionIdx', idx, @nix.Section);
         end
 
         function r = hasSection(obj, idName)
+            % Check if a Section exists as a direct child of the invoking Section.
+            %
+            % idName (char):  Name or ID of the Section.
+            %
+            % Returns:  (logical) True if the Section exists, false otherwise.
+            %
+            % Example:  check = currSection.hasSection('some-section-id');
+            %           check = currFile.sections{2653}.hasSection('settings1');
+
             r = nix.Utils.fetchHasEntity(obj, 'hasSection', idName);
         end
 
         function r = sectionCount(obj)
+            % Get the number of direct child Sections of the invoking Section.
+            %
+            % Returns:  (uint) The number of direct child (non nested) Sections.
+            %
+            % Example:  sc = currSection.sectionCount();
+
             r = nix.Utils.fetchEntityCount(obj, 'sectionCount');
         end
 
         function r = filterSections(obj, filter, val)
+            % Get a filtered cell array of all child Sections of the invoking Section.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       The filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Section]) A cell array of Sections filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getSecs = currSection.filterSections(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Filter.
+
             r = nix.Utils.filter(obj, 'sectionsFiltered', filter, val, @nix.Section);
         end
 
-        % findRelated returns the nearest occurrence downstream of a
-        % nix.Section matching the filter.
-        % If no section can be found downstream, it will look for the
-        % nearest occurrence upstream of a nix.Section matching the filter.
         function r = findRelated(obj, filter, val)
+            % Returns the nearest occurrence of a nix.Section from the
+            % invoking Section matching the provided nix.Filter.
+            %
+            % The function first searches downstream of the invoking Section for a 
+            % Section matching the provided nix.Filter. If no Section can be found 
+            % downstream, it will look for the nearest occurrence upstream of the 
+            % invoking Section for a match.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       The filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  (nix.Section) The first Section matching the provided nix.Filter.
+            %
+            % Example:  getSection = currSection.findRelated(nix.Filter.type, 'ephys');
+            %
+            % See also nix.Filter.
+
             r = nix.Utils.filter(obj, 'findRelated', filter, val, @nix.Section);
         end
 
-        % maxDepth is handled like an index
         function r = findSections(obj, maxDepth)
+            % Get all Sections and their child Sections of the 
+            % invoking Section recursively.
+            %
+            % This method traverses the trees of all Sections of the invoking Section
+            % and adds all Sections to the resulting cell array, until the maximum depth
+            % of the nested Sections has been reached. The traversal is accomplished via
+            % breadth first and adds the Sections accordingly.
+            %
+            % maxDepth (double):  The maximum depth of traversal to retrieve nested 
+            %                     Sections. Should be handled like an index.
+            %
+            % Example:  allSec = currSection.findSections(2);
+            %           % will add all Sections until including the 2nd layer of Sections.
+
             r = obj.filterFindSections(maxDepth, nix.Filter.acceptall, '');
         end
 
-        % maxDepth is handled like an index
         function r = filterFindSections(obj, maxDepth, filter, val)
+            % Get all Sections of the invoking Section recursively.
+            %
+            % This method traverses the trees of all Sections of the invoking Section.
+            % The traversal is accomplished via breadth first and can be limited in depth.
+            % On each node or Section a nix.Filter is applied. If the filter returns true,
+            % the respective Section will be added to the result list.
+            %
+            % maxDepth (double):    The maximum depth of traversal to retrieve nested 
+            %                       Sections. Should be handled like an index.
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports the filters 
+            %                       'acceptall', 'id', 'ids', 'name' and 'type'.
+            % val (char):           Value that is applied with the selected filter.
+            %
+            % Example:  allSec = currSection.filterFindSections(...
+            %                                               2, nix.Filter.type, 'ephys');
+            %
+            % See also nix.Filter.
+
             r = nix.Utils.find(obj, 'findSections', maxDepth, filter, val, @nix.Section);
         end
 
@@ -110,6 +308,18 @@ classdef Section < nix.NamedEntity
         % ----------------
 
         function r = createProperty(obj, name, datatype)
+            % Creates a nix.Property without values as child of the invoking Section.
+            %
+            % name (char):              Name of the added Property.
+            % datatype (nix.DataType):  Valid nix.DataType of the added Property.
+            %
+            % Returns:  (nix.Property) The created Property.
+            %
+            % Example:  newProperty = currSection.createProperty(...
+            %                                         'condition', nix.DataType.String);
+            %
+            % See also nix.Property, nix.DataType.
+
             if (~isa(datatype, 'nix.DataType'))
                 err.identifier = 'NIXMX:InvalidArgument';
                 err.message = 'Please provide a valid nix.DataType';
@@ -122,6 +332,19 @@ classdef Section < nix.NamedEntity
         end
 
         function r = createPropertyWithValue(obj, name, val)
+            % Creates a nix.Property as child of the invoking Section.
+            %
+            % name (char):     Name of the added Property.
+            % val (variable):  Cell array of values of the same type. The
+            %                  data type of the values will be inferred automatically.
+            %
+            % Returns:  (nix.Property) The created Property.
+            %
+            % Example:  newProperty = currSection.createProperty(...
+            %                               'Experimenter', {'First name', 'Last name'});
+            %
+            % See also nix.Property, nix.DataType.
+
             if (~iscell(val))
                 val = num2cell(val);
             end
@@ -130,31 +353,84 @@ classdef Section < nix.NamedEntity
             r = nix.Utils.createEntity(h, @nix.Property);
         end
 
-        function r = deleteProperty(obj, del)
-            if (isstruct(del) && isfield(del, 'id'))
-                id = del.id;
-            else
-                id = nix.Utils.parseEntityId(del, 'nix.Property');
-            end
+        function r = deleteProperty(obj, idNameEntity)
+            % Deletes a nix.Property from the invoking Section.
+            %
+            % When a Property is deleted, all of its Values will be deleted as well.
+            %
+            % idNameEntity (char/nix.Property):  Name or id of the entity to
+            %                                    be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Property has been removed, false otherwise.
+            %
+            % Example:  check = currSection.deleteProperty('some-property-id-101');
+            %           check = currSection.deleteProperty('condition');
+            %           check = currFile.sections{1}.deleteProperty(newPropertyEntity);
+            %
+            % See also nix.Property.
 
-            fname = strcat(obj.alias, '::deleteProperty');
-            r = nix_mx(fname, obj.nixhandle, id);
+            r = nix.Utils.deleteEntity(obj, 'deleteProperty', idNameEntity, 'nix.Property');
         end
 
         function r = openProperty(obj, idName)
+            % Retrieves a nix.Property from the invoking Section.
+            %
+            % idName (char):  Name or ID of the Property.
+            %
+            % Returns:  (nix.Property) The Property or an empty cell, 
+            %                          if the Property was not found.
+            %
+            % Example:  getProperty = currSection.openProperty('some-property-id');
+            %           getProperty = currFile.sections{1}.openProperty('condition');
+            %
+            % See also nix.Property.
+
             r = nix.Utils.openEntity(obj, 'openProperty', idName, @nix.Property);
         end
 
         function r = openPropertyIdx(obj, index)
+            % Retrieves a nix.Property from the invoking Section, accessed by index.
+            %
+            % index (double):  The index of the Property to read.
+            %
+            % Returns:  (nix.Property) The Property at the given index.
+            %
+            % Example:  getProperty = currSection.openPropertyIdx(1);
+            %
+            % See also nix.Property.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openPropertyIdx', idx, @nix.Property);
         end
 
         function r = propertyCount(obj)
+            % Get the number of the child nix.Properties of the invoking Section.
+            %
+            % Returns:  (uint) The number of child Properties.
+            %
+            % Example:  pc = currSection.propertyCount();
+            %
+            % See also nix.Property.
+
             r = nix.Utils.fetchEntityCount(obj, 'propertyCount');
         end
 
         function r = filterProperties(obj, filter, val)
+            % Get a filtered cell array of all child Properties of the invoking Section.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       filters 'acceptall', 'id', 'ids' and 'name'. 
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Property]) A cell array of Properties filtered according
+            %                            to the applied nix.Filter.
+            %
+            % Example:  getProperties = currSection.filterProperties(...
+            %                                           nix.Filter.name, 'condition');
+            %
+            % See also nix.Property, nix.Filter.
+
             r = nix.Utils.filter(obj, 'propertiesFiltered', filter, val, @nix.Property);
         end
 
@@ -163,22 +439,107 @@ classdef Section < nix.NamedEntity
         % ----------------
 
         function r = referringDataArrays(obj, varargin)
+            % Returns all nix.DataArrays which reference the invoking Section.
+            %
+            % varargin (empty/nix.Block):  If the argument is empty, the search will be 
+            %                              performed in the while file. If a nix.Block 
+            %                              entity is provided, the search will be 
+            %                              performed only in the provided Block.
+            %
+            % Returns:  ([nix.DataArray]) A cell array of all DataArray entities
+            %                             referring to the invoking Section.
+            %
+            % Example:
+            %   % get all DataArrays in the file referenced by currSection.
+            %   getDataArrays = currSection.referringDataArrays();
+            %
+            %   % get all DataArrays in Block blockEntity referenced by currSection.
+            %   getDataArrays = currSection.referringDataArrays(blockEntity);
+            %
+            % See also nix.Block, nix.DataArray.
+
             r = obj.referringUtil(@nix.DataArray, 'DataArrays', varargin{:});
         end
 
         function r = referringTags(obj, varargin)
+            % Returns all nix.Tags which reference the invoking Section.
+            %
+            % varargin (empty/nix.Block):  If the argument is empty, the search will be 
+            %                              performed in the while file. If a nix.Block 
+            %                              entity is provided, the search will be 
+            %                              performed only in the provided Block.
+            %
+            % Returns:  ([nix.Tag]) A cell array of all Tag entities
+            %                       referring to the invoking Section.
+            %
+            % Example:
+            %   % get all Tags in the file referenced by currSection.
+            %   getTags = currSection.referringTags();
+            %
+            %   % get all Tags in Block blockEntity referenced by currSection.
+            %   getTags = currSection.referringTags(blockEntity);
+            %
+            % See also nix.Block, nix.Tag.
+
             r = obj.referringUtil(@nix.Tag, 'Tags', varargin{:});
         end
 
         function r = referringMultiTags(obj, varargin)
+            % Returns all nix.MultiTags which reference the invoking Section.
+            %
+            % varargin (empty/nix.Block):  If the argument is empty, the search will be 
+            %                              performed in the while file. If a nix.Block 
+            %                              entity is provided, the search will be 
+            %                              performed only in the provided Block.
+            %
+            % Returns:  ([nix.MultiTag]) A cell array of all MultiTag entities
+            %                            referring to the invoking Section.
+            %
+            % Example:
+            %   % get all MultiTags in the file referenced by currSection.
+            %   getMultiTags = currSection.referringMultiTags();
+            %
+            %   % get all MultiTags in Block blockEntity referenced by currSection.
+            %   getMultiTags = currSection.referringMultiTags(blockEntity);
+            %
+            % See also nix.Block, nix.MultiTag.
+
             r = obj.referringUtil(@nix.MultiTag, 'MultiTags', varargin{:});
         end
 
         function r = referringSources(obj, varargin)
+            % Returns all nix.Sources which reference the invoking Section.
+            %
+            % varargin (empty/nix.Block):  If the argument is empty, the search will be 
+            %                              performed in the while file. If a nix.Block 
+            %                              entity is provided, the search will be 
+            %                              performed only in the provided Block.
+            %
+            % Returns:  ([nix.Source]) A cell array of all Source entities
+            %                          referring to the invoking Section.
+            %
+            % Example:
+            %   % get all Sources in the file referenced by currSection.
+            %   getSources = currSection.referringSources();
+            %
+            %   % get all Sources in Block blockEntity referenced by currSection.
+            %   getSources = currSection.referringSources(blockEntity);
+            %
+            % See also nix.Block, nix.Source.
+
             r = obj.referringUtil(@nix.Source, 'Sources', varargin{:});
         end
 
         function r = referringBlocks(obj)
+            % Returns all nix.Blocks which reference the invoking Section.
+            %
+            % Returns:  ([nix.Block]) A cell array of all Block entities
+            %                         referring to the invoking Section.
+            %
+            % Example:  getBlocks = currSection.referringBlocks();
+            %
+            % See also nix.Block.
+
             r = nix.Utils.fetchObjList(obj, 'referringBlocks', @nix.Block);
         end
     end
@@ -188,10 +549,18 @@ classdef Section < nix.NamedEntity
     % ----------------
 
     methods (Access=protected)
-        % referringUtil receives a nix entityConstructor, part of a function
-        % name and varargin to provide abstract access to nix.Section
-        % referringXXX and referringXXX(Block) methods.
         function r = referringUtil(obj, entityConstructor, fsuffix, varargin)
+            % Provides abstract access to nix.Section referringXXX and
+            % referringXXX(nix.Block) methods.
+            %
+            % entityConstructor (nix.Entity constructor)
+            % fsuffic (char)
+            % varargin (empty/nix.Block)
+            %
+            % Returns:  ([nix.Entity])
+            %
+            % Utility function, do not use out of context.
+
             if (isempty(varargin))
                 fname = strcat('referring', fsuffix);
                 r = nix.Utils.fetchObjList(obj, fname, entityConstructor);

--- a/+nix/SetDimension.m
+++ b/+nix/SetDimension.m
@@ -1,3 +1,23 @@
+% nix.SetDimension class provides access to the SetDimension properties.
+%
+% Used to provide labels for dimensionless data e.g. when stacking  different signals. 
+% In the example the first dimension would describe the measured unit, the second 
+% dimension the time, the third dimension would provide labels for three different
+% signals measured within the same experiment and packed into the same 3D DataArray.
+%
+% nix.SetDimension dynamic properties
+%   dimensionType (char):  read-only, returns type of the dimension as string.
+%   labels ([char]):       read-write, Character cell array to get and set
+%                            labels of the dimension.
+%
+%  Examples:    dt = currDataArray.dimensions{1}.dimensionType;
+%
+%               labels = currDataArray.dimensions{2}.labels;
+%               currDataArray.dimensions{2}.labels = {'sinus', 'cosinus'};
+%
+% See also nix.DataArray.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +27,9 @@
 % LICENSE file in the root of the Project.
 
 classdef SetDimension < nix.Entity
-    % SetDimension nix SetDimension object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'SetDimension'
+        alias = 'SetDimension'  % nix-mx namespace to access SetDimension specific nix backend functions.
     end
 
     methods

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -145,12 +145,12 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = referringDataArrays(obj)
-            % Returns all nix.DataArrays which referrence the invoking Source.
+            % Returns all nix.DataArrays which reference the invoking Source.
             %
             % Returns:  ([nix.DataArray]) A cell array of all DataArray entities
             %                             referring to the invoking Source.
             %
-            % Example:  getSource = currSource.referringDataArrays();
+            % Example:  getDataArrays = currSource.referringDataArrays();
             %
             % See also nix.DataArray.
 
@@ -158,12 +158,12 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = referringTags(obj)
-            % Returns all nix.Tags which referrence the invoking Source.
+            % Returns all nix.Tags which reference the invoking Source.
             %
             % Returns:  ([nix.Tag]) A cell array of all Tag entities
             %                       referring to the invoking Source.
             %
-            % Example:  getSource = currSource.referringTags();
+            % Example:  getTags = currSource.referringTags();
             %
             % See also nix.Tag.
 
@@ -171,12 +171,12 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         end
 
         function r = referringMultiTags(obj)
-            % Returns all nix.MultiTags which referrence the invoking Source.
+            % Returns all nix.MultiTags which reference the invoking Source.
             %
             % Returns:  ([nix.MultiTag]) A cell array of all MultiTag entities
             %                            referring to the invoking Source.
             %
-            % Example:  getSource = currSource.referringMultiTags();
+            % Example:  getMultiTags = currSource.referringMultiTags();
             %
             % See also nix.MultiTag.
 
@@ -187,7 +187,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             % Get a filtered cell array of all direct child Sources 
             % of the invoking Source.
             %
-            % filter (nix.Filter):  the nix.Filter to be applied.
+            % filter (nix.Filter):  The nix.Filter to be applied.
             % val (char):           Value that is applied with the selected
             %                       filter.
             %

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -15,6 +15,9 @@
 %                         entity and expose it to search methods in a broader context.
 %   definition (char):  read-write, additional description of the entity.
 %
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
+%
 % nix.Source dynamic child entity properties:
 %   sources      access to all nix.Source child entities.
 %
@@ -32,7 +35,7 @@
 classdef Source < nix.NamedEntity & nix.MetadataMixIn
 
     properties (Hidden)
-        alias = 'Source'  % nix-mx namespace to access Source specific nix backend functions.
+        alias = 'Source'  % namespace for Source nix backend function access.
     end
 
     methods

--- a/+nix/Source.m
+++ b/+nix/Source.m
@@ -1,3 +1,26 @@
+% nix.Source class is used to describe the provenance of other entities 
+% of the NIX data model.
+%
+% The Source entity is used to note the provenance of the data and offers the 
+% option to bind simple, low level additional metadata.
+% One special feature of the Source is the possibility to reference other Sources as 
+% children thus building up a tree of Sources.
+% This can, for example, be used to specify that a Source 'electrode array' contains
+% multiple electrodes as its child Sources.
+%
+% nix.Source dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, additional description of the entity.
+%
+% nix.Source dynamic child entity properties:
+%   sources      access to all nix.Source child entities.
+%
+% See also nix.Block, nix.DataArray, nix.Tag, nix.MultiTag, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +30,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Source < nix.NamedEntity & nix.MetadataMixIn
-    % Source nix Source object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Source'
+        alias = 'Source'  % nix-mx namespace to access Source specific nix backend functions.
     end
 
     methods
@@ -19,7 +40,7 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
             obj@nix.NamedEntity(h);
             obj@nix.MetadataMixIn();
 
-            % assign relations
+            % assign child entities
             nix.Dynamic.addGetChildEntities(obj, 'sources', @nix.Source);
         end
 
@@ -28,59 +49,198 @@ classdef Source < nix.NamedEntity & nix.MetadataMixIn
         % ------------------
 
         function r = sourceCount(obj)
+            % Get the number of direct child nix.Sources.
+            %
+            % Returns:  (uint) The number of child Sources.
+            %
+            % Example:  sc = currSource.sourceCount();
+
             r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
         function r = createSource(obj, name, type)
+            % Create a new nix.Source entity associated with the invoking Source.
+            %
+            % name (char):  The name of the Source, has to be unique within the file.
+            % type (char):  The type of the Source.
+            %
+            % Returns:  (nix.Source) The newly created Source.
+            %
+            % Example:  newSource = currSource.createSource('cell5', 'pyramidal');
+
             fname = strcat(obj.alias, '::createSource');
             h = nix_mx(fname, obj.nixhandle, name, type);
             r = nix.Utils.createEntity(h, @nix.Source);
         end
 
         function r = hasSource(obj, idName)
+            % Check if a nix.Source exists as a direct child of the invoking Source.
+            %
+            % idName (char):  Name or ID of the Source.
+            %
+            % Returns:  (logical) True if the Source exists, false otherwise.
+            %
+            % Example:  check = currSource.hasSource('some-source-id');
+            %           check = currFile.blocks{1}.sources{1}.hasSource('cell5');
+
             r = nix.Utils.fetchHasEntity(obj, 'hasSource', idName);
         end
 
-        function r = deleteSource(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteSource', del, 'nix.Source');
+        function r = deleteSource(obj, idNameEntity)
+            % Deletes a nix.Source and its children from the invoking Source.
+            %
+            % When a Source is deleted, all its sub-Sources
+            % will be deleted recursively from the Source as well.
+            %
+            % idNameEntity (char/nix.Source):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the Source has been removed, false otherwise.
+            %
+            % Example:  check = currSource.deleteSource('23bb8a99-1812-4bc6-a52c');
+            %           check = currSource.deleteSource('cell5');
+            %           check = currFile.blocks{1}.sources{1}.deleteSource(newSource);
+
+            r = nix.Utils.deleteEntity(obj, 'deleteSource', idNameEntity, 'nix.Source');
         end
 
         function r = openSource(obj, idName)
+            % Retrieves an existing direct Source from the invoking Source.
+            %
+            % idName (char):  Name or ID of the Source.
+            %
+            % Returns:  (nix.Source) The nix.Source or an empty cell, 
+            %                       if the Source was not found.
+            %
+            % Example:  getSource = currSource.openSource('23bb8a99-1812-4bc6-a52c');
+            %           getSource = currFile.blocks{1}.sources{1}.openSource('cell5');
+
             r = nix.Utils.openEntity(obj, 'openSource', idName, @nix.Source);
         end
 
         function r = openSourceIdx(obj, index)
+            % Retrieves an existing nix.Source from the invoking Source, 
+            % accessed by index.
+            %
+            % index (double):  The index of the Source to read.
+            %
+            % Returns:  (nix.Source) The Source at the given index.
+            %
+            % Example:  getSource = currSource.openSourceIdx(1);
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = parentSource(obj)
+            % Returns the parent Source of the invoking Source. Method performs a search,
+            % may thus not be the most efficient way.
+            %
+            % Returns:  (nix.Source) The parent Source if there is any, 
+            %                        an empty cell array otherwise.
+            %
+            % Example:  getSource = currSource.parentSource();
+
             r = nix.Utils.fetchObj(obj, 'parentSource', @nix.Source);
         end
 
         function r = referringDataArrays(obj)
+            % Returns all nix.DataArrays which referrence the invoking Source.
+            %
+            % Returns:  ([nix.DataArray]) A cell array of all DataArray entities
+            %                             referring to the invoking Source.
+            %
+            % Example:  getSource = currSource.referringDataArrays();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchObjList(obj, 'referringDataArrays', @nix.DataArray);
         end
 
         function r = referringTags(obj)
+            % Returns all nix.Tags which referrence the invoking Source.
+            %
+            % Returns:  ([nix.Tag]) A cell array of all Tag entities
+            %                       referring to the invoking Source.
+            %
+            % Example:  getSource = currSource.referringTags();
+            %
+            % See also nix.Tag.
+
             r = nix.Utils.fetchObjList(obj, 'referringTags', @nix.Tag);
         end
 
         function r = referringMultiTags(obj)
+            % Returns all nix.MultiTags which referrence the invoking Source.
+            %
+            % Returns:  ([nix.MultiTag]) A cell array of all MultiTag entities
+            %                            referring to the invoking Source.
+            %
+            % Example:  getSource = currSource.referringMultiTags();
+            %
+            % See also nix.MultiTag.
+
             r = nix.Utils.fetchObjList(obj, 'referringMultiTags', @nix.MultiTag);
         end
 
         function r = filterSources(obj, filter, val)
+            % Get a filtered cell array of all direct child Sources 
+            % of the invoking Source.
+            %
+            % filter (nix.Filter):  the nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Source]) A cell array of Sources filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getSources = currSource.filterSources(nix.Filter.type, 'pyramidal');
+            %
+            % See also nix.Filter.
+
             r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
 
-        % maxdepth is an index where idx = 0 corresponds to the calling source
         function r = findSources(obj, maxDepth)
+            % Get all Sources and their child Sources in the invoking Source recursively.
+            %
+            % This method traverses the trees of all Sources in the Source and adds all
+            % Sources to the resulting cell array, until the maximum depth of the nested
+            % Sources has been reached. The traversal is accomplished via breadth first 
+            % and adds the Sources accordingly.
+            %
+            % maxDepth (double):  The maximum depth of traversal to retrieve nested 
+            %                     Sources. Should be handled like an index,
+            %                     where idx = 0 corresponds to the calling source.
+            %
+            % Example:  allSources = currSource.findSources(2);
+            %           % will add all Sources until including the 2nd layer of Sources.
+
             r = obj.filterFindSources(maxDepth, nix.Filter.acceptall, '');
         end
 
-        % maxdepth is an index where idx = 0 corresponds to the calling source
         function r = filterFindSources(obj, maxDepth, filter, val)
+            % Get all Sources and their child Sources in the invoking Source recursively.
+            %
+            % This method traverses the trees of all Sources of the invoking Source.
+            % The traversal is accomplished via breadth first and can be limited in depth.
+            % On each node or Source a nix.Filter is applied. If the filter returns true,
+            % the respective Source will be added to the result list.
+            %
+            % maxDepth (double):    The maximum depth of traversal to retrieve nested 
+            %                       Sources. Should be handled like an index,
+            %                       where idx = 0 corresponds to the calling source.
+            % filter (nix.Filter):  The nix.Filter to be applied. Supports
+            %                       the filters 'acceptall', 'id', 'ids',
+            %                       'name' and 'type'.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Example:  allSources = currSource.filterFindSources(...
+            %                               2, nix.Filter.type, 'ephys');
+            %
+            % See also nix.Filter.
+
             r = nix.Utils.find(obj, 'findSources', maxDepth, filter, val, @nix.Source);
         end
     end

--- a/+nix/SourcesMixIn.m
+++ b/+nix/SourcesMixIn.m
@@ -1,3 +1,12 @@
+% Mixin Class for entities that can be associated with a nix.Source entity.
+%
+% In order to describe the provenance of data some entities of the NIX data model
+% can be associated with nix.Source entities. This class serves as a base class
+% for those.
+%
+% See also nix.Source, nix.Group, nix.DataArray, nix.Tag, nix.MultiTag.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +16,6 @@
 % LICENSE file in the root of the Project.
 
 classdef SourcesMixIn < handle
-    % SourcesMixIn
-    % mixin class for nix entities that can be related with sources
 
     properties (Abstract, Hidden)
         alias
@@ -20,37 +27,130 @@ classdef SourcesMixIn < handle
         end
 
         function r = sourceCount(obj)
+            % Get the number of direct child nix.Sources.
+            %
+            % Returns:  (uint) The number of child Sources.
+            %
+            % Example:  sc = currEntity.sourceCount();
+            %
+            % See also nix.Source.
+
             r = nix.Utils.fetchEntityCount(obj, 'sourceCount');
         end
 
-        % hasSource supports only check by id, not by name
         function r = hasSource(obj, idEntity)
+            % Check if a nix.Source exists as a direct child of the invoking Entity.
+            %
+            % idEntity (char/nix.Source):  ID of the Source or the Source itself.
+            %
+            % Returns:  (logical) True if the Source exists, false otherwise.
+            %
+            % Example:  check = currEntity.hasSource('some-source-id');
+            %           check = currFile.blocks{1}.tags{1}.hasSource(newSourceEntity);
+            %
+            % See also nix.Source.
+
             has = nix.Utils.parseEntityId(idEntity, 'nix.Source');
             r = nix.Utils.fetchHasEntity(obj, 'hasSource', has);
         end
 
-        function [] = addSource(obj, entity)
-            nix.Utils.addEntity(obj, 'addSource', entity, 'nix.Source');
+        function [] = addSource(obj, idEntity)
+            % Add an existing nix.Source to the referenced list of the invoking Entity.
+            %
+            % idEntity (char/nix.Source):  The ID of an existing Source, 
+            %                              or a nix.Source entity.
+            %
+            % Example:  currEntity.addSource('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currFile.blocks{1}.groups{1}.addSource(newSourceEntity);
+            %
+            % See also nix.Source.
+
+            nix.Utils.addEntity(obj, 'addSource', idEntity, 'nix.Source');
         end
 
         function [] = addSources(obj, entityArray)
+            % Set the list of referenced Sources for the invoking Entity.
+            %
+            % Previously referenced Sources that are not in the
+            % references cell array will be removed.
+            %
+            % entityArray ([nix.Source]):  A cell array of nix.Sources.
+            %
+            % Example:  currEntity.addSources({source1, source2});
+            %
+            % See also nix.Source.
+
             nix.Utils.addEntityArray(obj, 'addSources', entityArray, 'nix.Source');
         end
 
-        function r = removeSource(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'removeSource', del, 'nix.Source');
+        function r = removeSource(obj, idEntity)
+            % Removes the reference to a nix.Source from the invoking Entity.
+            %
+            % This method removes the association between the Source and the
+            % Entity, the Source itself will not be removed from the file.
+            %
+            % idEntity (char/nix.Source):  id of the Source to be removed
+            %                              or the Source itself.
+            %
+            % Returns:  (logical) True if the reference to the Source 
+            %                     has been removed, false otherwise.
+            %
+            % Example:  check = currEntity.removeSource('23bb8a99-1812-4bc6-a52c');
+            %           check = currFile.blocks{1}.groups{1}.removeSource(newSourceEntity);
+            %
+            % See also nix.Source.
+
+            r = nix.Utils.deleteEntity(obj, 'removeSource', idEntity, 'nix.Source');
         end
 
         function r = openSource(obj, idName)
+            % Retrieves an existing Source from the invoking Entity.
+            %
+            % idName (char):  Name or ID of the Source.
+            %
+            % Returns:  (nix.Source) The nix.Source or an empty cell, 
+            %                        if the Source was not found.
+            %
+            % Example:  getSource = currEntity.openSource('23bb8a99-1812-4bc6-a52c');
+            %           getSource = currFile.blocks{1}.tags{1}.openSource('subTrial2');
+            %
+            % See also nix.Source.
+
             r = nix.Utils.openEntity(obj, 'openSource', idName, @nix.Source);
         end
 
         function r = openSourceIdx(obj, index)
+            % Retrieves an existing nix.Source from the invoking Entity, 
+            % accessed by index.
+            %
+            % index (double):  The index of the Source to read.
+            %
+            % Returns:  (nix.Source) The Source at the given index.
+            %
+            % Example:  getSource = currEntity.openSourceIdx(1);
+            %
+            % See also nix.Source.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openSourceIdx', idx, @nix.Source);
         end
 
         function r = filterSources(obj, filter, val)
+            % Get a filtered cell array of all Source entities 
+            % referenced by the invoking Entity.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Source]) A cell array of Sources filtered according
+            %                          to the applied nix.Filter.
+            %
+            % Example:  getSources = currEntity.filterSources(...
+            %                                       nix.Filter.type, 'ephys_data');
+            %
+            % See also nix.Source, nix.Filter.
+
             r = nix.Utils.filter(obj, 'sourcesFiltered', filter, val, @nix.Source);
         end
     end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -37,7 +37,6 @@
 %   references   access to all nix.DataArray child entities referenced by the Tag.
 %   features     access to all nix.Features child entities referenced by the Tag.
 %   sources      access to all first level nix.Source child entities.
-%   sections     access to all first level nix.Section child entities.
 %
 % See also nix.DataArray, nix.Feature, nix.Source, nix.Section.
 %

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -1,3 +1,47 @@
+% nix.Tag class to annotate ('tag') regions of interrest in DataArrays.
+%
+% Besides the DataArray the Tag entities can be considered as the other core entities 
+% of the data model. They are meant to attach annotations directly to the data and to 
+% establish meaningful links between different kinds of stored data. Most importantly 
+% Tags allow the definition of points or regions of interest in data that is stored in 
+% other DataArray entities. The DataArray entities the Tag applies to are defined by 
+% its property references. One Tag can reference data in multiple DataArrays.
+%
+% Further the referenced data is defined by an origin vector called position and an 
+% optional extent vector that defines its size. Therefore position and extent of a Tag, 
+% together with the references field defines a group of points or regions of interest 
+% collected from a subset of all available DataArray entities.
+%
+% Further Tags have a field called nix.Features which makes it possible to associate other 
+% data with the Tag. Semantically a Feature of a Tag is some additional data that 
+% contains additional information about the points of hyperslabs defined by the Tag. 
+% This could be for example data that represents a stimulus (e.g. an image or a signal) 
+% that was applied in a certain interval during the recording.
+%
+% nix.Tag dynamic properties:
+%   id (char):          read-only, automatically created id of the entity.
+%   name (char):        read-only, name of the entity.      
+%   type (char):        read-write, type can be used to give semantic meaning to an 
+%                         entity and expose it to search methods in a broader context.
+%   definition (char):  read-write, optional description of the entity.
+%   position (double):  read-write, the position is a vector that points into referenced 
+%                           DataArrays.
+%   extent (double):    read-write, given a specified position vector, the extent vector 
+%                           defined the size of a region of interest in the 
+%                           referenced DataArray entities.
+%   unit ([char]):        read-write, the array of units is applied to all values for 
+%                           position and extent in order to calculate the right position
+%                           vectors in referenced DataArrays.
+%
+% nix.Tag dynamic child entity properties:
+%   references   access to all nix.DataArray child entities referenced by the Tag.
+%   features     access to all nix.Features child entities referenced by the Tag.
+%   sources      access to all first level nix.Source child entities.
+%   sections     access to all first level nix.Section child entities.
+%
+% See also nix.DataArray, nix.Feature, nix.Source, nix.Section.
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,11 +51,9 @@
 % LICENSE file in the root of the Project.
 
 classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
-    % Tag nix Tag object
 
     properties (Hidden)
-        % namespace reference for nix-mx functions
-        alias = 'Tag'
+        alias = 'Tag'  % nix-mx namespace to access Tag specific nix backend functions.
     end
 
     methods
@@ -25,7 +67,7 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
             nix.Dynamic.addProperty(obj, 'extent', 'rw');
             nix.Dynamic.addProperty(obj, 'units', 'rw');
 
-            % assign relations
+            % assign child entities
             nix.Dynamic.addGetChildEntities(obj, 'references', @nix.DataArray);
             nix.Dynamic.addGetChildEntities(obj, 'features', @nix.Feature);
         end
@@ -34,38 +76,136 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % References methods
         % ------------------
 
-        function [] = addReference(obj, entity)
-            nix.Utils.addEntity(obj, 'addReference', entity, 'nix.DataArray');
+        function [] = addReference(obj, idNameEntity)
+            % Add a nix.DataArray to the referenced list of the invoking Tag.
+            %
+            % idNameEntity (char/nix.DataArray):  The id or name of an existing DataArray,
+            %                                     or a valid nix.DataArray entity.
+            %
+            % Example:  currTag.addReferences('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           currTag.addReferences('subTrial2');
+            %           currFile.blocks{1}.tags{1}.addReferences(currDataArrayEntity);
+            %
+            % See also nix.DataArray.
+
+            nix.Utils.addEntity(obj, 'addReference', idNameEntity, 'nix.DataArray');
         end
 
         function [] = addReferences(obj, entityArray)
+            % Set the list of referenced DataArrays for the invoking Tag.
+            %
+            % Previously referenced DataArrays that are not in the
+            % references cell array will be removed.
+            %
+            % entityArray ([nix.DataArray]):  A cell array of nix.DataArrays.
+            %
+            % Example:  currTag.addReferences({dataArray1, dataArray2});
+            %
+            % See also nix.DataArray.
+
             nix.Utils.addEntityArray(obj, 'addReferences', entityArray, 'nix.DataArray');
         end
 
         function r = hasReference(obj, idName)
+            % Check if a nix.DataArray is referenced by the invoking Tag.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (logical) True if the DataArray exists, false otherwise.
+            %
+            % Example:  check = currTag.hasReference('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.tags{1}.hasReference('sessionData2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchHasEntity(obj, 'hasReference', idName);
         end
 
-        function r = removeReference(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'removeReference', del, 'nix.DataArray');
+        function r = removeReference(obj, idNameEntity)
+            % Removes the reference to a nix.DataArray from the invoking Tag.
+            %
+            % This method removes the association between the DataArray and the
+            % Tag, the DataArray itself will not be removed from the file.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the entity to
+            %                                   be deleted or the entity itself.
+            %
+            % Returns:  (logical) True if the reference to the DataArray 
+            %                     has been removed, false otherwise.
+            %
+            % Example:  check = currTag.removeReference('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currTag.removeReference('sessionData2');
+            %           check = currFile.blocks{1}.tags{1}.removeReference(newDataArray);
+            %
+            % See also nix.DataArray.
+
+            r = nix.Utils.deleteEntity(obj, 'removeReference', idNameEntity, 'nix.DataArray');
         end
 
         function r = openReference(obj, idName)
+            % Retrieves a referenced DataArray from the invoking Tag.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (nix.DataArray) The nix.DataArray or an empty cell, 
+            %                       if the DataArray was not found.
+            %
+            % Example:  getDA = currTag.openReference('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           getDA = currFile.blocks{1}.tags{1}.openReference('subTrial2');
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.openEntity(obj, 'openReferenceDataArray', idName, @nix.DataArray);
         end
 
         function r = openReferenceIdx(obj, index)
+            % Retrieves a referenced nix.DataArray from the invoking Tag, 
+            % accessed by index.
+            %
+            % index (double):  The index of the DataArray to read.
+            %
+            % Returns:  (nix.DataArray) The DataArray at the given index.
+            %
+            % Example:  getDA = currTag.openReferenceIdx(1);
+            %
+            % See also nix.DataArray.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openReferenceIdx', idx, @nix.DataArray);
         end
 
         function r = retrieveData(obj, idName)
+            % Returns the data from a DataArray referenced by the invoking Tag.
+            %
+            % idName (char):  Name or ID of the DataArray.
+            %
+            % Returns:  (var) Data of the DataArray referenced by the Tag.
+            %                   The Data is detached from the nix.File,
+            %                   changes to this data will not be saved to the file.
+            %
+            % Example:  data = currTag.retriveData('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           data = currFile.blocks{1}.tags{1}.retrieveData('subTrial2');
+            %
+            % See also nix.DataArray
+
             fname = strcat(obj.alias, '::retrieveData');
             data = nix_mx(fname, obj.nixhandle, idName);
             r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveDataIdx(obj, index)
+            % Returns the data from a DataArray referenced by the invoking Tag.
+            %
+            % index (double):  index of the referenced DataArray.
+            %
+            % Returns:  (var) Data of the DataArray referenced by the Tag.
+            %                   The Data is detached from the nix.File,
+            %                   changes to this data will not be saved to the file.
+            %
+            % Example:  data = currTag.retriveDataIdx(1);
+            %
+            % See also nix.DataArray
+
             idx = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::retrieveDataIdx');
             data = nix_mx(fname, obj.nixhandle, idx);
@@ -73,10 +213,32 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = referenceCount(obj)
+            % Get the number nix.DataArrays referenced by the invoking Tag.
+            %
+            % Returns:  (uint) The number of referenced DataArrays.
+            %
+            % Example:  dc = currTag.referenceCount();
+            %
+            % See also nix.DataArray.
+
             r = nix.Utils.fetchEntityCount(obj, 'referenceCount');
         end
 
         function r = filterReferences(obj, filter, val)
+            % Get a filtered cell array of all DataArrays referenced by the 
+            % invoking Tag.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.DataArray]) A cell array of DataArrays filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getDAs = currTag.filterReferences(nix.Filter.type, 'ephys_data');
+            %
+            % See also nix.DataArray, nix.Filter.
+
             r = nix.Utils.filter(obj, 'referencesFiltered', filter, val, @nix.DataArray);
         end
 
@@ -84,37 +246,128 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         % Features methods
         % ------------------
 
-        function r = addFeature(obj, entity, linkType)
-            id = nix.Utils.parseEntityId(entity, 'nix.DataArray');
+        function r = createFeature(obj, idNameEntity, linkType)
+            % Create a new nix.Feature entity associated with a nix.DataArray,
+            % that is used by the invoking Tag.
+            %
+            % idNameEntity (char/nix.DataArray):  Name or id of the DataArray to be
+            %                                     used or the DataArray itself.
+            % linkType (nix.LinkType):  nix.LinkType describing how the DataArray is 
+            %                           used by the Tag.
+            %
+            % Returns:  (nix.Feature) The newly created Feature.
+            %
+            % Example:  newFeat = currTag.createFeature('subTrial2', nix.LinkType.Tagged);
+            %
+            % See also nix.Feature, nix.LinkType.
+
+            id = nix.Utils.parseEntityId(idNameEntity, 'nix.DataArray');
             fname = strcat(obj.alias, '::createFeature');
             h = nix_mx(fname, obj.nixhandle, id, linkType);
             r = nix.Utils.createEntity(h, @nix.Feature);
         end
 
-        function r = hasFeature(obj, idName)
-            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', idName);
+        function r = hasFeature(obj, id)
+            % Check if a nix.Feature is associated with the invoking Tag.
+            %
+            % id (char):  ID of the Feature.
+            %
+            % Returns:  (logical) True if the Feature exists, false otherwise.
+            %
+            % Example:  check = currTag.hasFeature('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %
+            % See also nix.Feature.
+
+            r = nix.Utils.fetchHasEntity(obj, 'hasFeature', id);
         end
 
-        function r = removeFeature(obj, del)
-            r = nix.Utils.deleteEntity(obj, 'deleteFeature', del, 'nix.Feature');
+        function r = deleteFeature(obj, idEntity)
+            % Deletes a nix.Feature from the invoking Tag.
+            %
+            % This method deletes a Feature from the invoking Tag, the DataArray 
+            % referenced by this Feature will not be removed from the file.
+            %
+            % idEntity (char/nix.Feature):  id of the Feature to be deleted
+            %                                 or the Feature itself.
+            %
+            % Returns:  (logical) True if the Feature has been removed, false otherwise.
+            %
+            % Example:  check = currTag.deleteFeature('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %           check = currFile.blocks{1}.tags{1}.deleteFeature(newFeature);
+            %
+            % See also nix.Feature, nix.DataArray.
+
+            r = nix.Utils.deleteEntity(obj, 'deleteFeature', idEntity, 'nix.Feature');
         end
 
-        function r = openFeature(obj, idName)
-            r = nix.Utils.openEntity(obj, 'openFeature', idName, @nix.Feature);
+        function r = openFeature(obj, id)
+            % Retrieves an associated Feature from the invoking Tag.
+            %
+            % id (char):  ID of the Feature.
+            %
+            % Returns:  (nix.Feature) The Feature or an empty cell, 
+            %                         if the Feature was not found.
+            %
+            % Example:  getFeat = currTag.openFeature('23bb8a99-1812-4bc6-a52c-45e96864756b');
+            %
+            % See also nix.Feature.
+
+            r = nix.Utils.openEntity(obj, 'openFeature', id, @nix.Feature);
         end
 
         function r = openFeatureIdx(obj, index)
+            % Retrieves an associated nix.Feature from the invoking Tag, 
+            % accessed by index.
+            %
+            % index (double):  The index of the Feature to retrieve.
+            %
+            % Returns:  (nix.Feature) The Feature at the given index.
+            %
+            % Example:  getFeat = currTag.openFeatureIdx(1);
+            %
+            % See also nix.Feature.
+
             idx = nix.Utils.handleIndex(index);
             r = nix.Utils.openEntity(obj, 'openFeatureIdx', idx, @nix.Feature);
         end
 
-        function r = retrieveFeatureData(obj, idName)
+        function r = retrieveFeatureData(obj, id)
+            % Returns the raw data from the DataArray attached to the 
+            % Feature associated with the invoking Tag.
+            %
+            % Depending on the nix.LinkType used by the Feature,
+            % only the requested sections of the DataArray will be returned.
+            % 
+            % id (char):  ID of the Feature.
+            %
+            % Returns:  (var) Data from the referenced DataArray, 
+            %                 modified by LinkType of the Feature.
+            %
+            % Example:  getFeatData = currTag.retrieveFeatureData('some-id');
+            %
+            % See also nix.Feature, nix.LinkType.
+
             fname = strcat(obj.alias, '::featureRetrieveData');
-            data = nix_mx(fname, obj.nixhandle, idName);
+            data = nix_mx(fname, obj.nixhandle, id);
             r = nix.Utils.transposeArray(data);
         end
 
         function r = retrieveFeatureDataIdx(obj, index)
+            % Returns the raw data from the DataArray attached to the 
+            % Feature associated with the invoking Tag.
+            %
+            % Depending on the nix.LinkType used by the Feature,
+            % only the requested sections of the DataArray will be returned.
+            % 
+            % index (double):  index of the associated Feature.
+            %
+            % Returns:  (var) Data from the referenced DataArray, 
+            %                 modified by LinkType of the Feature.
+            %
+            % Example:  getFeatData = currTag.retrieveFeatureDataIdx(3);
+            %
+            % See also nix.Feature, nix.LinkType.
+
             idx = nix.Utils.handleIndex(index);
             fname = strcat(obj.alias, '::featureRetrieveDataIdx');
             data = nix_mx(fname, obj.nixhandle, idx);
@@ -122,10 +375,34 @@ classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
         end
 
         function r = featureCount(obj)
+            % Get the number nix.Features associated with the invoking Tag.
+            %
+            % Returns:  (uint) The number of associated Features.
+            %
+            % Example:  fc = currTag.featureCount();
+            %
+            % See also nix.Feature.
+
             r = nix.Utils.fetchEntityCount(obj, 'featureCount');
         end
 
         function r = filterFeatures(obj, filter, val)
+            % Get a filtered cell array of all Features associated with the 
+            % invoking Tag.
+            %
+            % filter (nix.Filter):  The nix.Filter to be applied. The filters 
+            %                       nix.Filter.acceptall, nix.Filter.id and
+            %                       nix.Filter.ids are supported.
+            % val (char):           Value that is applied with the selected
+            %                       filter.
+            %
+            % Returns:  ([nix.Feature]) A cell array of Features filtered according
+            %                           to the applied nix.Filter.
+            %
+            % Example:  getFeatures = currTag.filterFeatures(nix.Filter.id, 'some-id');
+            %
+            % See also nix.Feature, nix.Filter.
+
             r = nix.Utils.filter(obj, 'featuresFiltered', filter, val, @nix.Feature);
         end
     end

--- a/+nix/Tag.m
+++ b/+nix/Tag.m
@@ -25,13 +25,16 @@
 %                         entity and expose it to search methods in a broader context.
 %   definition (char):  read-write, optional description of the entity.
 %   position (double):  read-write, the position is a vector that points into referenced 
-%                           DataArrays.
+%                         DataArrays.
 %   extent (double):    read-write, given a specified position vector, the extent vector 
-%                           defined the size of a region of interest in the 
-%                           referenced DataArray entities.
-%   unit ([char]):        read-write, the array of units is applied to all values for 
-%                           position and extent in order to calculate the right position
-%                           vectors in referenced DataArrays.
+%                         defined the size of a region of interest in the 
+%                         referenced DataArray entities.
+%   unit ([char]):      read-write, the array of units is applied to all values for 
+%                         position and extent in order to calculate the right position
+%                         vectors in referenced DataArrays.
+%
+%   info (struct):      Entity property summary. The values in this structure are detached
+%                       from the entity, changes will not be persisted to the file.
 %
 % nix.Tag dynamic child entity properties:
 %   references   access to all nix.DataArray child entities referenced by the Tag.
@@ -52,7 +55,7 @@
 classdef Tag < nix.NamedEntity & nix.MetadataMixIn & nix.SourcesMixIn
 
     properties (Hidden)
-        alias = 'Tag'  % nix-mx namespace to access Tag specific nix backend functions.
+        alias = 'Tag'  % namespace for Tag nix backend function access.
     end
 
     methods

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -1,3 +1,8 @@
+% nix.Utils provides utility functions accessing the nix backend.
+%
+% Utility functions, do not use out of context!
+%
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -52,12 +57,13 @@ classdef Utils
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 
-        % This method calls the nix-mx function specified by 'nixMxFunc', handing 
-        % over 'handle' as the main nix entity handle and 'relatedHandle' as a 
-        % second nix entity handle related to the first one.
-        % 'objConstructor' requires the Matlab entity constructor of the expected 
-        % returned nix Entities.
         function r = fetchObjListByEntity(obj, mxMethodName, relatedHandle, objConstructor)
+            % This method calls the nix-mx function specified by 'nixMxFunc', handing 
+            % over 'handle' as the main nix entity handle and 'relatedHandle' as a 
+            % second nix entity handle related to the first one.
+            % 'objConstructor' requires the Matlab entity constructor of the expected 
+            % returned nix Entities.
+
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nixhandle, relatedHandle);
             r = nix.Utils.createEntityArray(list, objConstructor);
@@ -96,10 +102,11 @@ classdef Utils
             nix_mx(mxMethod, obj.nixhandle, handleArray);
         end
 
-        % Function can be used for both nix delete and remove methods.
-        % The first actually removes the entity, the latter
-        % removes only the reference to the entity.
         function r = deleteEntity(obj, mxMethodName, idNameEntity, nixEntity)
+            % Function can be used for both nix delete and remove methods.
+            % The first actually removes the entity, the latter
+            % removes only the reference to the entity.
+
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             id = nix.Utils.parseEntityId(idNameEntity, nixEntity);
             r = nix_mx(mxMethod, obj.nixhandle, id);
@@ -165,15 +172,17 @@ classdef Utils
         % -----------------------------------------------------------
 
         function r = transposeArray(data)
-        % Data must agree with file & dimensions; see mkarray.cc(42)
+            % Data must agree with file & dimensions; see mkarray.cc(42)
+
             r = permute(data, length(size(data)):-1:1);
         end
 
         function r = handleIndex(idx)
-        % Matlab uses 1-based indexing opposed to 0 based indexing in C++.
-        % handleIndex transforms a Matlab style index to a C++ style
-        % index and raises the appropriate Matlab error in case of an
-        % invalid subscript.
+            % Matlab uses 1-based indexing opposed to 0 based indexing in C++.
+            % handleIndex transforms a Matlab style index to a C++ style
+            % index and raises the appropriate Matlab error in case of an
+            % invalid subscript.
+
             if (idx < 1)
                 err.identifier = 'MATLAB:badsubscript';
                 err.message = 'Subscript indices must either be real positive integers or logicals.';

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -178,7 +178,7 @@ classdef Utils
         end
 
         function r = handleIndex(idx)
-            % Matlab uses 1-based indexing opposed to 0 based indexing in C++.
+            % Matlab uses 1-based indexing opposed to 0-based indexing in C++.
             % handleIndex transforms a Matlab style index to a C++ style
             % index and raises the appropriate Matlab error in case of an
             % invalid subscript.

--- a/startup.m
+++ b/startup.m
@@ -1,1 +1,8 @@
 addpath(genpath(pwd));
+
+t1 = 'Welcome to the NIX data model Matlab package!';
+t2 = '* You can browse the documentation using "doc nix". ';
+t3 = '* The help command for classes and methods provide basic usage examples.';
+t4 = '* More detailed examples can be found in the "examples" and "tests" folders.';
+
+fprintf('\n%s\n\n%s\n%s\n%s\n\n', t1, t2, t3, t4);

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -1,3 +1,5 @@
+% TestBlock provides tests for all supported nix.Block methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestBlock
-% TESTBLOCK Tests for the nix.Block object
-
     funcs = {};
     funcs{end+1} = @testAttributes;
     funcs{end+1} = @testCreateDataArray;
@@ -58,8 +58,8 @@ function funcs = TestBlock
     funcs{end+1} = @testFindSourceFiltered;
 end
 
-function [] = testAttributes( varargin )
 %% Test: Access Attributes
+function [] = testAttributes( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'test nixBlock');
 
@@ -78,7 +78,7 @@ function [] = testAttributes( varargin )
     assert(isempty(b.definition));
 end
 
-%% Test: Create Data Array
+%% Test: Create DataArray
 function [] = testCreateDataArray( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -122,7 +122,7 @@ function [] = testCreateDataArray( varargin )
     assert(size(f.blocks{1}.dataArrays, 1) == 11);
 end
 
-%% Test: Create Data Array from data
+%% Test: Create DataArray from data
 function [] = testCreateDataArrayFromData( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     daType = 'nix.DataArray';
@@ -164,7 +164,7 @@ function [] = testCreateDataArrayFromData( varargin )
     assert(~isempty(b.dataArrays));
 end
 
-%% Test: delete dataArray by entity and id
+%% Test: Delete DataArray by entity and id
 function [] = testDeleteDataArray( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixBlock');
@@ -179,8 +179,8 @@ function [] = testDeleteDataArray( varargin )
     assert(~b.deleteDataArray('I do not exist'));
 end
 
-function [] = testCreateTag( varargin )
 %% Test: Create Tag
+function [] = testCreateTag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixblock');
     
@@ -195,7 +195,7 @@ function [] = testCreateTag( varargin )
     assert(~isempty(b.tags));
 end
 
-%% Test: delete tag by entity and id
+%% Test: Delete Tag by entity and id
 function [] = testDeleteTag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
@@ -212,8 +212,8 @@ function [] = testDeleteTag( varargin )
     assert(~b.deleteTag('I do not exist'));
 end
 
+%% Test: Create MultiTag by DataArray entity and DataArray id
 function [] = testCreateMultiTag( varargin )
-%% Test: Create multitag by DataArray entity and DataArray id
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.createDataArray('mTagTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -231,7 +231,7 @@ function [] = testCreateMultiTag( varargin )
     assert(strcmp(b.multiTags{2}.type, 'nixMultiTag2'));
 end
 
-%% Test: delete multitag by entity and id
+%% Test: Delete MultiTag by entity and id
 function [] = testDeleteMultiTag( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
@@ -249,7 +249,7 @@ function [] = testDeleteMultiTag( varargin )
     assert(~b.deleteMultiTag('I do not exist'));
 end
 
-%% Test: create source
+%% Test: Create Source
 function [] = testCreateSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixblock');
@@ -261,7 +261,7 @@ function [] = testCreateSource ( varargin )
     assert(strcmp(s.type, 'nixsource'));
 end
 
-%% Test: delete source by entity and id
+%% Test: Delete Source by entity and id
 function [] = testDeleteSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixblock');
@@ -277,7 +277,7 @@ function [] = testDeleteSource( varargin )
     assert(~b.deleteSource('I do not exist'));
 end
 
-%% Test: Fetch nix.DataArrays
+%% Test: Fetch DataArrays
 function [] = testListArrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -294,7 +294,7 @@ function [] = testListArrays( varargin )
     assert(size(f.blocks{1}.dataArrays, 1) == 2);
 end
 
-%% Test: Fetch nix.Sources
+%% Test: Fetch Sources
 function [] = testListSources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -313,7 +313,7 @@ function [] = testListSources( varargin )
     assert(size(f.blocks{1}.sources, 1) == 2);
 end
 
-%% Test: Fetch nix.Tags
+%% Test: Fetch Tags
 function [] = testListTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -333,7 +333,7 @@ function [] = testListTags( varargin )
     assert(size(f.blocks{1}.tags, 1) == 2);
 end
 
-%% Test: fetch multitags
+%% Test: Fetch MultiTags
 function [] = testListMultiTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -353,8 +353,8 @@ function [] = testListMultiTags( varargin )
     assert(size(f.blocks{1}.multiTags, 1) == 2);
 end
 
+%% Test: Open DataArray by ID or name
 function [] = testOpenDataArray( varargin )
-%% Test: Open data array by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('arraytest', 'nixBlock');
     daName = 'arrayTest1';
@@ -373,8 +373,8 @@ function [] = testOpenDataArray( varargin )
     assert(isempty(getDataArray));
 end
 
+%% Test: Open Tag by ID or name
 function [] = testOpenTag( varargin )
-%% Test: Open tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
     position = [1.0 1.2 1.3 15.9];
@@ -392,8 +392,8 @@ function [] = testOpenTag( varargin )
     assert(isempty(getTag));
 end
 
+%% Test: Open MultiTag by ID or name
 function [] = testOpenMultiTag( varargin )
-%% Test: Open multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.createDataArray('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -411,8 +411,8 @@ function [] = testOpenMultiTag( varargin )
     assert(isempty(getMultiTag));
 end
 
+%% Test: Open Source by ID or name
 function [] = testOpenSource( varargin )
-%% Test: Open source by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
     sName = 'sourcetest1';
@@ -429,8 +429,8 @@ function [] = testOpenSource( varargin )
     assert(isempty(getSource));
 end
 
+%% Test: Open Group by index
 function [] = testOpenGroupIdx( varargin )
-%% Test Open Group by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     g1 = b.createGroup('testGroup1', 'nixGroup');
@@ -442,8 +442,8 @@ function [] = testOpenGroupIdx( varargin )
     assert(strcmp(f.blocks{1}.openGroupIdx(3).name, g3.name));
 end
 
+%% Test: Open DataArray by index
 function [] = testOpenDataArrayIdx( varargin )
-%% Test Open DataArray by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d1 = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [3 2]);
@@ -455,8 +455,8 @@ function [] = testOpenDataArrayIdx( varargin )
     assert(strcmp(f.blocks{1}.openDataArrayIdx(3).name, d3.name));
 end
 
+%% Test: Open Tag by index
 function [] = testOpenTagIdx( varargin )
-%% Test Open Tag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t1 = b.createTag('testTag1', 'nixTag', [1 2]);
@@ -468,8 +468,8 @@ function [] = testOpenTagIdx( varargin )
     assert(strcmp(f.blocks{1}.openTagIdx(3).name, t3.name));
 end
 
+%% Test: Open MultiTag by index
 function [] = testOpenMultiTagIdx( varargin )
-%% Test Open MultiTag by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Bool, [2 3]);
@@ -482,8 +482,8 @@ function [] = testOpenMultiTagIdx( varargin )
     assert(strcmp(f.blocks{1}.openMultiTagIdx(3).name, t3.name));
 end
 
+%% Test: Open Source by index
 function [] = testOpenSourceIdx( varargin )
-%% Test Open Source by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s1 = b.createSource('testSource1', 'nixSource');
@@ -495,8 +495,8 @@ function [] = testOpenSourceIdx( varargin )
     assert(strcmp(f.blocks{1}.openSourceIdx(3).name, s3.name));
 end
 
+%% Test: Has MultiTag by ID or name
 function [] = testHasMultiTag( varargin )
-%% Test: Block has multi tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('mTagTestBlock', 'nixBlock');
     tmp = b.createDataArray('mTagTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
@@ -508,8 +508,8 @@ function [] = testHasMultiTag( varargin )
     assert(~b.hasMultiTag('I do not exist'));
 end
 
+%% Test: Has Tag by ID or name
 function [] = testHasTag( varargin )
-%% Test: Block has tag by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'nixBlock');
     tmp = b.createTag('tagtest1', 'nixTag', [1.0 1.2 1.3 15.9]);
@@ -561,7 +561,7 @@ function [] = testOpenMetadata( varargin )
     assert(strcmp(b.openMetadata.name, 'testSection'));
 end
 
-%% Test: nix.Block has nix.DataArray by ID or name
+%% Test: Has DataArray by ID or name
 function [] = testHasDataArray( varargin )
     fileName = 'testRW.h5';
     daName = 'hasDataArrayTest';
@@ -578,7 +578,7 @@ function [] = testHasDataArray( varargin )
     assert(f.blocks{1}.hasDataArray(daID));
 end
 
-%% Test: nix.Block has nix.Source by ID or name
+%% Test: Has Source by ID or name
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'sourcetest1';
@@ -595,7 +595,7 @@ function [] = testHasSource( varargin )
     assert(f.blocks{1}.hasSource(sID));
 end
 
-%% Test: Create nix.Group
+%% Test: Create Group
 function [] = testCreateGroup( varargin )
     fileName = 'testRW.h5';
     groupName = 'testGroup';
@@ -617,7 +617,7 @@ function [] = testCreateGroup( varargin )
     assert(strcmp(f.blocks{1}.groups{1}.name, groupName));
 end
 
-%% Test: nix.Block has nix.Group by name or id
+%% Test: Has Group by name or id
 function [] = testHasGroup( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -633,7 +633,7 @@ function [] = testHasGroup( varargin )
     assert(~b.hasGroup(g.id));
 end
 
-%% Test: Get nix.Group by name or id
+%% Test: Get Group by name or id
 function [] = testOpenGroup( varargin )
     groupName = 'testGroup';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -647,7 +647,7 @@ function [] = testOpenGroup( varargin )
     assert(strcmp(f.blocks{1}.openGroup(groupName).name, groupName));
 end
 
-%% Test: Delete nix.Group by entity and id
+%% Test: Delete Group by entity and id
 function [] = testDeleteGroup( varargin )
     fileName = 'testRW.h5';
     groupType = 'nixGroup';
@@ -750,8 +750,8 @@ function [] = testSourceCount( varargin )
     assert(f.blocks{1}.sourceCount() == 2);
 end
 
+%% Test: Compare Block entities
 function [] = testCompare( varargin )
-%% Test: Compare block entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
@@ -761,7 +761,7 @@ function [] = testCompare( varargin )
     assert(b2.compare(b1) > 0);
 end
 
-%% Test: filter sources
+%% Test: Filter Sources
 function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -831,7 +831,7 @@ function [] = testFilterSource( varargin )
 end
 
 
-%% Test: filter groups
+%% Test: Filter Groups
 function [] = testFilterGroup( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -896,7 +896,7 @@ function [] = testFilterGroup( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: filter tags
+%% Test: Filter Tags
 function [] = testFilterTag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -961,7 +961,7 @@ function [] = testFilterTag( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: filter multi tags
+%% Test: Filter MultiTags
 function [] = testFilterMultiTag( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -1033,7 +1033,7 @@ function [] = testFilterMultiTag( varargin )
     assert(size( b.filterMultiTags(nix.Filter.name, filterName), 1) == 1);
 end
 
-%% Test: filter data arrays
+%% Test: Filter DataArrays
 function [] = testFilterDataArray( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -1098,7 +1098,7 @@ function [] = testFilterDataArray( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: Find source w/o filter
+%% Test: Find Source w/o filter
 function [] = testFindSource
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -1145,7 +1145,7 @@ function [] = testFindSource
     assert(size(filtered, 1) == 1);
 end
 
-%% Test: Find sources with filters
+%% Test: Find Sources with filters
 function [] = testFindSourceFiltered
     findSource = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);

--- a/tests/TestDataArray.m
+++ b/tests/TestDataArray.m
@@ -1,3 +1,5 @@
+% TestDataArray provides tests for all supported nix.DataArray methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestDataArray
-% TESTDATAARRAY tests for DataArray
-
     funcs = {};
     funcs{end+1} = @testAttributes;
     funcs{end+1} = @testOpenData;
@@ -35,8 +35,8 @@ function funcs = TestDataArray
     funcs{end+1} = @testFilterSource;
 end
 
-function [] = testAttributes( varargin )
 %% Test: Access Attributes
+function [] = testAttributes( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
@@ -161,7 +161,7 @@ function [] = testOpenMetadata( varargin )
     assert(strcmp(da.openMetadata.name, 'testSection'));
 end
 
-%% Test: List sources
+%% Test: List Sources
 function [] = testListSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     b = f.blocks{1};
@@ -302,7 +302,7 @@ function [] = testWriteDataInteger( varargin )
     assert(isequal(f.blocks{1}.dataArrays{8}.readAllData, numData));
 end
 
-%% Test: Add sources by entity and id
+%% Test: Add Source by entity and id
 function [] = testAddSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -317,7 +317,7 @@ function [] = testAddSource ( varargin )
     assert(size(d.sources, 1) == 2);
 end
 
-%% Test: Add sources by entity cell array
+%% Test: Add Sources by entity cell array
 function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
@@ -351,7 +351,7 @@ function [] = testAddSources ( varargin )
     assert(size(f.blocks{1}.dataArrays{1}.sources, 1) == 3);
 end
 
-%% Test: Open source by ID or name
+%% Test: Open Source by id or name
 function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
@@ -389,7 +389,7 @@ function [] = testOpenSourceIdx( varargin )
     assert(strcmp(f.blocks{1}.dataArrays{1}.openSourceIdx(3).name, s3.name));
 end
 
-%% Test: Remove sources by entity and id
+%% Test: Remove Source by entity and id
 function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -409,7 +409,7 @@ function [] = testRemoveSource ( varargin )
     assert(size(s.sources, 1) == 2);
 end
 
-%% Test: has nix.Source by ID or entity
+%% Test: Has Source by id or entity
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -513,8 +513,8 @@ function [] = testDimensions( varargin )
     assert(isequal(daAliasWa.dataExtent, [3 3]));
 end
 
+%% Test: Open Dimension by index
 function [] = testOpenDimensionIdx( varargin )
-%% Test: Open dimension by index
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
@@ -524,8 +524,6 @@ function [] = testOpenDimensionIdx( varargin )
     da.appendSampledDimension(200);
     da.appendRangeDimension([1, 2, 3, 4]);
 
-    % for some weird reason getting the dimension by index starts with 1
-    % instead of 0 compared to all other index functions.
     assert(strcmp(da.openDimensionIdx(1).dimensionType, 'set'));
     assert(strcmp(da.openDimensionIdx(2).dimensionType, 'sample'));
     assert(strcmp(da.openDimensionIdx(3).dimensionType, 'range'));
@@ -583,8 +581,8 @@ function [] = testSetDataExtent( varargin )
     assert(da.dataExtent(1) == extent(1) && size(da.readAllData, 2) == extent(2));
 end
 
-function [] = testCompare( varargin )
 %% Test: Compare DataArray entities
+function [] = testCompare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
@@ -598,7 +596,7 @@ function [] = testCompare( varargin )
     assert(d1.compare(d3) ~= 0);
 end
 
-%% Test: filter sources
+%% Test: Filter Sources
 function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';

--- a/tests/TestDimensions.m
+++ b/tests/TestDimensions.m
@@ -1,3 +1,5 @@
+% TestDimensions provides tests for all supported nix.Dimension methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,16 +9,14 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestDimensions
-% TestDimensions tests for Dimensions
-
     funcs = {};
     funcs{end+1} = @testSetDimension;
     funcs{end+1} = @testSampleDimension;
     funcs{end+1} = @testRangeDimension;
 end
 
+%% Test: SetDimension
 function [] = testSetDimension( varargin )
-%% Test: set dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
@@ -49,8 +49,8 @@ function [] = testSetDimension( varargin )
     end;
 end
 
+%% Test: SampledDimension
 function [] = testSampleDimension( varargin )
-%% Test: sampled dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);
@@ -102,8 +102,8 @@ function [] = testSampleDimension( varargin )
     assert(d1.positionAt(10) == d1.offset + 9 * d1.samplingInterval);
 end
 
+%% Test: RangeDimension
 function [] = testRangeDimension( varargin )
-%% Test: range dimension
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('daTestBlock', 'test nixBlock');
     da = b.createDataArray('daTest', 'test nixDataArray', nix.DataType.Double, [1 2]);

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -1,3 +1,5 @@
+% TestFeature provides tests for all supported nix.Feature methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,15 +9,13 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestFeature
-% TESTFEATURE tests for Feature
-
     funcs = {};
     funcs{end+1} = @testOpenData;
     funcs{end+1} = @testHandleLinkType;
     funcs{end+1} = @testSetData;
 end
 
-%% Test: Open data from feature
+%% Test: Open data from Feature
 function [] = testOpenData ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -27,7 +27,7 @@ function [] = testOpenData ( varargin )
     assert(~isempty(feat.openData));
 end
 
-%% Test: Get and set nix.LinkType
+%% Test: Get and set LinkType
 function [] = testHandleLinkType ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -63,7 +63,7 @@ function [] = testHandleLinkType ( varargin )
     assert(f.blocks{1}.tags{1}.features{1}.linkType == 2);
 end
 
-%% Test: Set data by entity, ID and name
+%% Test: Set data by entity, id and name
 function [] = testSetData ( varargin )
     fileName = 'testRW.h5';
     daName1 = 'featTestDA1';

--- a/tests/TestFeature.m
+++ b/tests/TestFeature.m
@@ -21,7 +21,7 @@ function [] = testOpenData ( varargin )
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
-    tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     feat = t.features{1};
     assert(~isempty(feat.openData));
@@ -34,7 +34,7 @@ function [] = testHandleLinkType ( varargin )
     b = f.createBlock('featureTest', 'nixBlock');
     da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2 3 4 5 6]);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
-    feat = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    feat = t.createFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     try
         feat.linkType = '';
@@ -79,7 +79,7 @@ function [] = testSetData ( varargin )
     da3 = b.createDataArray(daName3, daType, nix.DataType.Double, daData);
     da4 = b.createDataArray(daName4, daType, nix.DataType.Double, daData);
     t = b.createTag('featureTest', 'nixTag', [1, 2]);
-    feat = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    feat = t.createFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     
     assert(strcmp(feat.openData.name, daName1));
     feat.setData(da2);

--- a/tests/TestFile.m
+++ b/tests/TestFile.m
@@ -1,3 +1,5 @@
+% TestFile provides tests for all supported nix.File methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestFile
-% TESTFILE tests for File
-
     funcs = {};
     funcs{end+1} = @testReadOnly;
     funcs{end+1} = @testReadWrite;
@@ -217,8 +217,8 @@ function [] = testDeleteSection( varargin )
     assert(~checkDelete);
 end
 
+%% Test: Open Section
 function [] = testOpenSection( varargin )
-%% Test open section
     f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
     getSection = f.openSection(f.sections{1,1}.id);
     assert(strcmp(getSection.name, 'General'));
@@ -228,8 +228,8 @@ function [] = testOpenSection( varargin )
     assert(isempty(getSection));
 end
 
+%% Test: Open Section by index
 function [] = testOpenSectionIdx( varargin )
-%% Test Open Section by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s1 = f.createSection('testSection1', 'nixSection');
     s2 = f.createSection('testSection2', 'nixSection');
@@ -240,8 +240,8 @@ function [] = testOpenSectionIdx( varargin )
     assert(strcmp(f.openSectionIdx(3).name, s3.name));
 end
 
+%% Test: Open Block by ID or name
 function [] = testOpenBlock( varargin )
-%% Test Open Block by ID or name
     f = nix.File(fullfile(pwd,'tests','test.h5'), nix.FileMode.ReadOnly);
 
     getBlockByID = f.openBlock(f.blocks{1,1}.id);
@@ -255,8 +255,8 @@ function [] = testOpenBlock( varargin )
     assert(isempty(getBlock));
 end
 
+%% Test: Open Block by index
 function [] = testOpenBlockIdx( varargin )
-%% Test Open Block by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
@@ -267,7 +267,7 @@ function [] = testOpenBlockIdx( varargin )
     assert(strcmp(f.openBlockIdx(3).name, b3.name));
 end
 
-%% Test: nix.File has nix.Block by ID or name
+%% Test: Has Block by ID or name
 function [] = testHasBlock( varargin )
     fileName = 'testRW.h5';
     blockName = 'hasBlockTest';
@@ -283,7 +283,7 @@ function [] = testHasBlock( varargin )
     assert(f.hasBlock(bID));
 end
 
-%% Test: nix.File has nix.Section by ID or name
+%% Test: Has Section by ID or name
 function [] = testHasSection( varargin )
     fileName = 'testRW.h5';
     secName = 'hasSectionTest';
@@ -299,8 +299,8 @@ function [] = testHasSection( varargin )
     assert(f.hasSection(sID));
 end
 
+%% Test: Filter Sections
 function [] = testFilterSection( varargin )
-%% Test: filter Sections
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -356,8 +356,8 @@ function [] = testFilterSection( varargin )
 
 end
 
+%% Test: Filter Blocks
 function [] = testFilterBlock( varargin )
-%% Test: filter Blocks
     filterName = 'filterMe';
     filterType = 'filterType';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -413,7 +413,7 @@ function [] = testFilterBlock( varargin )
 
 end
 
-%% Test: Find sections w/o filter
+%% Test: Find Sections w/o filter
 function [] = testFindSection
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     sl1 = f.createSection('sectionLvl1', 'nixSection');
@@ -459,7 +459,7 @@ function [] = testFindSection
     assert(size(filtered, 1) == 1);
 end
 
-%% Test: Find sections with filter
+%% Test: Find Sections with filter
 function [] = testFindSectionFiltered
     findSection = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);

--- a/tests/TestMultiTag.m
+++ b/tests/TestMultiTag.m
@@ -1,3 +1,5 @@
+% TestMultiTag provides tests for all supported nix.MultiTag methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestMultiTag
-% TESTMultiTag tests for MultiTag
-
     funcs = {};
     funcs{end+1} = @testAddSource;
     funcs{end+1} = @testAddSources;
@@ -17,9 +17,9 @@ function funcs = TestMultiTag
     funcs{end+1} = @testAddReferences;
     funcs{end+1} = @testHasReference;
     funcs{end+1} = @testRemoveReference;
-    funcs{end+1} = @testAddFeature;
+    funcs{end+1} = @testCreateFeature;
     funcs{end+1} = @testHasFeature;
-    funcs{end+1} = @testRemoveFeature;
+    funcs{end+1} = @testDeleteFeature;
     funcs{end+1} = @testFetchReferences;
     funcs{end+1} = @testFetchSources;
     funcs{end+1} = @testFetchFeatures;
@@ -33,7 +33,7 @@ function funcs = TestMultiTag
     funcs{end+1} = @testOpenReferenceIdx;
     funcs{end+1} = @testFeatureCount;
     funcs{end+1} = @testReferenceCount;
-    funcs{end+1} = @testAddPositions;
+    funcs{end+1} = @testSetPositions;
     funcs{end+1} = @testHasPositions;
     funcs{end+1} = @testOpenPositions;
     funcs{end+1} = @testSetOpenExtents;
@@ -51,7 +51,7 @@ function funcs = TestMultiTag
     funcs{end+1} = @testFilterFeature;
 end
 
-%% Test: Add sources by entity and id
+%% Test: Add Source by entity and id
 function [] = testAddSource ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -78,7 +78,7 @@ function [] = testAddSource ( varargin )
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 2);
 end
 
-%% Test: Add sources by entity cell array
+%% Test: Add Source by entity cell array
 function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
@@ -113,7 +113,7 @@ function [] = testAddSources ( varargin )
     assert(size(f.blocks{1}.multiTags{1}.sources, 1) == 3);
 end
 
-%% Test: Remove sources by entity and id
+%% Test: Remove Source by entity and id
 function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -135,7 +135,7 @@ function [] = testRemoveSource ( varargin )
     assert(size(s.sources,1) == 2);
 end
 
-%% Test: Add references by entity and id
+%% Test: Add reference by entity and id
 function [] = testAddReference ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -164,7 +164,7 @@ function [] = testAddReference ( varargin )
     assert(size(f.blocks{1}.multiTags{1}.references, 1) == 2);
 end
 
-%% Test: Add references by entity cell array
+%% Test: Add reference by entity cell array
 function [] = testAddReferences ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
@@ -198,7 +198,7 @@ function [] = testAddReferences ( varargin )
     assert(size(f.blocks{1}.multiTags{1}.references, 1) == 3);
 end
 
-%% Test: Remove references by entity and id
+%% Test: Remove reference by entity and id
 function [] = testRemoveReference ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
@@ -221,8 +221,8 @@ function [] = testRemoveReference ( varargin )
     assert(size(b.dataArrays, 1) == 3);
 end
 
-%% Test: Add features by entity and id
-function [] = testAddFeature ( varargin )
+%% Test: Create Feature by entity and id
+function [] = testCreateFeature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -244,12 +244,12 @@ function [] = testAddFeature ( varargin )
 
     assert(isempty(t.features));
     assert(isempty(f.blocks{1}.multiTags{1}.features));
-    tmp = t.addFeature(b.dataArrays{2}.id, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{3}, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{4}.id, nix.LinkType.Untagged);
-    tmp = t.addFeature(b.dataArrays{5}, nix.LinkType.Untagged);
-    tmp = t.addFeature(b.dataArrays{6}.id, nix.LinkType.Indexed);
-    tmp = t.addFeature(b.dataArrays{7}, nix.LinkType.Indexed);
+    tmp = t.createFeature(b.dataArrays{2}.id, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{3}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{4}.id, nix.LinkType.Untagged);
+    tmp = t.createFeature(b.dataArrays{5}, nix.LinkType.Untagged);
+    tmp = t.createFeature(b.dataArrays{6}.id, nix.LinkType.Indexed);
+    tmp = t.createFeature(b.dataArrays{7}, nix.LinkType.Indexed);
     assert(size(t.features, 1) == 6);
     assert(size(f.blocks{1}.multiTags{1}.features, 1) == 6);
     
@@ -258,8 +258,8 @@ function [] = testAddFeature ( varargin )
     assert(size(f.blocks{1}.multiTags{1}.features, 1) == 6);
 end
 
-%% Test: Remove features by entity and id
-function [] = testRemoveFeature ( varargin )
+%% Test: Delete Feature by entity and id
+function [] = testDeleteFeature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
 	tmp = b.createDataArray(...
@@ -271,18 +271,18 @@ function [] = testRemoveFeature ( varargin )
     tmp = b.createDataArray(...
         'featTestDA2', 'nixDataArray', nix.DataType.Double, [3 4]);
 
-    tmp = t.addFeature(b.dataArrays{2}.id, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{3}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{2}.id, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{3}, nix.LinkType.Tagged);
 
-    assert(t.removeFeature(t.features{2}.id));
-    assert(t.removeFeature(t.features{1}));
+    assert(t.deleteFeature(t.features{2}.id));
+    assert(t.deleteFeature(t.features{1}));
     assert(isempty(t.features));
 
-    assert(~t.removeFeature('I do not exist'));
+    assert(~t.deleteFeature('I do not exist'));
     assert(size(b.dataArrays, 1) == 3);
 end
 
-%% Test: fetch references
+%% Test: Fetch references
 function [] = testFetchReferences( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
@@ -296,7 +296,7 @@ function [] = testFetchReferences( varargin )
     assert(size(t.references, 1) == 2);
 end
 
-%% Test: fetch sources
+%% Test: Fetch Sources
 function [] = testFetchSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -311,7 +311,7 @@ function [] = testFetchSources( varargin )
     assert(size(t.sources, 1) == 2);
 end
 
-%% Test: fetch features
+%% Test: Fetch Features
 function [] = testFetchFeatures( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -320,11 +320,11 @@ function [] = testFetchFeatures( varargin )
 
     assert(isempty(t.features));
     tmp = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{2}, nix.LinkType.Tagged);
     assert(size(t.features, 1) == 1);
 end
 
-%% Test: Open source by ID or name
+%% Test: Open Source by id or name
 function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourceTest', 'nixBlock');
@@ -346,8 +346,8 @@ function [] = testOpenSource( varargin )
     assert(isempty(s));
 end
 
-function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
+function [] = testOpenSourceIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
@@ -364,7 +364,7 @@ function [] = testOpenSourceIdx( varargin )
     assert(strcmp(f.blocks{1}.multiTags{1}.openSourceIdx(3).name, s3.name));
 end
 
-%% Test: has nix.Source by ID or entity
+%% Test: Has Source by id or entity
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'sourceTest1';
@@ -403,7 +403,7 @@ function [] = testSourceCount( varargin )
     assert(f.blocks{1}.multiTags{1}.sourceCount() == 2);
 end
 
-%% Test: Open feature by ID
+%% Test: Open Feature by id
 function [] = testOpenFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -411,7 +411,7 @@ function [] = testOpenFeature( varargin )
     t = b.createMultiTag('featuretest', 'nixMultiTag', b.dataArrays{1});
 
     tmp = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{2}, nix.LinkType.Tagged);
     assert(~isempty(t.openFeature(t.features{1}.id)));
 
     %-- test open non existing feature
@@ -419,8 +419,8 @@ function [] = testOpenFeature( varargin )
     assert(isempty(getFeat));
 end
 
+%% Test Open Feature by index
 function [] = testOpenFeatureIdx( varargin )
-%% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
@@ -428,16 +428,16 @@ function [] = testOpenFeatureIdx( varargin )
     f1 = b.createDataArray('testFeature1', 'nixDataArray', nix.DataType.Bool, [2 2]);
     f2 = b.createDataArray('testFeature2', 'nixDataArray', nix.DataType.Bool, [2 2]);
     f3 = b.createDataArray('testFeature3', 'nixDataArray', nix.DataType.Bool, [2 2]);
-    t.addFeature(f1, nix.LinkType.Tagged);
-    t.addFeature(f2, nix.LinkType.Untagged);
-    t.addFeature(f3, nix.LinkType.Indexed);
+    t.createFeature(f1, nix.LinkType.Tagged);
+    t.createFeature(f2, nix.LinkType.Untagged);
+    t.createFeature(f3, nix.LinkType.Indexed);
 
     assert(f.blocks{1}.multiTags{1}.openFeatureIdx(1).linkType == nix.LinkType.Tagged);
     assert(f.blocks{1}.multiTags{1}.openFeatureIdx(2).linkType == nix.LinkType.Untagged);
     assert(f.blocks{1}.multiTags{1}.openFeatureIdx(3).linkType == nix.LinkType.Indexed);
 end
 
-%% Test: Open reference by ID or name
+%% Test: Open reference by id or name
 function [] = testOpenReference( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
@@ -458,8 +458,8 @@ function [] = testOpenReference( varargin )
     assert(isempty(getRef));
 end
 
+%% Test Open reference by index
 function [] = testOpenReferenceIdx( varargin )
-%% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 9]);
@@ -485,10 +485,10 @@ function [] = testFeatureCount( varargin )
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', da);
 
     assert(t.featureCount() == 0);
-    t.addFeature(b.createDataArray('testDataArray1', 'nixDataArray', ...
+    t.createFeature(b.createDataArray('testDataArray1', 'nixDataArray', ...
         nix.DataType.Double, [1 2]), nix.LinkType.Tagged);
     assert(t.featureCount() == 1);
-    t.addFeature(b.createDataArray('testDataArray2', 'nixDataArray', ...
+    t.createFeature(b.createDataArray('testDataArray2', 'nixDataArray', ...
         nix.DataType.Double, [3 4]), nix.LinkType.Tagged);
 
     clear t da b f;
@@ -514,8 +514,8 @@ function [] = testReferenceCount( varargin )
     assert(f.blocks{1}.multiTags{1}.referenceCount() == 2);
 end
 
-%% Test: Add positions by entity and id
-function [] = testAddPositions ( varargin )
+%% Test: Set positions by entity and id
+function [] = testSetPositions ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     posName1 = 'positionsTest1';
     posName2 = 'positionsTest2';
@@ -528,11 +528,11 @@ function [] = testAddPositions ( varargin )
     tmp = b.createDataArray(posName1, 'nixDataArray', nix.DataType.Double, [0 1]);
     tmp = b.createDataArray(posName2, 'nixDataArray', nix.DataType.Double, [2 4]);
 
-    t.addPositions(b.dataArrays{2}.id);
+    t.setPositions(b.dataArrays{2}.id);
     assert(strcmp(t.openPositions.name, posName1));
     assert(strcmp(f.blocks{1}.multiTags{1}.openPositions.name, posName1));
 
-    t.addPositions(b.dataArrays{3});
+    t.setPositions(b.dataArrays{3});
     assert(strcmp(t.openPositions.name, posName2));
     assert(strcmp(f.blocks{1}.multiTags{1}.openPositions.name, posName2));
     
@@ -549,7 +549,7 @@ function [] = testHasPositions( varargin )
     t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
-    t.addPositions(b.dataArrays{2}.id);
+    t.setPositions(b.dataArrays{2}.id);
     assert(t.hasPositions);
 end
 
@@ -561,11 +561,11 @@ function [] = testOpenPositions( varargin )
     t = b.createMultiTag('positionstest', 'nixMultiTag', b.dataArrays{1});
     tmp = b.createDataArray('positionsTest1', 'nixDataArray', nix.DataType.Double, [0 1]);
 
-    t.addPositions(b.dataArrays{2}.id);
+    t.setPositions(b.dataArrays{2}.id);
     assert(~isempty(t.openPositions));
 end
 
-%% Test: Set extents by entity and ID, open and reset extents
+%% Test: Set extents by entity and id, open and reset extents
 function [] = testSetOpenExtents ( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -584,7 +584,7 @@ function [] = testSetOpenExtents ( varargin )
     assert(isempty(t.openExtents));
     assert(isempty(f.blocks{1}.multiTags{1}.openExtents));
     
-    t.addPositions(b.dataArrays{2});
+    t.setPositions(b.dataArrays{2});
     t.setExtents(b.dataArrays{4}.id);
     assert(strcmp(t.openExtents.name, extName1));
     assert(strcmp(f.blocks{1}.multiTags{1}.openExtents.name, extName1));
@@ -593,7 +593,7 @@ function [] = testSetOpenExtents ( varargin )
     assert(isempty(t.openExtents));
     assert(isempty(f.blocks{1}.multiTags{1}.openExtents));
     
-    t.addPositions(b.dataArrays{3});
+    t.setPositions(b.dataArrays{3});
     t.setExtents(b.dataArrays{5});
     
     clear tmp t da b f;
@@ -770,7 +770,7 @@ function [] = testRetrieveDataIdx( varargin )
     assert(isequal(t.retrieveDataIdx(3, 2), raw2(1:2, 3:6)), 'Retrieve pos 3, ref 2 fail');
 end
 
-%% Test: Retrieve feature data by id or name
+%% Test: Retrieve Feature data by id or name
 function [] = testRetrieveFeatureData( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -803,9 +803,9 @@ function [] = testRetrieveFeatureData( varargin )
     t.setExtents(da_ext);
 
     % add feature data_arrays
-    t.addFeature(da_feat1, nix.LinkType.Untagged);
-    t.addFeature(da_feat2, nix.LinkType.Tagged);
-    t.addFeature(da_feat3, nix.LinkType.Indexed);
+    t.createFeature(da_feat1, nix.LinkType.Untagged);
+    t.createFeature(da_feat2, nix.LinkType.Tagged);
+    t.createFeature(da_feat3, nix.LinkType.Indexed);
 
     % test invalid position idx
     try
@@ -859,7 +859,7 @@ function [] = testRetrieveFeatureData( varargin )
     clear ME;
 end
 
-%% Test: Retrieve feature data
+%% Test: Retrieve Feature data by idx
 function [] = testRetrieveFeatureDataIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -892,9 +892,9 @@ function [] = testRetrieveFeatureDataIdx( varargin )
     t.setExtents(da_ext);
 
     % add feature data_arrays
-    t.addFeature(da_feat1, nix.LinkType.Untagged);
-    t.addFeature(da_feat2, nix.LinkType.Tagged);
-    t.addFeature(da_feat3, nix.LinkType.Indexed);
+    t.createFeature(da_feat1, nix.LinkType.Untagged);
+    t.createFeature(da_feat2, nix.LinkType.Tagged);
+    t.createFeature(da_feat3, nix.LinkType.Indexed);
 
     % test invalid position idx
     try
@@ -948,7 +948,7 @@ function [] = testRetrieveFeatureDataIdx( varargin )
     clear ME;
 end
 
-%% Test: nix.MultiTag has feature by ID
+%% Test: Has Feature by id
 function [] = testHasFeature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -956,7 +956,7 @@ function [] = testHasFeature( varargin )
     da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createMultiTag('featureTest', 'nixMultiTag', da);
     daf = b.createDataArray('featTestDA', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feature = t.addFeature(daf, nix.LinkType.Tagged);
+    feature = t.createFeature(daf, nix.LinkType.Tagged);
     featureID = feature.id;
 
     assert(~t.hasFeature('I do not exist'));
@@ -967,7 +967,7 @@ function [] = testHasFeature( varargin )
     assert(f.blocks{1}.multiTags{1}.hasFeature(featureID));
 end
 
-%% Test: nix.MultiTag has reference by ID or name
+%% Test: Has reference by id or name
 function [] = testHasReference( varargin )
     fileName = 'testRW.h5';
     daName = 'refTestDataArray';
@@ -1021,7 +1021,7 @@ function [] = testSetUnits( varargin )
     assert(isequal(f.blocks{1}.multiTags{1}.units, newUnits));
 end
 
-%% Test: Read and write nix.MultiTag attributes
+%% Test: Read and write attributes
 function [] = testAttributes( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -1054,8 +1054,8 @@ function [] = testAttributes( varargin )
     assert(isequal(f.blocks{1}.multiTags{1}.type, testType));
 end
 
-function [] = testCompare( varargin )
 %% Test: Compare MultiTag entities
+function [] = testCompare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
@@ -1071,7 +1071,7 @@ function [] = testCompare( varargin )
     assert(t1.compare(t3) ~= 0);
 end
 
-%% Test: filter sources
+%% Test: Filter Sources
 function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -1147,7 +1147,7 @@ function [] = testFilterSource( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: filter references
+%% Test: Filter references
 function [] = testFilterReference( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -1222,17 +1222,17 @@ function [] = testFilterReference( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: filter features
+%% Test: Filter Features
 function [] = testFilterFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     d = b.createDataArray('testDataArray', 'nixDataArray', nix.DataType.Double, [2 7]);
     t = b.createMultiTag('testMultiTag', 'nixMultiTag', d);
     d = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.addFeature(d, nix.LinkType.Tagged);
+    feat = t.createFeature(d, nix.LinkType.Tagged);
     filterID = feat.id;
 	d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.addFeature(d, nix.LinkType.Tagged);
+    feat = t.createFeature(d, nix.LinkType.Tagged);
     filterIDs = {filterID, feat.id};
 
     % test empty id filter

--- a/tests/TestProperty.m
+++ b/tests/TestProperty.m
@@ -1,3 +1,5 @@
+% TestProperty provides tests for all supported nix.Property methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestProperty
-% TESTPROPERTY % Tests for the nix.Property object
-
     funcs = {};
     funcs{end+1} = @testAttributes;
     funcs{end+1} = @testUpdateValues;
@@ -140,7 +140,7 @@ function [] = testDeleteValues( varargin )
     assert(isempty(f.sections{1}.properties{1}.values));
 end
 
-%% Test: Compare properties
+%% Test: Compare Properties
 function [] = testCompare( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -1,3 +1,5 @@
+% TestSection provides tests for all supported nix.Section methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestSection
-% TESTSECTION Tests for the nix.Section object
-
     funcs = {};
     funcs{end+1} = @testCreateSection;
     funcs{end+1} = @testDeleteSection;
@@ -56,7 +56,7 @@ function [] = testCreateSection( varargin )
     assert(size(s.sections, 1) == 2);
 end
 
-%% Test: Delete Section by entity or ID
+%% Test: Delete Section by entity or id
 function [] = testDeleteSection( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
@@ -71,16 +71,16 @@ function [] = testDeleteSection( varargin )
     assert(~s.deleteSection('I do not exist'));
 end
 
-function [] = testListSubsections( varargin )
 %% Test: List/fetch subsections
+function [] = testListSubsections( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     s1 = f.sections{3};
 
     assert(size(s1.sections, 1) == 4);
 end
 
+%% Test: Open subsection by id or name
 function [] = testOpenSection( varargin )
-%% Test: Open subsection by ID or name
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     s1 = f.sections{3};
 
@@ -97,8 +97,8 @@ function [] = testOpenSection( varargin )
     assert(isempty(getSection));
 end
 
-function [] = testOpenSectionIdx( varargin )
 %% Test Open Section by index
+function [] = testOpenSectionIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
     s1 = s.createSection('testSection1', 'nixSection');
@@ -110,8 +110,8 @@ function [] = testOpenSectionIdx( varargin )
     assert(strcmp(f.sections{1}.openSectionIdx(3).name, s3.name));
 end
 
+%% Test: Get parent Section
 function [] = testParent( varargin )
-%% Test: get parent section
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     s1 = f.sections{3};
 
@@ -121,14 +121,17 @@ function [] = testParent( varargin )
     assert(strcmp(s2.parent.id, s1.id));
 end
 
+%% Test: Has Section by id and name
 function [] = testHasSection( varargin )
-%% Test: Has Section
-    f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
-    root = f.sections{3};
-    child = root.sections{1};
+    testFile = fullfile(pwd, 'tests', 'testRW.h5');
+    f = nix.File(testFile, nix.FileMode.Overwrite);
+    rootSec = f.createSection('mainSection', 'nixSection');
+    subSec1 = rootSec.createSection('subSection1', 'nixSection');
+    subSec2 = rootSec.createSection('subSection2', 'nixSection');
 
-    assert(root.hasSection(child.id));
-    assert(~root.hasSection('whatever'));
+    assert(~rootSec.hasSection('I do not exist'));
+    assert(rootSec.hasSection(subSec1.id));
+    assert(rootSec.hasSection(subSec2.name));
 end
 
 %% Test: Section count
@@ -148,8 +151,8 @@ function [] = testSectionCount( varargin )
 end
 
 
+%% Test: Access Attributes
 function [] = testAttributes( varargin )
-%% Test: Access Attributes / Links
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('foo', 'bar');
 
@@ -173,8 +176,8 @@ function [] = testAttributes( varargin )
     assert(isempty(s.repository));
 end
 
+%% Test: Fetch Properties
 function [] = testProperties( varargin )
-%% Test: Properties
     f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
     trial = f.sections{2}.sections{2}.sections{1};
 
@@ -183,7 +186,7 @@ function [] = testProperties( varargin )
     assert(isempty(f.sections{3}.properties));
 end
 
-%% Test: Create property by data type
+%% Test: Create Property by data type
 function [] = testCreateProperty( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
@@ -195,7 +198,7 @@ function [] = testCreateProperty( varargin )
     assert(strcmp(s.properties{1}.name, 'newProperty1'));
 end
 
-%% Test: Create property with value
+%% Test: Create Property with value
 function [] = testCreatePropertyWithValue( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
@@ -256,35 +259,35 @@ function [] = testCreatePropertyWithValue( varargin )
     assert(strcmpi(s.properties{end}.datatype, 'double'));
 end
 
-%% Test: Delete property by entity, propertyStruct, ID and name
+%% Test: Delete Property by entity, ID and name
 function [] = testDeleteProperty( varargin )
     f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
     s.createProperty('newProperty1', nix.DataType.Double);
     s.createProperty('newProperty2', nix.DataType.Bool);
     s.createProperty('newProperty3', nix.DataType.String);
-    s.createProperty('newProperty4', nix.DataType.Double);
 
-    assert(s.deleteProperty('newProperty4'));
-    assert(s.deleteProperty(s.properties{3}.id));
-    delProp = s.properties{2};
-    assert(s.deleteProperty(delProp));
+    assert(s.deleteProperty('newProperty3'));
+    assert(s.deleteProperty(s.properties{2}.id));
     assert(s.deleteProperty(s.properties{1}));
 
     assert(~s.deleteProperty('I do not exist'));
 end
 
-%% Test: Open property by ID and name
+%% Test: Open Property by id and name
 function [] = testOpenProperty( varargin )
-    f = nix.File(fullfile(pwd, 'tests', 'test.h5'), nix.FileMode.ReadOnly);
-    trial = f.sections{2}.sections{2}.sections{1};
+    f = nix.File(fullfile(pwd,'tests','testRW.h5'), nix.FileMode.Overwrite);
+    s = f.createSection('mainSection', 'nixSection');
+    prop1 = s.createProperty('newProperty1', nix.DataType.Double);
+    prop2 = s.createProperty('newProperty2', nix.DataType.Bool);
 
-    assert(~isempty(trial.openProperty(trial.properties{1}.id)));
-    assert(~isempty(trial.openProperty(trial.properties{1}.name)));
+    assert(isempty(s.openProperty('I do not exist')));
+    assert(~isempty(s.openProperty(prop1.id)));
+    assert(~isempty(s.openProperty(prop2.name)));
 end
 
+%% Test Open Property by index
 function [] = testOpenPropertyIdx( varargin )
-%% Test Open Propery by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('testSection', 'nixSection');
     p1 = s.createProperty('testProperty1', nix.DataType.Double);
@@ -312,7 +315,7 @@ function [] = testPropertyCount( varargin )
     assert(f.sections{1}.propertyCount() == 2);
 end
 
-%% Test: set, open and remove section link
+%% Test: Set, open and remove Section link
 function [] = testLink( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     mainSec = f.createSection('mainSection', 'nixSection');
@@ -329,7 +332,7 @@ function [] = testLink( varargin )
     assert(isempty(mainSec.openLink));
 end
 
-%% Test: inherited properties
+%% Test: Inherited Property entities
 function [] = testInheritedProperties( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s = f.createSection('mainSection', 'nixSection');
@@ -348,7 +351,7 @@ function [] = testInheritedProperties( varargin )
     assert(size(s.inheritedProperties, 1) == 2);
 end
 
-%% Test: referring data arrays
+%% Test: Referring DataArrays
 function [] = testReferringDataArrays( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -370,7 +373,7 @@ function [] = testReferringDataArrays( varargin )
     assert(isempty(s.referringDataArrays));
 end
 
-%% Test: referring block data arrays
+%% Test: Referring Block DataArrays
 function [] = testReferringBlockDataArrays( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testDataArray1';
@@ -405,7 +408,7 @@ function [] = testReferringBlockDataArrays( varargin )
     assert(strcmp(testDataArray{1}.name, testName));
 end
 
-%% Test: referring tags
+%% Test: Referring Tags
 function [] = testReferringTags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -427,7 +430,7 @@ function [] = testReferringTags( varargin )
     assert(isempty(s.referringTags));
 end
 
-%% Test: referring block tags
+%% Test: Referring Block Tags
 function [] = testReferringBlockTags( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testTag1';
@@ -462,7 +465,7 @@ function [] = testReferringBlockTags( varargin )
     assert(strcmp(testTag{1}.name, testName));
 end
 
-%% Test: referring multi tags
+%% Test: Referring MultiTags
 function [] = testReferringMultiTags( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -486,7 +489,7 @@ function [] = testReferringMultiTags( varargin )
     assert(isempty(s.referringMultiTags));
 end
 
-%% Test: referring block multi tags
+%% Test: Referring Block MultiTags
 function [] = testReferringBlockMultiTags( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testMultiTag1';
@@ -523,7 +526,7 @@ function [] = testReferringBlockMultiTags( varargin )
     assert(strcmp(testTag{1}.name, testName));
 end
 
-%% Test: referring sources
+%% Test: Referring Sources
 function [] = testReferringSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -545,7 +548,7 @@ function [] = testReferringSources( varargin )
     assert(isempty(s.referringSources));
 end
 
-%% Test: referring block sources
+%% Test: Referring Block Sources
 function [] = testReferringBlockSources( varargin )
     err = 'Provide either empty arguments or a single Block entity';
     testName = 'testSource1';
@@ -580,7 +583,7 @@ function [] = testReferringBlockSources( varargin )
     assert(strcmp(testSource{1}.name, testName));
 end
 
-%% Test: referring blocks
+%% Test: Referring Blocks
 function [] = testReferringBlocks( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
@@ -599,8 +602,8 @@ function [] = testReferringBlocks( varargin )
     assert(size(s.referringBlocks, 1) == 1);
 end
 
+%% Test: Compare Section entities
 function [] = testCompare( varargin )
-%% Test: Compare group entities
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     s1 = f.createSection('testSection1', 'nixSection');
     s2 = f.createSection('testSection2', 'nixSection');
@@ -610,7 +613,7 @@ function [] = testCompare( varargin )
     assert(s2.compare(s1) > 0);
 end
 
-%% Test: filter Sections
+%% Test: Filter Sections
 function [] = testFilterSection( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -666,7 +669,7 @@ function [] = testFilterSection( varargin )
     end
 end
 
-%% Test: filter properties
+%% Test: Filter Properties
 function [] = testFilterProperty( varargin )
     filterName = 'filterMe';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -707,7 +710,6 @@ function [] = testFilterProperty( varargin )
     end
 
     % test fail on nix.Filter.metadata
-    err = 'unknown or unsupported filter';
     try
         f.sections{1}.filterProperties(nix.Filter.metadata, 'someMetadata');
     catch ME
@@ -722,7 +724,7 @@ function [] = testFilterProperty( varargin )
     end
 end
 
-%% Test: Find sections w/o filter
+%% Test: Find Sections w/o filter
 function [] = testFindSection
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     main = f.createSection('testSection', 'nixSection');
@@ -772,7 +774,7 @@ function [] = testFindSection
     assert(size(filtered, 1) == 1);
 end
 
-%% Test: Find sections with filters
+%% Test: Find Sections with filters
 function [] = testFilterFindSections
     findSection = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
@@ -841,7 +843,7 @@ function [] = testFilterFindSections
     end
 end
 
-%% Test: Find sections related to the current section
+%% Test: Find Sections related to the invoking Section
 function [] = testFindRelated
     findSectionType = 'nixFindSection';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -1,3 +1,5 @@
+% TestSource provides tests for all supported nix.Source methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,7 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestSource
-% TESTSOURCE tests for Source
     funcs = {};
     funcs{end+1} = @testCreateSource;
     funcs{end+1} = @testDeleteSource;
@@ -29,7 +30,7 @@ function funcs = TestSource
     funcs{end+1} = @testFilterFindSource;
 end
 
-%% Test: fetch sources
+%% Test: Fetch Sources
 function [] = testFetchSources( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -50,7 +51,7 @@ function [] = testFetchSources( varargin )
     assert(size(f.blocks{1}.sources{1}.sources, 1) == 2);
 end
 
-%% Test: Open source by ID or name
+%% Test: Open Source by id or name
 function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
@@ -70,8 +71,8 @@ function [] = testOpenSource( varargin )
     assert(isempty(getNonSource));
 end
 
-function [] = testOpenSourceIdx( varargin )
 %% Test Open Source by index
+function [] = testOpenSourceIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     s = b.createSource('testSource', 'nixSource');
@@ -144,7 +145,7 @@ function [] = testOpenMetadata( varargin )
     assert(strcmp(s.openMetadata.name, 'testSection'));
 end
 
-%% Test: create source
+%% Test: Create Source
 function [] = testCreateSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
@@ -157,7 +158,7 @@ function [] = testCreateSource ( varargin )
     assert(strcmp(createSource.type, 'nixSource'));
 end
 
-%% Test: delete source
+%% Test: Delete Source by id, name and entity
 function [] = testDeleteSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('sourcetest', 'nixBlock');
@@ -166,14 +167,16 @@ function [] = testDeleteSource( varargin )
 
     tmp = s.createSource('nestedsource1', 'nixSource');
     tmp = s.createSource('nestedsource2', 'nixSource');
-    assert(s.deleteSource('nestedsource1'));
-    assert(s.deleteSource(s.sources{1}.id));
+    tmp = s.createSource('nestedsource3', 'nixSource');
+    assert(s.deleteSource(s.sources{3}.id));
+    assert(s.deleteSource(s.sources{2}.name));
+    assert(s.deleteSource(s.sources{1}));
     assert(~s.deleteSource('I do not exist'));
     assert(isempty(s.sources));
 end
 
-function [] = testAttributes( varargin )
 %% Test: Access Attributes
+function [] = testAttributes( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('tagtest', 'test nixBlock');
     s = b.createSource('sourcetest', 'test nixSource');
@@ -193,7 +196,7 @@ function [] = testAttributes( varargin )
     assert(isempty(s.definition));
 end
 
-%% Test: nix.Source has nix.Source by ID or name
+%% Test: Has Source by id and name
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'nestedsource';
@@ -211,7 +214,7 @@ function [] = testHasSource( varargin )
     assert(f.blocks{1}.sources{1}.hasSource(nestedID));
 end
 
-%% Test: Get parent source
+%% Test: Get parent Source
 function [] = testParentSource( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -224,9 +227,10 @@ function [] = testParentSource( varargin )
 
     assert(strcmp(s3.parentSource.name, sourceName2));
     assert(strcmp(s2.parentSource.name, sourceName1));
+    assert(isempty(s1.parentSource));
 end
 
-%% Test: Referring data arrays
+%% Test: Referring DataArrays
 function [] = testReferringDataArrays( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -245,7 +249,7 @@ function [] = testReferringDataArrays( varargin )
     assert(size(s.referringDataArrays, 1) == 2);
 end
 
-%% Test: Referring tags
+%% Test: Referring Tags
 function [] = testReferringTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -264,7 +268,7 @@ function [] = testReferringTags( varargin )
     assert(size(s.referringTags, 1) == 2);
 end
 
-%% Test: Referring multi tags
+%% Test: Referring MultiTags
 function [] = testReferringMultiTags( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -284,8 +288,8 @@ function [] = testReferringMultiTags( varargin )
     assert(size(s.referringMultiTags, 1) == 2);
 end
 
-function [] = testCompare( varargin )
 %% Test: Compare Source entities
+function [] = testCompare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
@@ -299,7 +303,7 @@ function [] = testCompare( varargin )
     assert(s1.compare(s3) ~= 0);
 end
 
-%% Test: filter sources
+%% Test: Filter Sources
 function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -369,7 +373,7 @@ function [] = testFilterSource( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: Find source w/o filter
+%% Test: Find Source w/o filter
 function [] = testFindSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -417,7 +421,7 @@ function [] = testFindSource( varargin )
     assert(size(filtered, 1) == 1);
 end
 
-%% Test: Find sources with filters
+%% Test: Find Sources with filters
 function [] = testFilterFindSource( varargin )
     findSource = 'nixFindSource';
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);

--- a/tests/TestTag.m
+++ b/tests/TestTag.m
@@ -1,3 +1,5 @@
+% TestTag provides tests for all supported nix.Tag methods.
+%
 % Copyright (c) 2016, German Neuroinformatics Node (G-Node)
 %
 % All rights reserved.
@@ -7,8 +9,6 @@
 % LICENSE file in the root of the Project.
 
 function funcs = TestTag
-% TESTTag tests for Tag
-
     funcs = {};
     funcs{end+1} = @testAddSource;
     funcs{end+1} = @testAddSources;
@@ -16,8 +16,8 @@ function funcs = TestTag
     funcs{end+1} = @testAddReference;
     funcs{end+1} = @testAddReferences;
     funcs{end+1} = @testRemoveReference;
-    funcs{end+1} = @testAddFeature;
-    funcs{end+1} = @testRemoveFeature;
+    funcs{end+1} = @testCreateFeature;
+    funcs{end+1} = @testDeleteFeature;
     funcs{end+1} = @testFetchReferences;
     funcs{end+1} = @testReferenceCount;
     funcs{end+1} = @testFetchSources;
@@ -46,7 +46,7 @@ function funcs = TestTag
     funcs{end+1} = @testFilterFeature;
 end
 
-%% Test: Add sources by entity and id
+%% Test: Add Sources by entity and id
 function [] = testAddSource ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
@@ -69,7 +69,7 @@ function [] = testAddSource ( varargin )
     assert(size(f.blocks{1}.tags{1}.sources, 1) == 2);
 end
 
-%% Test: Add sources by entity cell array
+%% Test: Add Sources by entity cell array
 function [] = testAddSources ( varargin )
     testFile = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(testFile, nix.FileMode.Overwrite);
@@ -103,7 +103,7 @@ function [] = testAddSources ( varargin )
     assert(size(f.blocks{1}.tags{1}.sources, 1) == 3);
 end
 
-%% Test: Remove sources by entity and id
+%% Test: Remove Sources by entity and id
 function [] = testRemoveSource ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
@@ -203,8 +203,8 @@ function [] = testRemoveReference ( varargin )
     assert(size(b.dataArrays, 1) == 2);
 end
 
-%% Test: Add features by entity and id
-function [] = testAddFeature ( varargin )
+%% Test: Create Features by entity and id
+function [] = testCreateFeature ( varargin )
     fileName = fullfile(pwd, 'tests', 'testRW.h5');
     f = nix.File(fileName, nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -219,12 +219,12 @@ function [] = testAddFeature ( varargin )
     
     assert(isempty(t.features));
     assert(isempty(f.blocks{1}.tags{1}.features));
-    tmp = t.addFeature(b.dataArrays{1}.id, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{3}.id, nix.LinkType.Untagged);
-    tmp = t.addFeature(b.dataArrays{4}, nix.LinkType.Untagged);
-    tmp = t.addFeature(b.dataArrays{5}.id, nix.LinkType.Indexed);
-    tmp = t.addFeature(b.dataArrays{6}, nix.LinkType.Indexed);
+    tmp = t.createFeature(b.dataArrays{1}.id, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{3}.id, nix.LinkType.Untagged);
+    tmp = t.createFeature(b.dataArrays{4}, nix.LinkType.Untagged);
+    tmp = t.createFeature(b.dataArrays{5}.id, nix.LinkType.Indexed);
+    tmp = t.createFeature(b.dataArrays{6}, nix.LinkType.Indexed);
     assert(size(t.features, 1) == 6);
     assert(size(f.blocks{1}.tags{1}.features, 1) == 6);
 
@@ -233,26 +233,26 @@ function [] = testAddFeature ( varargin )
     assert(size(f.blocks{1}.tags{1}.features, 1) == 6);
 end
 
-%% Test: Remove features by entity and id
-function [] = testRemoveFeature ( varargin )
+%% Test: Remove Features by entity and id
+function [] = testDeleteFeature ( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
     tmp = b.createDataArray('featureTestDataArray2', 'nixDataArray', nix.DataType.Double, [3 4]);
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('featureTest', 'nixTag', position);
-    tmp = t.addFeature(b.dataArrays{1}.id, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{1}.id, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{2}, nix.LinkType.Tagged);
 
-    assert(t.removeFeature(t.features{2}.id));
-    assert(t.removeFeature(t.features{1}));
+    assert(t.deleteFeature(t.features{2}.id));
+    assert(t.deleteFeature(t.features{1}));
     assert(isempty(t.features));
 
-    assert(~t.removeFeature('I do not exist'));
+    assert(~t.deleteFeature('I do not exist'));
     assert(size(b.dataArrays, 1) == 2);
 end
 
-%% Test: fetch references
+%% Test: Fetch references
 function [] = testFetchReferences( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
@@ -285,7 +285,7 @@ function [] = testReferenceCount( varargin )
     assert(f.blocks{1}.tags{1}.referenceCount() == 2);
 end
 
-%% Test: fetch sources
+%% Test: Fetch Sources
 function [] = testFetchSources( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
@@ -302,7 +302,7 @@ function [] = testFetchSources( varargin )
     assert(size(t.sources, 1) == 3);
 end
 
-%% Test: fetch features
+%% Test: Fetch Features
 function [] = testFetchFeatures( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
@@ -311,8 +311,8 @@ function [] = testFetchFeatures( varargin )
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('featureTest', 'nixTag', position);
 
-    tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
-    tmp = t.addFeature(b.dataArrays{2}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{2}, nix.LinkType.Tagged);
 
     assert(size(t.features, 1) == 2);
 end
@@ -325,10 +325,10 @@ function [] = testFeatureCount( varargin )
     t = b.createTag('testTag', 'nixTag', [1 2]);
 
     assert(t.featureCount() == 0);
-    t.addFeature(b.createDataArray('testDataArray1', 'nixDataArray', ...
+    t.createFeature(b.createDataArray('testDataArray1', 'nixDataArray', ...
         nix.DataType.Double, [1 2]), nix.LinkType.Tagged);
     assert(t.featureCount() == 1);
-    t.addFeature(b.createDataArray('testDataArray2', 'nixDataArray', ...
+    t.createFeature(b.createDataArray('testDataArray2', 'nixDataArray', ...
         nix.DataType.Double, [3 4]), nix.LinkType.Tagged);
     
     clear t b f;
@@ -336,7 +336,7 @@ function [] = testFeatureCount( varargin )
     assert(f.blocks{1}.tags{1}.featureCount() == 2);
 end
 
-%% Test: Open source by ID or name
+%% Test: Open Source by id or name
 function [] = testOpenSource( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('test', 'nixBlock');
@@ -375,7 +375,7 @@ function [] = testOpenSourceIdx( varargin )
     assert(strcmp(f.blocks{1}.tags{1}.openSourceIdx(3).name, s3.name));
 end
 
-%% Test: nix.Tag has nix.Source by ID or entity
+%% Test: Has Source by id or entity
 function [] = testHasSource( varargin )
     fileName = 'testRW.h5';
     sName = 'sourceTest1';
@@ -413,14 +413,14 @@ function [] = testSourceCount( varargin )
     assert(f.blocks{1}.tags{1}.sourceCount() == 2);
 end
 
-%% Test: Open feature by ID
+%% Test: Open Feature by id
 function [] = testOpenFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     tmp = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     position = [1.0 1.2 1.3 15.9];
     t = b.createTag('featureTest', 'nixTag', position);
-    tmp = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    tmp = t.createFeature(b.dataArrays{1}, nix.LinkType.Tagged);
 
     assert(~isempty(t.openFeature(t.features{1}.id)));
 
@@ -429,24 +429,24 @@ function [] = testOpenFeature( varargin )
     assert(isempty(feat));
 end
 
+%% Test Open Feature by index
 function [] = testOpenFeatureIdx( varargin )
-%% Test Open feature by index
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [2 9]);
     d1 = b.createDataArray('testFeature1', 'nixDataArray', nix.DataType.Double, [1 2]);
     d2 = b.createDataArray('testFeature2', 'nixDataArray', nix.DataType.Double, [3 2]);
     d3 = b.createDataArray('testFeature3', 'nixDataArray', nix.DataType.Double, [7 2]);
-    t.addFeature(d1, nix.LinkType.Tagged);
-    t.addFeature(d2, nix.LinkType.Untagged);
-    t.addFeature(d3, nix.LinkType.Indexed);
+    t.createFeature(d1, nix.LinkType.Tagged);
+    t.createFeature(d2, nix.LinkType.Untagged);
+    t.createFeature(d3, nix.LinkType.Indexed);
 
     assert(f.blocks{1}.tags{1}.openFeatureIdx(1).linkType == nix.LinkType.Tagged);
     assert(f.blocks{1}.tags{1}.openFeatureIdx(2).linkType == nix.LinkType.Untagged);
     assert(f.blocks{1}.tags{1}.openFeatureIdx(3).linkType == nix.LinkType.Indexed);
 end
 
-%% Test: Open reference by ID or name
+%% Test: Open reference by id or name
 function [] = testOpenReference( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('referenceTest', 'nixBlock');
@@ -466,8 +466,8 @@ function [] = testOpenReference( varargin )
     assert(isempty(getNonRef));
 end
 
-function [] = testOpenReference_idx( varargin )
 %% Test Open reference by index
+function [] = testOpenReference_idx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [2 9]);
@@ -588,7 +588,7 @@ function [] = testRetrieveDataIdx( varargin )
     assert(retData(1) == raw(t.position + 1), 'Position check failed');
 end
 
-%% Test: Retrieve feature data by name and id
+%% Test: Retrieve Feature data by name and id
 function [] = testRetrieveFeatureData( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -613,14 +613,14 @@ function [] = testRetrieveFeatureData( varargin )
     % test retrieve untagged feature data by name
     df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.addFeature(df, nix.LinkType.Untagged);
+    t.createFeature(df, nix.LinkType.Untagged);
     retData = t.retrieveFeatureData('testUntagged');
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data by id
     df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.addFeature(df, nix.LinkType.Tagged);
+    t.createFeature(df, nix.LinkType.Tagged);
     retData = t.retrieveFeatureData(df.id);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
@@ -628,12 +628,12 @@ function [] = testRetrieveFeatureData( varargin )
     % test retrieve indexed feature data by id
     df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.addFeature(df, nix.LinkType.Indexed);
+    t.createFeature(df, nix.LinkType.Indexed);
     retData = t.retrieveFeatureData(df.id);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
 end
 
-%% Test: Retrieve feature data by index
+%% Test: Retrieve Feature data by index
 function [] = testRetrieveFeatureDataIdx( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
@@ -650,14 +650,14 @@ function [] = testRetrieveFeatureDataIdx( varargin )
     % test retrieve untagged feature data 
     df = b.createDataArrayFromData('testUntagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.addFeature(df, nix.LinkType.Untagged);
+    t.createFeature(df, nix.LinkType.Untagged);
     retData = t.retrieveFeatureDataIdx(1);
     assert(size(retData, 2) == size(rawFeature, 2), 'Untagged size check fail');
 
     % test retrieve tagged feature data 
     df = b.createDataArrayFromData('testTagged', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.addFeature(df, nix.LinkType.Tagged);
+    t.createFeature(df, nix.LinkType.Tagged);
     retData = t.retrieveFeatureDataIdx(2);
     assert(size(retData, 2) == t.extent, 'Tagged Extent check fail');
     assert(retData(1) == rawFeature(t.position + 1), 'Tagged Position check fail');
@@ -665,7 +665,7 @@ function [] = testRetrieveFeatureDataIdx( varargin )
     % test retrieve indexed feature data
     df = b.createDataArrayFromData('testIndexed', 'nixDataArray', rawFeature);
     df.appendSampledDimension(1);
-    t.addFeature(df, nix.LinkType.Indexed);
+    t.createFeature(df, nix.LinkType.Indexed);
     retData = t.retrieveFeatureDataIdx(3);
     assert(size(retData, 2) == size(rawFeature, 2), 'Indexed size check fail');
 
@@ -676,7 +676,7 @@ function [] = testRetrieveFeatureDataIdx( varargin )
     end
 end
 
-%% Test: Read and write nix.Tag attributes
+%% Test: Read and write Tag attributes
 function [] = testAttributes( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
@@ -741,14 +741,14 @@ function [] = testAttributes( varargin )
     assert(isequal(f.blocks{1}.tags{1}.extent, lastExt));
 end
 
-%% Test: nix.Tag has feature by ID
+%% Test: Has Feature by id
 function [] = testHasFeature( varargin )
     fileName = 'testRW.h5';
     f = nix.File(fullfile(pwd, 'tests', fileName), nix.FileMode.Overwrite);
     b = f.createBlock('featureTest', 'nixBlock');
     da = b.createDataArray('featureTestDataArray', 'nixDataArray', nix.DataType.Double, [1 2]);
     t = b.createTag('featureTest', 'nixTag', [1.0 1.2 1.3 15.9]);
-    feature = t.addFeature(b.dataArrays{1}, nix.LinkType.Tagged);
+    feature = t.createFeature(b.dataArrays{1}, nix.LinkType.Tagged);
     featureID = feature.id;
 
     assert(~t.hasFeature('I do not exist'));
@@ -759,7 +759,7 @@ function [] = testHasFeature( varargin )
     assert(f.blocks{1}.tags{1}.hasFeature(featureID));
 end
 
-%% Test: nix.Tag has reference by ID or name
+%% Test: Has reference by id or name
 function [] = testHasReference( varargin )
     fileName = 'testRW.h5';
     daName = 'referenceTest';
@@ -777,8 +777,8 @@ function [] = testHasReference( varargin )
     assert(f.blocks{1}.tags{1}.hasReference(daName));
 end
 
-function [] = testCompare( varargin )
 %% Test: Compare Tag entities
+function [] = testCompare( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b1 = f.createBlock('testBlock1', 'nixBlock');
     b2 = f.createBlock('testBlock2', 'nixBlock');
@@ -792,7 +792,7 @@ function [] = testCompare( varargin )
     assert(t1.compare(t3) ~= 0);
 end
 
-%% Test: filter sources
+%% Test: Filter Sources
 function [] = testFilterSource( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -867,7 +867,7 @@ function [] = testFilterSource( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: filter references
+%% Test: Filter references
 function [] = testFilterReference( varargin )
     filterName = 'filterMe';
     filterType = 'filterType';
@@ -941,16 +941,16 @@ function [] = testFilterReference( varargin )
     assert(strcmp(filtered{1}.name, mainName));
 end
 
-%% Test: filter features
+%% Test: Filter Features
 function [] = testFilterFeature( varargin )
     f = nix.File(fullfile(pwd, 'tests', 'testRW.h5'), nix.FileMode.Overwrite);
     b = f.createBlock('testBlock', 'nixBlock');
     t = b.createTag('testTag', 'nixTag', [1 2 3]);
     d = b.createDataArray('testDataArray1', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.addFeature(d, nix.LinkType.Tagged);
+    feat = t.createFeature(d, nix.LinkType.Tagged);
     filterID = feat.id;
 	d = b.createDataArray('testDataArray2', 'nixDataArray', nix.DataType.Double, [1 2]);
-    feat = t.addFeature(d, nix.LinkType.Tagged);
+    feat = t.createFeature(d, nix.LinkType.Tagged);
     filterIDs = {filterID, feat.id};
 
     % test empty id filter


### PR DESCRIPTION
This humongous PR adds documentation for the NIX Matlab bindings.

The documentation includes the original nix source code documentation as well as information from the nix API documentation page and the nixpy tutorial and was adapted to the current Matlab bindings.
Since there are no proper style guides for doc strings in Matlab, the chosen format is a mixture of Matlabs own documentation style and custom additions. Where applicable every Class and method includes very basic usage examples. Classes and Methods that should not be used by a normal user contain a corresponding description in the documentation.
When using the `startup.m` script to set the environment for work with the Matlab bindings, a short message with pointers to the documentation, help, tests and primer script is displayed to point users towards the usage examples.

In addition to the added Class and Method documentation, the following changes are added as well:
- nix.Group: rename `getDataArray`, `getTag`, `getMultiTag` to `openDataArray`, `openTag`, `openMultiTag`.
- nix.Tag: rename `addFeature` to `createFeature` since it is an actual create method.
- nix.Tag: rename `removeFeature` to `deleteFeature` since it is an actual delete method.
- nix.MultiTag: rename `addPositions` to `setPositions` since it is more a setter than adding data.
- nix.MultiTag: rename `addFeature` to `createFeature` since it actually creates a feature.
- nix.MultiTag: rename `removeFeature` to `deleteFeature` since it actually deletes a feature.
- nix.Section: simplification of the `deleteProperty` method.
- nix.Dimension: Fix index bug in SampledDimension and RangeDimension.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b).