### PR TITLE
[cmake] support static NIX

### DIFF
--- a/cmake/FindNIX.cmake
+++ b/cmake/FindNIX.cmake
@@ -4,6 +4,16 @@
 #  NIX_INCLUDE_DIRS - The Nix include directories
 #  NIX_LIBRARIES - The libraries needed to use Nix
 
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if(NIX_USE_STATIC_LIBS)
+  set(_nix_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+  endif()
+endif()
+
 
 find_path(NIX_INCLUDE_DIR nix.hpp
   HINTS /usr/local/include
@@ -19,8 +29,8 @@ find_library(NIX_LIBRARY NAMES nix libnix
   /usr/local/lib
   /usr/lib)
 
-set(NIX_LIBRARIES ${NIX_LIBRARY} )
-set(NIX_INCLUDE_DIRS ${NIX_INCLUDE_DIR} )
+set(NIX_LIBRARIES ${NIX_LIBRARY})
+set(NIX_INCLUDE_DIRS ${NIX_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set NIX_FOUND to TRUE
@@ -28,5 +38,12 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Nix DEFAULT_MSG
   NIX_LIBRARY NIX_INCLUDE_DIR)
 
-mark_as_advanced(NIX_INCLUDE_DIR NIX_LIBRARY)
+mark_as_advanced(NIX_INCLUDE_DIR NIX_LIBRARIES)
+
+if(NIX_USE_STATIC_LIBS)
+  if(NIX_FOUND)
+    add_definitions(-DNIX_STATIC=1)
+  endif()
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_nix_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 


### PR DESCRIPTION
Use NIX_USE_STATIC_LIBS before find_package(NIX ...) to turn on building against the static version of NIX.