### PR TITLE
several changes to cmake files, several readme changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(nix_mx C CXX)
-
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 4)
 set(VERSION_PATCH 2)
@@ -99,15 +98,30 @@ if(DEBUG_GLUE)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_VERSION} VERSION_GREATER 3.2)
-  add_custom_target(macOS_zip COMMAND
-    ${CMAKE_COMMAND} -E tar "cfv" "nix_mx_macOS_${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.zip" --format=zip
-    "${CMAKE_CURRENT_SOURCE_DIR}/+nix"
-    "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt"
-    "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests"
-    "${CMAKE_CURRENT_SOURCE_DIR}/examples"
-    "${CMAKE_CURRENT_SOURCE_DIR}/startup.m"
-    "${CMAKE_BINARY_DIR}/*.mexmac*")
+  set(ZIP_FILE_NAME "nix_mx_macOS_${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.zip")
+
+  add_custom_target( 
+    macOS_zip 
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/+nix ${CMAKE_BINARY_DIR}/+nix
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/examples ${CMAKE_BINARY_DIR}/examples
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tests ${CMAKE_BINARY_DIR}/tests
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/README.md ${CMAKE_BINARY_DIR}/
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/startup.m ${CMAKE_BINARY_DIR}/
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE.txt ${CMAKE_BINARY_DIR}/
+    COMMAND ${CMAKE_COMMAND} -E tar "cf" ${ZIP_FILE_NAME} --format=zip 
+      "${CMAKE_BINARY_DIR}/+nix"
+      "${CMAKE_BINARY_DIR}/LICENSE.txt"
+      "${CMAKE_BINARY_DIR}/README.md"
+      "${CMAKE_BINARY_DIR}/tests"
+      "${CMAKE_BINARY_DIR}/examples"
+      "${CMAKE_BINARY_DIR}/startup.m"
+      "${CMAKE_BINARY_DIR}/*.mexmac*"
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/+nix
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tests
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/examples
+    COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_BINARY_DIR}/LICENSE.txt
+    COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_BINARY_DIR}/README.md
+    COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_BINARY_DIR}/startup.m)
 endif()
 
 MESSAGE(STATUS "===============================")

--- a/MacOSBuild.md
+++ b/MacOSBuild.md
@@ -1,17 +1,24 @@
-How to build NIX-MX on macOS
-----------------------------
+# How to build NIX-MX on macOS
 
 To compile NIX-MX for macOS for your MATLAB Version follow these steps:
 
-**Dependencies**
 
