### PR TITLE
Fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ tests/*.h5
 *.dll
 *.mex*
 *.exe*
+
+# IDE specifics
+.idea/
+cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(VERSION_PATCH 0)
 
 set(VERSION_ABI   1)
 
+# Switch static build
+option(BUILD_STATIC "Build static version of the library" ON)
+
 ### include local modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -21,12 +24,12 @@ endif()
 # packages
 
 # Provide Boost lib
-set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_LIBS ${BUILD_STATIC})
 find_package(Boost 1.49.0 REQUIRED date_time regex program_options system filesystem)
 include_directories(${Boost_INCLUDE_DIR})
 
 # Provide HDF5 lib
-set(HDF5_USE_STATIC_LIBRARIES ON)
+set(HDF5_USE_STATIC_LIBRARIES ${BUILD_STATIC})
 find_package (HDF5 REQUIRED COMPONENTS C)
 
 # The computing environment
@@ -62,7 +65,7 @@ if(NOT CE_PACKAGE)
   Install GNU Octave (or MathWorks MATLAB).")
 endif()
 
-set(NIX_USE_STATIC_LIBS ON)
+set(NIX_USE_STATIC_LIBS ${BUILD_STATIC})
 find_package(NIX REQUIRED)
 
 include_directories(${CE_INCDIR} ${NIX_INCLUDE_DIR} "src" "src/utils")
@@ -80,8 +83,8 @@ add_library(nix_mx ${LIBTYPE} nix_mx.cc ${SOURCE_FILES} ${INCLUDE_FILES})
 
 target_link_libraries(nix_mx ${CE_LIBRARIES} ${NIX_LIBRARIES} ${Boost_LIBRARIES} ${HDF5_LIBRARIES})
 set_target_properties(nix_mx PROPERTIES
-		              VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
-		              SOVERSION ${VERSION_ABI})
+                      VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+                      SOVERSION ${VERSION_ABI})
 set_target_properties(nix_mx PROPERTIES PREFIX "")
 set_target_properties(nix_mx PROPERTIES SUFFIX .${CE_EXTENSION})
 
@@ -92,8 +95,6 @@ endif()
 if(DEBUG_GLUE)
    add_definitions(-DDEBUG_GLUE=1)
 endif()
-
-
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_VERSION} GREATER 3.2)
   add_custom_target(macOS_zip COMMAND
@@ -107,11 +108,16 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_VERSION} GREATER 3.2)
     "${CMAKE_BINARY_DIR}/*.mexmac*")
 endif()
 
-MESSAGE(STATUS "=====================")
+MESSAGE(STATUS "===============================")
+MESSAGE(STATUS "READY. ")
+MESSAGE(STATUS "===============================")
 MESSAGE(STATUS "Computing environment")
 MESSAGE(STATUS "  Package: ${CE_PACKAGE}")
 MESSAGE(STATUS "  Version: ${CE_VERSION}")
 MESSAGE(STATUS "  Module : ${CE_EXTENSION}")
 MESSAGE(STATUS "  BOOST  : ${Boost_LIBRARIES}")
 MESSAGE(STATUS "  NIX    : ${NIX_LIBRARIES}")
-MESSAGE(STATUS "=====================")
+MESSAGE(STATUS "===============================")
+MESSAGE(STATUS "CFLAGS:  ${CMAKE_CXX_FLAGS}")
+MESSAGE(STATUS "STATIC:  ${BUILD_STATIC}")
+MESSAGE(STATUS "===============================")

--- a/cmake/FindMATLAB.cmake
+++ b/cmake/FindMATLAB.cmake
@@ -40,7 +40,7 @@
 SET(MATLAB_FOUND 0)
 IF(WIN32)
   # Search for a version of Matlab available, starting from the most modern one to older versions
-  FOREACH(MATVER "7.14" "7.12" "7.11" "7.10" "7.9" "7.8" "7.7" "7.6" "7.5" "7.4")
+  FOREACH(MATVER "9.3" "9.2" "9.1" "8.6" "8.5" "8.4" "8.3" "8.2" "8.1" "8" "7.14" "7.12" "7.11" "7.10" "7.9" "7.8" "7.7" "7.6" "7.5" "7.4")
     IF((NOT DEFINED MATLAB_ROOT)
         OR ("${MATLAB_ROOT}" STREQUAL "")
         OR ("${MATLAB_ROOT}" STREQUAL "/registry"))

--- a/src/nixdataarray.cc
+++ b/src/nixdataarray.cc
@@ -85,8 +85,6 @@ namespace nixdataarray {
         mwSize ndims = mxGetNumberOfDimensions(arr);
         const mwSize *dims = mxGetDimensions(arr);
         
-        mwSize tmp = ndims;
-        
         // Quick fix for writing data arrays that have exactly one row.
         // This fix does not resolve more complex arrays that have a 
         // last dimension of exactly one row.

--- a/src/nixfile.cc
+++ b/src/nixfile.cc
@@ -28,8 +28,9 @@ mxArray *message(std::vector<nix::valid::Message> mes) {
 
         nix::valid::Message curr = mes[i];
 
-        struct_builder msb({ 1 }, { "id", "msg" });
+        struct_builder msb({ 1 }, { "id", "name", "msg" });
         msb.set(curr.id);
+        msb.set(curr.name);
         msb.set(curr.msg);
 
         mxSetCell(list, i, msb.array());

--- a/src/utils/glue.h
+++ b/src/utils/glue.h
@@ -255,7 +255,7 @@ private:
     fn_t fun;
 };
 
-};
+}
 
 struct registry {
 

--- a/src/utils/mknix.cc
+++ b/src/utils/mknix.cc
@@ -145,7 +145,6 @@ nix::Value mx_to_value_from_struct(const mxArray *arr) {
     };
 
     nix::Value val;
-    bool has_value = false;
 
     int number_of_fields = mxGetNumberOfFields(arr);
     for (int idx = 0; idx < number_of_fields; idx++)  {

--- a/src/utils/struct.h
+++ b/src/utils/struct.h
@@ -39,7 +39,15 @@ struct struct_builder {
 
         sa = mxCreateStructArray(dims_size, dims_mw.data(), f_size, f.data());
 #else
-        sa = mxCreateStructArray(dims.size(), dims.data(), fields.size(), fields.data());
+        if (dims.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+            throw std::invalid_argument(std::string("Dimension size is larger than supported."));
+        }
+        else if (fields.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+            throw std::invalid_argument(std::string("Field size is larger than supported."));
+        }
+        else {
+            sa = mxCreateStructArray(static_cast<int>(dims.size()), dims.data(), static_cast<int>(fields.size()), fields.data());
+        }
 #endif
     }
 

--- a/win_build.bat
+++ b/win_build.bat
@@ -11,6 +11,8 @@ REM provide them at %NIX-DEP%\x86 or %NIX-DEP%\x64
 SET HDF5_VERSION_DIR=hdf5-1.10.1
 REM Static build requires cmake version 3.9.1
 SET CMAKEVER=3.9.1
+REM Leave NIX_MX_ONLY "" for full nix and nix-mx build
+SET NIX_MX_ONLY=""
 
 ECHO --------------------------------------------------------------------------
 ECHO Checking dependencies ...
@@ -75,6 +77,7 @@ IF EXIST %HDF5_DIR% (ECHO hdf5 OK) ELSE (EXIT /b)
 ECHO BOOST_INCLUDEDIR=%BOOST_INCLUDEDIR%, checking directory...
 IF EXIST %BOOST_ROOT% (ECHO boost OK) ELSE (EXIT /b)
 
+IF %NIX_MX_ONLY% == "" (
 ECHO --------------------------------------------------------------------------
 ECHO Setting up nix build ...
 ECHO --------------------------------------------------------------------------
@@ -119,6 +122,7 @@ IF %ERRORLEVEL% == 1 (EXIT /b)
 REM nix-mx requires nixversion file in ../nix/include/nix
 IF EXIST %NIX_ROOT%\build\include\nix\nixversion.hpp (
 	COPY %NIX_ROOT%\build\include\nix\nixversion.hpp %NIX_ROOT%\include\nix\
+)
 )
 
 ECHO --------------------------------------------------------------------------


### PR DESCRIPTION
This PR
- supports the new "name" field of the `file.validate` method. (G-Node/nix#705)
- adds Matlab versions up to R2017b for the Windows build to FindMatlab.cmake.
- adds a "build only matlab part" switch to the windows build script.
- removes some unused code and resolves a size conversion compiler warning.
