### PR TITLE
Windows static link build

### DIFF
--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -157,13 +157,19 @@ classdef Utils
                 error(err);
             end
 
+            if (maxDepth < 0)
+                err.identifier = 'NIXMX:InvalidArgument';
+                err.message = 'Search depth must be positive integers or logicals.';
+                error(err);
+            end
+
             nix.Utils.validFilter(filter, val);
 
             % transform matlab to c++ style index
-            md = nix.Utils.handleIndex(maxDepth);
+            %md = nix.Utils.handleIndex(maxDepth);
 
             mxMethod = strcat(obj.alias, '::', mxMethodName);
-            list = nix_mx(mxMethod, obj.nixhandle, md, uint8(filter), val);
+            list = nix_mx(mxMethod, obj.nixhandle, maxDepth, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);
         end
 

--- a/+nix/Utils.m
+++ b/+nix/Utils.m
@@ -165,9 +165,6 @@ classdef Utils
 
             nix.Utils.validFilter(filter, val);
 
-            % transform matlab to c++ style index
-            %md = nix.Utils.handleIndex(maxDepth);
-
             mxMethod = strcat(obj.alias, '::', mxMethodName);
             list = nix_mx(mxMethod, obj.nixhandle, maxDepth, uint8(filter), val);
             r = nix.Utils.createEntityArray(list, objConstructor);

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/*.h5
 # library files
 *.dll
 *.mex*
+*.exe*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,16 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O2")
 endif()
 
-#packages
+# packages
 
-find_package(Boost 1.49.0 REQUIRED)
+# Provide Boost lib
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost 1.49.0 REQUIRED date_time regex program_options system filesystem)
 include_directories(${Boost_INCLUDE_DIR})
+
+# Provide HDF5 lib
+set(HDF5_USE_STATIC_LIBRARIES ON)
+find_package (HDF5 REQUIRED COMPONENTS C)
 
 # The computing environment
 
@@ -56,6 +62,7 @@ if(NOT CE_PACKAGE)
   Install GNU Octave (or MathWorks MATLAB).")
 endif()
 
+set(NIX_USE_STATIC_LIBS ON)
 find_package(NIX REQUIRED)
 
 include_directories(${CE_INCDIR} ${NIX_INCLUDE_DIR} "src" "src/utils")
@@ -71,7 +78,7 @@ endif()
 
 add_library(nix_mx ${LIBTYPE} nix_mx.cc ${SOURCE_FILES} ${INCLUDE_FILES})
 
-target_link_libraries(nix_mx ${CE_LIBRARIES} ${NIX_LIBRARIES})
+target_link_libraries(nix_mx ${CE_LIBRARIES} ${NIX_LIBRARIES} ${Boost_LIBRARIES} ${HDF5_LIBRARIES})
 set_target_properties(nix_mx PROPERTIES
 		              VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
 		              SOVERSION ${VERSION_ABI})
@@ -105,4 +112,6 @@ MESSAGE(STATUS "Computing environment")
 MESSAGE(STATUS "  Package: ${CE_PACKAGE}")
 MESSAGE(STATUS "  Version: ${CE_VERSION}")
 MESSAGE(STATUS "  Module : ${CE_EXTENSION}")
+MESSAGE(STATUS "  BOOST  : ${Boost_LIBRARIES}")
+MESSAGE(STATUS "  NIX    : ${NIX_LIBRARIES}")
 MESSAGE(STATUS "=====================")

--- a/src/nixblock.cc
+++ b/src/nixblock.cc
@@ -38,7 +38,7 @@ namespace nixblock {
         nix::DataType dtype = nix::string_to_data_type(input.str(4));
         nix::NDSize size = input.ndsize(5);
 
-        nix::DataArray dt = block.createDataArray(name, type, dtype, size);
+        nix::DataArray dt = block.createDataArray(name, type, dtype, size, nix::Compression::None);
         output.set(0, dt);
     }
 

--- a/tests/TestBlock.m
+++ b/tests/TestBlock.m
@@ -1125,23 +1125,23 @@ function [] = testFindSource
     end
 
     % find all
-    filtered = b.findSources(5);
-    assert(size(filtered, 1) == 10);
-
-    % find until level 4
     filtered = b.findSources(4);
     assert(size(filtered, 1) == 10);
 
     % find until level 3
     filtered = b.findSources(3);
-    assert(size(filtered, 1) == 6);
+    assert(size(filtered, 1) == 10);
 
     % find until level 2
     filtered = b.findSources(2);
-    assert(size(filtered, 1) == 3);
+    assert(size(filtered, 1) == 6);
 
     % find until level 1
     filtered = b.findSources(1);
+    assert(size(filtered, 1) == 3);
+
+    % find until level 0
+    filtered = b.findSources(0);
     assert(size(filtered, 1) == 1);
 end
 
@@ -1186,9 +1186,9 @@ function [] = testFindSourceFiltered
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = b.filterFindSources(1, nix.Filter.type, findSource);
+    filtered = b.filterFindSources(0, nix.Filter.type, findSource);
     assert(isempty(filtered));
-    filtered = b.filterFindSources(4, nix.Filter.type, findSource);
+    filtered = b.filterFindSources(3, nix.Filter.type, findSource);
     assert(size(filtered, 1) == 3);
     assert(strcmp(filtered{1}.type, findSource));
 

--- a/tests/TestSection.m
+++ b/tests/TestSection.m
@@ -753,25 +753,29 @@ function [] = testFindSection
         assert(strcmp(ME.message, err));
     end
 
-    % find all
-    filtered = sl1.findSections(5);
-    assert(size(filtered, 1) == 10);
+    % Check invalid entry
+    err = 'Search depth must be positive integers or logicals.';
+    try
+        sl1.findSections(-20);
+    catch ME
+        assert(strcmp(ME.message, err));
+    end
 
-    % find until level 4
+    % find all
     filtered = sl1.findSections(4);
-    assert(size(filtered, 1) == 10);
+    assert(size(filtered, 1) == 9);
 
     % find until level 3
     filtered = sl1.findSections(3);
-    assert(size(filtered, 1) == 6);
+    assert(size(filtered, 1) == 9);
 
     % find until level 2
     filtered = sl1.findSections(2);
-    assert(size(filtered, 1) == 3);
+    assert(size(filtered, 1) == 5);
 
     % find until level 1
     filtered = sl1.findSections(1);
-    assert(size(filtered, 1) == 1);
+    assert(size(filtered, 1) == 2);
 end
 
 %% Test: Find Sections with filters
@@ -805,7 +809,7 @@ function [] = testFilterFindSections
     assert(strcmp(filtered{1}.id, sl41.id));
 
     % test find by ids
-    filterids = {sl1.id, sl41.id};
+    filterids = {sl21.id, sl41.id};
     filtered = sl1.filterFindSections(1, nix.Filter.ids, filterids);
     assert(size(filtered, 1) == 1);
     filtered = sl1.filterFindSections(4, nix.Filter.ids, filterids);
@@ -821,7 +825,7 @@ function [] = testFilterFindSections
     assert(strcmp(filtered{1}.name, sl41.name));
 
     % test find by type
-    filtered = sl1.filterFindSections(1, nix.Filter.type, findSection);
+    filtered = main.filterFindSections(1, nix.Filter.type, findSection);
     assert(isempty(filtered));
     filtered = sl1.filterFindSections(4, nix.Filter.type, findSection);
     assert(size(filtered, 1) == 3);

--- a/tests/TestSource.m
+++ b/tests/TestSource.m
@@ -401,23 +401,23 @@ function [] = testFindSource( varargin )
     end
 
     % find all
-    filtered = s.findSources(5);
+    filtered = s.findSources(4);
     assert(size(filtered, 1) == 11);
 
     % find until level 3
-    filtered = s.findSources(4);
+    filtered = s.findSources(3);
     assert(size(filtered, 1) == 7);
 
     % find until level 2
-    filtered = s.findSources(3);
+    filtered = s.findSources(2);
     assert(size(filtered, 1) == 4);
 
     % find until level 1
-    filtered = s.findSources(2);
+    filtered = s.findSources(1);
     assert(size(filtered, 1) == 2);
 
     % find until level 0
-    filtered = s.findSources(1);
+    filtered = s.findSources(0);
     assert(size(filtered, 1) == 1);
 end
 

--- a/win_build.bat
+++ b/win_build.bat
@@ -88,6 +88,13 @@ cmake --build . --config %BUILD_TYPE% --target testrunner
 IF %ERRORLEVEL% == 1 (EXIT /b)
 
 ECHO --------------------------------------------------------------------------
+ECHO Building nix-tool ...
+ECHO --------------------------------------------------------------------------
+cmake --build . --config %BUILD_TYPE% --target nix-tool
+
+IF %ERRORLEVEL% == 1 (EXIT /b)
+
+ECHO --------------------------------------------------------------------------
 ECHO Testing nix ...
 ECHO --------------------------------------------------------------------------
 %NIX_BUILD_DIR%\TestRunner.exe
@@ -119,6 +126,8 @@ IF %ERRORLEVEL% == 1 (EXIT /b)
 
 REM Copying required nix-mx.mex file to nix-mx root folder
 COPY %NIX_MX_ROOT%\build\%BUILD_TYPE%\nix_mx.mexw* %NIX_MX_ROOT%\ /Y
+REM Provide nix-tool as well for validation and content display
+COPY %NIX_ROOT%\build\%BUILD_TYPE%\nix-tool.exe %NIX_MX_ROOT%\ /Y
 
 CD %NIX_MX_ROOT%
 

--- a/win_build.bat
+++ b/win_build.bat
@@ -1,16 +1,31 @@
 @ECHO off
 SET MATLAB_BINARY=c:\work\MATLAB_R2011a\bin
-REM Latest dependencies at https://projects.g-node.org/nix/
+REM Latest Boost dependencies at https://projects.g-node.org/nix/
 SET NIX_DEP=c:\work\nix-dep
 REM clone nix source from https://github.com/G-Node/nix
 SET NIX_ROOT=c:\work\nix
 SET NIX_MX_ROOT=c:\work\nix-mx
+REM This build script requires HDF5 version 1.10.1
+REM Latest HDF5 dependencies for VS 2013 at https://www.hdfgroup.org/downloads/hdf5/
+REM provide them at %NIX-DEP%\x86 or %NIX-DEP%\x64
 SET HDF5_VERSION_DIR=hdf5-1.10.1
+REM Static build requires cmake version 3.9.1
+SET CMAKEVER=3.9.1
+
+ECHO --------------------------------------------------------------------------
+ECHO Checking dependencies ...
+ECHO --------------------------------------------------------------------------
 
 IF NOT EXIST cmake (
-	ECHO Require a valid installation of cmake.
+	ECHO Require a valid installation of cmake.\nExit...
 	EXIT /b
 )
+
+FOR /F "tokens=*" %%a in ('cmake /V ^| find "%CMAKEVER%" /c') DO SET HASCMAKEVER=%%a
+IF NOT [%HASCMAKEVER%]==[1] (
+	ECHO Require cmake version %CMAKEVER%.
+	EXIT /b
+	)
 
 IF NOT EXIST %NIX_DEP% (
 	ECHO Please provide the nix dependency directory.
@@ -53,11 +68,11 @@ SET PATH=%PATH%;%HDF5_BASE%\bin
 SET BOOST_ROOT=%BASE%\boost-1.57.0
 SET BOOST_INCLUDEDIR=%BOOST_ROOT%\include\boost-1_57
 
-ECHO CPPUNIT_INCLUDE_DIR=%CPPUNIT_INCLUDE_DIR%
+ECHO CPPUNIT_INCLUDE_DIR=%CPPUNIT_INCLUDE_DIR%, checking directory...
 IF EXIST %CPPUNIT_INCLUDE_DIR% (ECHO cppunit OK) ElSE (EXIT /b)
-ECHO HDF5_DIR=%HDF5_DIR%
+ECHO HDF5_DIR=%HDF5_DIR%, checking directory...
 IF EXIST %HDF5_DIR% (ECHO hdf5 OK) ELSE (EXIT /b)
-ECHO BOOST_INCLUDEDIR=%BOOST_INCLUDEDIR%
+ECHO BOOST_INCLUDEDIR=%BOOST_INCLUDEDIR%, checking directory...
 IF EXIST %BOOST_ROOT% (ECHO boost OK) ELSE (EXIT /b)
 
 ECHO --------------------------------------------------------------------------

--- a/win_build.bat
+++ b/win_build.bat
@@ -5,9 +5,15 @@ SET NIX_DEP=c:\work\nix-dep
 REM clone nix source from https://github.com/G-Node/nix
 SET NIX_ROOT=c:\work\nix
 SET NIX_MX_ROOT=c:\work\nix-mx
+SET HDF5_VERSION_DIR=hdf5-1.10.1
+
+IF NOT EXIST cmake (
+	ECHO Require a valid installation of cmake.
+	EXIT /b
+)
 
 IF NOT EXIST %NIX_DEP% (
-	ECHO Please provide valid nix dependencies.
+	ECHO Please provide the nix dependency directory.
 	EXIT /b
 )
 
@@ -40,8 +46,8 @@ SET BASE=%NIX_DEP%\%PLATFORM%\%BUILD_TYPE%
 SET CPPUNIT_INCLUDE_DIR=%BASE%\cppunit-1.13.2\include
 SET PATH=%PATH%;%CPPUNIT_INCLUDE_DIR%
 
-SET HDF5_BASE=%NIX_DEP%\%PLATFORM%\hdf5-1.8.14
-SET HDF5_DIR=%HDF5_BASE%\cmake\hdf5
+SET HDF5_BASE=%NIX_DEP%\%PLATFORM%\%HDF5_VERSION_DIR%
+SET HDF5_DIR=%HDF5_BASE%\cmake
 SET PATH=%PATH%;%HDF5_BASE%\bin
 
 SET BOOST_ROOT=%BASE%\boost-1.57.0
@@ -65,7 +71,7 @@ REM Clean up build folder to ensure clean build.
 DEL * /S /Q
 RD /S /Q "CMakeFiles" "Testing" "Debug" "Release" "nix-tool.dir" "x64" "TestRunner.dir" "nix.dir"
 
-IF %PROCESSOR_ARCHITECTURE% == x86 ( cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
+IF %PROCESSOR_ARCHITECTURE% == x86 ( cmake .. -DBUILD_STATIC=ON -G "Visual Studio 12") ELSE (cmake .. -DBUILD_STATIC=ON -G "Visual Studio 12 Win64")
 
 ECHO --------------------------------------------------------------------------
 ECHO Building nix via %NIX_ROOT%\build\nix.sln ...
@@ -101,14 +107,6 @@ CD %NIX_MX_ROOT%\build
 REM Clean up build folder to ensure clean build.
 DEL * /S /Q
 RD /S /Q "CMakeFiles" "Debug" "nix_mx.dir" "Release" "Win32" "x64"
-
-REM Copying required libraries to nix-mx root folder
-COPY %NIX_BUILD_DIR%\nix.dll %NIX_MX_ROOT%\ /Y
-COPY %HDF5_BASE%\bin\hdf5.dll %NIX_MX_ROOT%\ /Y
-COPY %HDF5_BASE%\bin\msvcp120.dll %NIX_MX_ROOT%\ /Y
-COPY %HDF5_BASE%\bin\msvcr120.dll %NIX_MX_ROOT%\ /Y
-COPY %HDF5_BASE%\bin\zlib.dll %NIX_MX_ROOT%\ /Y
-COPY %HDF5_BASE%\bin\szip.dll %NIX_MX_ROOT%\ /Y
 
 IF %PROCESSOR_ARCHITECTURE% == x86 (cmake .. -G "Visual Studio 12") ELSE (cmake .. -G "Visual Studio 12 Win64")
 


### PR DESCRIPTION
- Statically links all dependencies into the created mex files under windows. This now provides support for Matlab versions R2015+, wohoo!
- The updated build script checks for cmake version 3.9.1 and adds the nix-tool to the distribution.
- This PR also introduces a small fix for #153.

Successfully built and tested under win32 (Matlab R2011a) and win64 (Matlab R2011a, R2014b, R2015a, R2016b)