-- You have to have a working build environment including a C++ compiler
-- Install the nix C++ libraries (e.g. via homebrew `brew install nixio`) to build it from source please visit [NIX](https://github.com/G-Node/nix)
-- Install cmake and the boost libraries (e.g. via homebrew `brew install boost; brew install cmake`
-- Clone the nix-mx repository `git clone https://github.com/g-node/nix-mx.git`
-- Change into the directory and create a build subfolder: `mkdir build`
-- Change into the build folder and configure the build: `cd build; cmake ..`
-- Compile nix-mx: `make`
-- You may want to create a zip archive by: `make macOS_zip`
-- Move the zip file to your preferred installation folder and extract it there
+- You have to have a working build environment including a C++ compiler.
+- Install the NIX C++ libraries via [homebrew](https://brew.sh):
 
+```bash
+ brew tap g-node/pkg
+ brew install g-node/pkg/nixio
+ ````
+
+- To build the NIX C++ libraries from source please refer to the [NIX repository](https://github.com/G-Node/nix) for details.
+- Install cmake and the boost libraries (e.g. via homebrew `brew install boost; brew install cmake`.
+- Clone the nix-mx repository `git clone https://github.com/g-node/nix-mx.git`.
+- Change into the directory and create a build subfolder: `mkdir build`.
+- Change into the build folder and configure the build: `cd build; cmake ..`. By default cmake will try to find the static NIX library. If this is not found use `cmake .. -DBUILD_STATIC=OFF` instead.
+- Compile nix-mx: `make`.
+- You may want to create a zip archive by: `make macOS_zip`.
+- Move the zip file to your preferred installation folder and extract it there.
+- Start MATLAB and navigate within MATLAB to this location.
+- We may run the `startup.m` script that adds the installation folder to the MATLAB search path.
+- Test if everything worked by calling the tests `RunTest`. There may be warnings but none of the tests should fail.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,49 @@
-About NIX-MX
--------------
+# About NIX-MX
 
 The *NIX-MX* project is an extension to [NIX](https://github.com/G-Node/nix) and provides 
 Matlab bindings for *NIX*.
 
-
-Development Status
-------------------
+## Development Status
 
 The *NIX-MX* project has been developed and tested under Windows 32 and Windows 64 and can 
 easily be built under MacOS. Specifically all of the features of NIX v1.4.1 have been 
 implemented and tests for all of the methods exist and pass.
 
+## Getting Started (Windows 32/64)
 
-Getting Started (Windows 32/64)
--------------------------------
-
-**Quick start packages, Release 1.4.1**
+### Quick start packages, Release 1.4.1
 
 The [quick start packages](https://github.com/G-Node/nix-mx/releases) are compiled under 
 Windows 32/64 and contain all binary and Matlab files required to use NIX-MX with 
 the respective Windows OS.
-The included *NIX* library is a [stable release 1.4.1 build](https://github.com/G-Node/nix/releases/tag/1.4.1). 
-To use the packages, unzip them into a folder of your choice and run the `startup.m` 
-script from the root folder. Do not change the file/folder structure.
+The included *NIX* library is a [stable release 1.4.1 build](https://github.com/G-Node/nix/releases/tag/1.4.1).
+To use the packages, unzip them into a folder of your choice and run the `startup.m` script from the root folder. Do not change the file/folder structure.
 
 The Windows 64 package contains:
+
 - NIX library (stable release 1.4.1 build, compiled using BOOST 1.57.0, CPPUNIT 1.13.2 and HDF 1.10.1)
 - NIX-MX (Release 1.4.1)
 
 The Windows 32 package contains:
+
 - NIX library (stable release 1.4.1 build, compiled using BOOST 1.57.0, CPPUNIT 1.13.2 and HDF 1.10.1)
 - NIX-MX (Release 1.4.1)
 
-**Build NIX-MX under Windows**
+### Build NIX-MX under Windows
 
 To build NIX-MX under Windows please follow the guide provided at [WinBuild.md](https://github.com/G-Node/nix-mx/blob/master/WinBuild.md). 
 For an automated build, you can also use the `win_build.bat` script after you have read 
 the build guide and set up all required paths and repositories accordingly.
 
+## Getting Started (macOS)
 
-Getting Started (macOS)
--------------------------------
-
-**Quick start packages, Release 1.4.1**
+### Quick start packages, Release 1.4.1
 
 The quick start packages (https://github.com/G-Node/nix-mx/releases)
 are compiled under macOS Sierra using Matlab 2016b and contain the compiled mex files, 
 nix m-files, tests, and a `startup.m` script. To use nix-mx unzip the file and run the 
 `startup.m` script in MATLAB. This simply adds the current folder containing the mex 
 files to the MATLAB path. Do not change the file/folder structure.
-
 
 In order to have it working the respective NIX C++ library must be installed on the 
 system. The easiest way is using homebrew `brew install nixio`
@@ -62,6 +55,12 @@ the nix-mx folder and execute:
 
 This will execute a bunch of tests, there may be warnings but no test should fail.
 
-**Build NIX-MX under macOS**
+### Build NIX-MX under macOS
 
 To build NIX-MX under macOS please follow the guide provided at [MacOSBuild.md](https://github.com/G-Node/nix-mx/blob/master/MacOSBuild.md)
+
+## Note: Build issues with new MATLAB releases
+
+Mathworks release a new edition twice a year. We may not be able to keep up with this pace for lack of time or because we do not have access to the current release. 
+
+Often is is only the build configuration that fails. In such cases please check out this [issue](https://github.com/G-Node/nix-mx/issues/172). In case you successsfully built and tested with a newer MATLAB version than was supported please consider submitting the changes via pull-request. Thank you!

--- a/cmake/FindMATLAB.cmake
+++ b/cmake/FindMATLAB.cmake
@@ -40,7 +40,7 @@
 SET(MATLAB_FOUND 0)
 IF(WIN32)
   # Search for a version of Matlab available, starting from the most modern one to older versions
-  FOREACH(MATVER "9.5" "9.4" "9.3" "9.2" "9.1" "8.6" "8.5" "8.4" "8.3" "8.2" "8.1" "8" "7.14" "7.12" "7.11" "7.10" "7.9" "7.8" "7.7" "7.6" "7.5" "7.4")
+  FOREACH(MATVER "9.8" "9.7" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "8.6" "8.5" "8.4" "8.3" "8.2" "8.1" "8" "7.14" "7.12" "7.11" "7.10" "7.9" "7.8" "7.7" "7.6" "7.5" "7.4")
     IF((NOT DEFINED MATLAB_ROOT)
         OR ("${MATLAB_ROOT}" STREQUAL "")
         OR ("${MATLAB_ROOT}" STREQUAL "/registry"))
@@ -126,7 +126,7 @@ ELSE(WIN32)
     IF((NOT DEFINED MATLAB_ROOT) OR ("${MATLAB_ROOT}" STREQUAL ""))
 
     # Search for a version of Matlab available, starting from the most modern one to older versions
-      FOREACH(MATVER "R2018b" "R2018a" "R2017b" "R2017a" "R2016b" "R2016a" "R2015b" "R2015a" "R2014b" "R2014a" "R2013b" "R2013a" "R2012b" "R2012a" "R2011b" "R2011a" "R2010b" "R2010a" "R2009b" "R2009a" "R2008b")
+      FOREACH(MATVER "R2020a" "R2019b" "R2019a" "R2018b" "R2018a" "R2017b" "R2017a" "R2016b" "R2016a" "R2015b" "R2015a" "R2014b" "R2014a" "R2013b" "R2013a" "R2012b" "R2012a" "R2011b" "R2011a" "R2010b" "R2010a" "R2009b" "R2009a" "R2008b")
         SET(MATLAB_VERSION ${MATVER})
         IF((NOT DEFINED MATLAB_ROOT) OR ("${MATLAB_ROOT}" STREQUAL ""))
           IF(EXISTS /Applications/MATLAB_${MATVER}.app)

--- a/cmake/FindNIX.cmake
+++ b/cmake/FindNIX.cmake
@@ -14,14 +14,13 @@ if(NIX_USE_STATIC_LIBS)
   endif()
 endif()
 
-
 find_path(NIX_INCLUDE_DIR nix.hpp
   HINTS /usr/local/include
   /usr/include
   $ENV{NIX_ROOT}/include
   PATH_SUFFIXES nix)
 
-find_library(NIX_LIBRARY NAMES nix libnix
+find_library(NIX_LIBRARY NAMES nix libnix nixio libnixio
   HINTS $ENV{NIX_ROOT}/build/Release
   HINTS $ENV{NIX_BUILD_DIR}
   HINTS ${NIX_INCLUDE_DIR}/../lib

--- a/cmake/FindNIX.cmake
+++ b/cmake/FindNIX.cmake
@@ -1,8 +1,8 @@
 # - Try to find NIX
 # Once done this will define
-#  NIX_FOUND - System has Nix
-#  NIX_INCLUDE_DIRS - The Nix include directories
-#  NIX_LIBRARIES - The libraries needed to use Nix
+#  NIX_FOUND - System has NIX
+#  NIX_INCLUDE_DIRS - The NIX include directories
+#  NIX_LIBRARIES - The libraries needed to use NIX
 
 # Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
 if(NIX_USE_STATIC_LIBS)
@@ -34,7 +34,7 @@ set(NIX_INCLUDE_DIRS ${NIX_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set NIX_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(Nix DEFAULT_MSG
+find_package_handle_standard_args(NIX DEFAULT_MSG
   NIX_LIBRARY NIX_INCLUDE_DIR)
 
 mark_as_advanced(NIX_INCLUDE_DIR NIX_LIBRARIES)


### PR DESCRIPTION
* This pr allows findMatlab to find current versions, built was confirmed to be working with 2020a

* As suggested a link to the respective issue (#172) was added to the README . Tried to improve the build instructions in particular to avoid the apparent confusion between nix-mx and nix c++ build instructions.

* Changed the way the macOS zip is built. For some reasons I had issues on my machine which I did not have before...